### PR TITLE
feat: add textarea component

### DIFF
--- a/integrations/react/src/components.ts
+++ b/integrations/react/src/components.ts
@@ -9,12 +9,13 @@
 
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 import { createComponent } from '@stencil/react-output-target/runtime';
-import { type ModusWcButtonCustomEvent, type ModusWcInputCustomEvent } from "@trimble-cms/modus-wc";
+import { type ModusWcButtonCustomEvent, type ModusWcInputCustomEvent, type ModusWcTextareaCustomEvent } from "@trimble-cms/modus-wc";
 import { ModusWcAvatar as ModusWcAvatarElement, defineCustomElement as defineModusWcAvatar } from "@trimble-cms/modus-wc/dist/components/modus-wc-avatar.js";
 import { ModusWcBadge as ModusWcBadgeElement, defineCustomElement as defineModusWcBadge } from "@trimble-cms/modus-wc/dist/components/modus-wc-badge.js";
 import { ModusWcButton as ModusWcButtonElement, defineCustomElement as defineModusWcButton } from "@trimble-cms/modus-wc/dist/components/modus-wc-button.js";
 import { ModusWcDivider as ModusWcDividerElement, defineCustomElement as defineModusWcDivider } from "@trimble-cms/modus-wc/dist/components/modus-wc-divider.js";
 import { ModusWcInput as ModusWcInputElement, defineCustomElement as defineModusWcInput } from "@trimble-cms/modus-wc/dist/components/modus-wc-input.js";
+import { ModusWcTextarea as ModusWcTextareaElement, defineCustomElement as defineModusWcTextarea } from "@trimble-cms/modus-wc/dist/components/modus-wc-textarea.js";
 import { ModusWcTypography as ModusWcTypographyElement, defineCustomElement as defineModusWcTypography } from "@trimble-cms/modus-wc/dist/components/modus-wc-typography.js";
 import React from 'react';
 
@@ -74,6 +75,24 @@ export const ModusWcInput: StencilReactComponent<ModusWcInputElement, ModusWcInp
         onFocus: 'focus'
     } as ModusWcInputEvents,
     defineCustomElement: defineModusWcInput
+});
+
+type ModusWcTextareaEvents = {
+    onBlur: EventName<ModusWcTextareaCustomEvent<FocusEvent>>,
+    onChange: EventName<CustomEvent<string>>,
+    onFocus: EventName<ModusWcTextareaCustomEvent<FocusEvent>>
+};
+
+export const ModusWcTextarea: StencilReactComponent<ModusWcTextareaElement, ModusWcTextareaEvents> = /*@__PURE__*/ createComponent<ModusWcTextareaElement, ModusWcTextareaEvents>({
+    tagName: 'modus-wc-textarea',
+    elementClass: ModusWcTextareaElement,
+    react: React,
+    events: {
+        onBlur: 'blur',
+        onChange: 'change',
+        onFocus: 'focus'
+    } as ModusWcTextareaEvents,
+    defineCustomElement: defineModusWcTextarea
 });
 
 type ModusWcTypographyEvents = NonNullable<unknown>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -180,6 +180,76 @@ export namespace Components {
         "value": string;
     }
     /**
+     * A customizable textarea component.
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface ModusWcTextarea {
+        /**
+          * The ID of the element that describes the textarea.
+         */
+        "ariaDescribedby"?: string;
+        /**
+          * Indicates whether the textarea has an invalid input.
+         */
+        "ariaInvalid"?: boolean;
+        /**
+          * The aria-label attribute for accessibility.
+         */
+        "ariaLabel": string;
+        /**
+          * Custom CSS class to apply to the textarea element.
+         */
+        "customClass": string;
+        /**
+          * DaisyUI CSS class to apply to the textarea element.
+         */
+        "daisyClass": string;
+        /**
+          * Specifies the text direction of the textarea content.
+         */
+        "dir"?: 'ltr' | 'rtl' | 'auto';
+        /**
+          * The disabled state of the textarea.
+         */
+        "disabled": boolean;
+        /**
+          * The ID of the textarea element.
+         */
+        "id"?: string;
+        /**
+          * The maximum number of characters allowed in the textarea.
+         */
+        "maxLength"?: number;
+        /**
+          * The name of the textarea.
+         */
+        "name": string;
+        /**
+          * The placeholder text for the textarea.
+         */
+        "placeholder": string;
+        /**
+          * The readonly state of the textarea.
+         */
+        "readonly": boolean;
+        /**
+          * The required state of the textarea.
+         */
+        "required": boolean;
+        /**
+          * The number of visible text lines for the textarea.
+         */
+        "rows"?: number;
+        /**
+          * The tabindex of the textarea.
+         */
+        "tabIndex"?: number;
+        /**
+          * The value of the textarea.
+         */
+        "value": string;
+    }
+    /**
      * A customizable typography component used to render text with different sizes, variants, weights, and text casing.
      * Adheres to WCAG 2.2 standards.
      */
@@ -227,6 +297,10 @@ export interface ModusWcButtonCustomEvent<T> extends CustomEvent<T> {
 export interface ModusWcInputCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusWcInputElement;
+}
+export interface ModusWcTextareaCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusWcTextareaElement;
 }
 declare global {
     /**
@@ -303,6 +377,29 @@ declare global {
         prototype: HTMLModusWcInputElement;
         new (): HTMLModusWcInputElement;
     };
+    interface HTMLModusWcTextareaElementEventMap {
+        "blur": FocusEvent;
+        "change": string;
+        "focus": FocusEvent;
+    }
+    /**
+     * A customizable textarea component.
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface HTMLModusWcTextareaElement extends Components.ModusWcTextarea, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusWcTextareaElementEventMap>(type: K, listener: (this: HTMLModusWcTextareaElement, ev: ModusWcTextareaCustomEvent<HTMLModusWcTextareaElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusWcTextareaElementEventMap>(type: K, listener: (this: HTMLModusWcTextareaElement, ev: ModusWcTextareaCustomEvent<HTMLModusWcTextareaElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLModusWcTextareaElement: {
+        prototype: HTMLModusWcTextareaElement;
+        new (): HTMLModusWcTextareaElement;
+    };
     /**
      * A customizable typography component used to render text with different sizes, variants, weights, and text casing.
      * Adheres to WCAG 2.2 standards.
@@ -329,6 +426,7 @@ declare global {
         "modus-wc-button": HTMLModusWcButtonElement;
         "modus-wc-divider": HTMLModusWcDividerElement;
         "modus-wc-input": HTMLModusWcInputElement;
+        "modus-wc-textarea": HTMLModusWcTextareaElement;
         "modus-wc-typography": HTMLModusWcTypographyElement;
         "stencil-docs": HTMLStencilDocsElement;
     }
@@ -522,6 +620,88 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
+     * A customizable textarea component.
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface ModusWcTextarea {
+        /**
+          * The ID of the element that describes the textarea.
+         */
+        "ariaDescribedby"?: string;
+        /**
+          * Indicates whether the textarea has an invalid input.
+         */
+        "ariaInvalid"?: boolean;
+        /**
+          * The aria-label attribute for accessibility.
+         */
+        "ariaLabel": string;
+        /**
+          * Custom CSS class to apply to the textarea element.
+         */
+        "customClass"?: string;
+        /**
+          * DaisyUI CSS class to apply to the textarea element.
+         */
+        "daisyClass"?: string;
+        /**
+          * Specifies the text direction of the textarea content.
+         */
+        "dir"?: 'ltr' | 'rtl' | 'auto';
+        /**
+          * The disabled state of the textarea.
+         */
+        "disabled"?: boolean;
+        /**
+          * The ID of the textarea element.
+         */
+        "id"?: string;
+        /**
+          * The maximum number of characters allowed in the textarea.
+         */
+        "maxLength"?: number;
+        /**
+          * The name of the textarea.
+         */
+        "name"?: string;
+        /**
+          * Emitted when the textarea loses focus.
+         */
+        "onBlur"?: (event: ModusWcTextareaCustomEvent<FocusEvent>) => void;
+        /**
+          * Emitted when the textarea value changes.
+         */
+        "onChange"?: (event: ModusWcTextareaCustomEvent<string>) => void;
+        /**
+          * Emitted when the textarea gains focus.
+         */
+        "onFocus"?: (event: ModusWcTextareaCustomEvent<FocusEvent>) => void;
+        /**
+          * The placeholder text for the textarea.
+         */
+        "placeholder"?: string;
+        /**
+          * The readonly state of the textarea.
+         */
+        "readonly"?: boolean;
+        /**
+          * The required state of the textarea.
+         */
+        "required"?: boolean;
+        /**
+          * The number of visible text lines for the textarea.
+         */
+        "rows"?: number;
+        /**
+          * The tabindex of the textarea.
+         */
+        "tabIndex"?: number;
+        /**
+          * The value of the textarea.
+         */
+        "value"?: string;
+    }
+    /**
      * A customizable typography component used to render text with different sizes, variants, weights, and text casing.
      * Adheres to WCAG 2.2 standards.
      */
@@ -567,6 +747,7 @@ declare namespace LocalJSX {
         "modus-wc-button": ModusWcButton;
         "modus-wc-divider": ModusWcDivider;
         "modus-wc-input": ModusWcInput;
+        "modus-wc-textarea": ModusWcTextarea;
         "modus-wc-typography": ModusWcTypography;
         "stencil-docs": StencilDocs;
     }
@@ -600,6 +781,11 @@ declare module "@stencil/core" {
              * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-input": LocalJSX.ModusWcInput & JSXBase.HTMLAttributes<HTMLModusWcInputElement>;
+            /**
+             * A customizable textarea component.
+             * Adheres to WCAG 2.2 standards.
+             */
+            "modus-wc-textarea": LocalJSX.ModusWcTextarea & JSXBase.HTMLAttributes<HTMLModusWcTextareaElement>;
             /**
              * A customizable typography component used to render text with different sizes, variants, weights, and text casing.
              * Adheres to WCAG 2.2 standards.

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.scss
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.scss
@@ -1,0 +1,4 @@
+/**
+* This component uses Tailwind CSS and DaisyUI.
+* Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
+*/

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.spec.ts
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.spec.ts
@@ -1,0 +1,155 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ModusWcTextarea } from './modus-wc-textarea';
+
+describe('modus-wc-textarea', () => {
+  it('renders with default props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextarea],
+      html: '<modus-wc-textarea aria-label="Default textarea"></modus-wc-textarea>',
+    });
+    expect(page.root).not.toBeNull();
+    expect(page.root).toEqualHtml(`
+      <modus-wc-textarea aria-label="Default textarea" value="">
+        <textarea aria-label="Default textarea" aria-placeholder="" class="modus-wc-textarea" placeholder="" value=""></textarea>
+      </modus-wc-textarea>
+    `);
+  });
+
+  it('renders with custom props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextarea],
+      html: `<modus-wc-textarea 
+        aria-describedby="description" 
+        aria-invalid="true" 
+        aria-label="Custom textarea" 
+        custom-class="custom-class" 
+        daisy-class="daisy-class" 
+        dir="rtl" 
+        disabled="true"
+        id="custom-id" 
+        max-length="100" 
+        name="custom-name" 
+        placeholder="Custom placeholder" 
+        readonly="true"
+        required="true"
+        rows="5" 
+        tab-index="1" 
+        value="Custom value"
+      ></modus-wc-textarea>`,
+    });
+    expect(page.root).not.toBeNull();
+    expect(page.root).toEqualHtml(`
+      <modus-wc-textarea 
+        aria-describedby="description" 
+        aria-invalid="true" 
+        aria-label="Custom textarea" 
+        custom-class="custom-class" 
+        daisy-class="daisy-class" 
+        dir="rtl" 
+        disabled="true" 
+        id="custom-id" 
+        max-length="100" 
+        name="custom-name" 
+        placeholder="Custom placeholder" 
+        readonly="true"
+        required="true"
+        rows="5" 
+        tab-index="1" 
+        value="Custom value"
+      >
+        <textarea 
+          aria-describedby="description"
+          aria-invalid=""
+          aria-label="Custom textarea"
+          aria-placeholder="Custom placeholder"
+          aria-required=""
+          class="modus-wc-textarea custom-class daisy-class"
+          dir="rtl"
+          disabled
+          id="custom-id"
+          maxlength="100"
+          name="custom-name"
+          placeholder="Custom placeholder"
+          readonly
+          required
+          rows="5"
+          tabindex="1"
+          value="Custom value"
+        ></textarea>
+      </modus-wc-textarea>
+    `);
+  });
+
+  it('emits blur event', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextarea],
+      html: '<modus-wc-textarea aria-label="Blur test"></modus-wc-textarea>',
+    });
+    expect(page.root).not.toBeNull();
+    const textarea = page.root!.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    const blurSpy = jest.fn();
+    page.root!.addEventListener('blur', blurSpy);
+    textarea!.dispatchEvent(new FocusEvent('blur'));
+    await page.waitForChanges();
+    expect(blurSpy).toHaveBeenCalled();
+  });
+
+  it('emits change event', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextarea],
+      html: '<modus-wc-textarea aria-label="Change test"></modus-wc-textarea>',
+    });
+    expect(page.root).not.toBeNull();
+    const textarea = page.root!.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    const changeSpy = jest.fn();
+    page.root!.addEventListener('change', changeSpy);
+    textarea!.value = 'New value';
+    textarea!.dispatchEvent(new Event('change'));
+    await page.waitForChanges();
+    expect(changeSpy).toHaveBeenCalled();
+    expect(changeSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'New value',
+      })
+    );
+  });
+
+  it('emits focus event', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextarea],
+      html: '<modus-wc-textarea aria-label="Focus test"></modus-wc-textarea>',
+    });
+    expect(page.root).not.toBeNull();
+    const textarea = page.root!.querySelector('textarea');
+    expect(textarea).not.toBeNull();
+    const focusSpy = jest.fn();
+    page.root!.addEventListener('focus', focusSpy);
+    textarea!.dispatchEvent(new FocusEvent('focus'));
+    await page.waitForChanges();
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it('warns when ariaLabel is not provided', async () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    await newSpecPage({
+      components: [ModusWcTextarea],
+      html: '<modus-wc-textarea></modus-wc-textarea>',
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      'ModusWcTextarea: ariaLabel is required for accessibility.'
+    );
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('does not warn when ariaLabel is provided', async () => {
+    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    await newSpecPage({
+      components: [ModusWcTextarea],
+      html: '<modus-wc-textarea aria-label="Valid label"></modus-wc-textarea>',
+    });
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.stories.ts
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.stories.ts
@@ -1,0 +1,115 @@
+import { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { ModusWCMode, setModusWCMode } from '../../../utils/theme';
+
+interface TextareaArgs {
+  ariaDescribedby: string;
+  ariaInvalid: boolean;
+  ariaLabel: string;
+  customClass: string;
+  daisyClass: string;
+  dir: 'ltr' | 'rtl' | 'auto';
+  disabled: boolean;
+  id: string;
+  maxLength: number;
+  mode: ModusWCMode;
+  name: string;
+  placeholder: string;
+  readonly: boolean;
+  required: boolean;
+  rows: number;
+  tabIndex: number;
+  value: string;
+}
+
+const meta: Meta<TextareaArgs> = {
+  title: 'Components/Textarea',
+  component: 'modus-wc-textarea',
+  argTypes: {
+    ariaDescribedby: { control: 'text' },
+    ariaInvalid: { control: 'boolean' },
+    ariaLabel: { control: 'text' },
+    customClass: { control: 'text' },
+    daisyClass: { control: 'text' },
+    dir: {
+      control: { type: 'select' },
+      options: ['ltr', 'rtl', 'auto'],
+    },
+    disabled: { control: 'boolean' },
+    id: { control: 'text' },
+    maxLength: { control: 'number' },
+    mode: {
+      control: { type: 'select' },
+      options: ['default', 'dark', 'high-contrast'],
+    },
+    name: { control: 'text' },
+    placeholder: { control: 'text' },
+    readonly: { control: 'boolean' },
+    required: { control: 'boolean' },
+    rows: { control: 'number' },
+    tabIndex: { control: 'number' },
+    value: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<TextareaArgs>;
+
+const Template: Story = {
+  render: (args) => {
+    setModusWCMode(args.mode);
+
+    return html`
+      <div>
+        <h1>Textarea</h1>
+        <modus-wc-textarea
+          aria-describedby=${ifDefined(args.ariaDescribedby)}
+          aria-invalid=${ifDefined(args.ariaInvalid)}
+          aria-label=${args.ariaLabel}
+          custom-class=${ifDefined(args.customClass)}
+          daisy-class=${ifDefined(args.daisyClass)}
+          dir=${ifDefined(args.dir)}
+          ?disabled=${args.disabled}
+          id=${ifDefined(args.id)}
+          max-length=${ifDefined(args.maxLength)}
+          name=${ifDefined(args.name)}
+          placeholder=${ifDefined(args.placeholder)}
+          ?readonly=${args.readonly}
+          ?required=${args.required}
+          rows=${ifDefined(args.rows)}
+          tab-index=${ifDefined(args.tabIndex)}
+          value=${ifDefined(args.value)}
+          @blur=${(e: CustomEvent) => console.log('blur', e.detail)}
+          @change=${(e: CustomEvent) => console.log('change', e.detail)}
+          @focus=${(e: CustomEvent) => console.log('focus', e.detail)}
+        ></modus-wc-textarea>
+        <stencil-docs component-name="modus-wc-textarea"></stencil-docs>
+      </div>
+    `;
+  },
+};
+
+export const Default: Story = {
+  ...Template,
+  args: {
+    ariaDescribedby: 'description',
+    ariaInvalid: false,
+    ariaLabel: 'Enter your comments',
+    customClass: '',
+    daisyClass: '',
+    dir: 'ltr',
+    disabled: false,
+    id: 'textarea-1',
+    maxLength: undefined,
+    mode: 'default',
+    name: 'comments',
+    placeholder: 'Type your comments here',
+    readonly: false,
+    required: false,
+    rows: 4,
+    tabIndex: 0,
+    value: '',
+  },
+};

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
@@ -1,0 +1,158 @@
+import { h, Component, Event, EventEmitter, Prop } from '@stencil/core';
+
+/**
+ * A customizable textarea component.
+ *
+ * Adheres to WCAG 2.2 standards.
+ */
+@Component({
+  tag: 'modus-wc-textarea',
+  styleUrl: 'modus-wc-textarea.scss',
+  shadow: false,
+})
+export class ModusWcTextarea {
+  /**
+   * The ID of the element that describes the textarea.
+   */
+  @Prop() ariaDescribedby?: string;
+
+  /**
+   * Indicates whether the textarea has an invalid input.
+   */
+  @Prop() ariaInvalid?: boolean;
+
+  /**
+   * The aria-label attribute for accessibility.
+   */
+  @Prop() ariaLabel!: string;
+
+  /**
+   * Custom CSS class to apply to the textarea element.
+   */
+  @Prop() customClass: string = '';
+
+  /**
+   * DaisyUI CSS class to apply to the textarea element.
+   */
+  @Prop() daisyClass: string = '';
+
+  /**
+   * Specifies the text direction of the textarea content.
+   */
+  @Prop() dir?: 'ltr' | 'rtl' | 'auto';
+
+  /**
+   * The disabled state of the textarea.
+   */
+  @Prop() disabled: boolean = false;
+
+  /**
+   * The ID of the textarea element.
+   */
+  @Prop() id?: string;
+
+  /**
+   * The maximum number of characters allowed in the textarea.
+   */
+  @Prop() maxLength?: number;
+
+  /**
+   * The name of the textarea.
+   */
+  @Prop() name: string = '';
+
+  /**
+   * The placeholder text for the textarea.
+   */
+  @Prop() placeholder: string = '';
+
+  /**
+   * The readonly state of the textarea.
+   */
+  @Prop() readonly: boolean = false;
+
+  /**
+   * The required state of the textarea.
+   */
+  @Prop() required: boolean = false;
+
+  /**
+   * The number of visible text lines for the textarea.
+   */
+  @Prop() rows?: number;
+
+  /**
+   * The tabindex of the textarea.
+   */
+  @Prop() tabIndex?: number;
+
+  /**
+   * The value of the textarea.
+   */
+  @Prop({ mutable: true, reflect: true }) value: string = '';
+
+  /**
+   * Emitted when the textarea loses focus.
+   */
+  @Event() blur!: EventEmitter<FocusEvent>;
+
+  /**
+   * Emitted when the textarea value changes.
+   */
+  @Event() change!: EventEmitter<string>;
+
+  /**
+   * Emitted when the textarea gains focus.
+   */
+  @Event() focus!: EventEmitter<FocusEvent>;
+
+  componentWillLoad() {
+    if (!this.ariaLabel) {
+      console.warn('ModusWcTextarea: ariaLabel is required for accessibility.');
+    }
+  }
+
+  private handleBlur = (event: FocusEvent) => {
+    this.blur.emit(event);
+  };
+
+  private handleChange = (event: Event) => {
+    const input = event.target as HTMLTextAreaElement;
+    this.change.emit(input.value);
+  };
+
+  private handleFocus = (event: FocusEvent) => {
+    this.focus.emit(event);
+  };
+
+  render() {
+    return (
+      <textarea
+        aria-describedby={this.ariaDescribedby}
+        aria-invalid={this.ariaInvalid}
+        aria-label={this.ariaLabel}
+        aria-placeholder={this.placeholder}
+        aria-required={this.required}
+        class={{
+          'modus-wc-textarea': true,
+          [this.customClass]: !!this.customClass,
+          [this.daisyClass]: !!this.daisyClass,
+        }}
+        dir={this.dir}
+        disabled={this.disabled}
+        id={this.id}
+        maxLength={this.maxLength}
+        name={this.name}
+        onBlur={this.handleBlur}
+        onChange={this.handleChange}
+        onFocus={this.handleFocus}
+        placeholder={this.placeholder}
+        readonly={this.readonly}
+        required={this.required}
+        rows={this.rows}
+        tabIndex={this.tabIndex}
+        value={this.value}
+      />
+    );
+  }
+}

--- a/src/components/atoms/modus-wc-textarea/readme.md
+++ b/src/components/atoms/modus-wc-textarea/readme.md
@@ -1,0 +1,137 @@
+# modus-wc-textarea
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+A customizable textarea component.
+
+Adheres to WCAG 2.2 standards.
+
+## Usage
+
+### Component-usage
+
+```html
+<!-- Basic Usage -->
+<modus-wc-textarea
+  aria-label="Enter your comments"
+  placeholder="Type your comments here"
+></modus-wc-textarea>
+
+<!-- With all properties -->
+<modus-wc-textarea
+  aria-describedby="textarea-description"
+  aria-invalid="false"
+  aria-label="Full example textarea"
+  custom-class="my-custom-class"
+  daisy-class="modus-wc-textarea-custom"
+  dir="ltr"
+  disabled="false"
+  id="full-example"
+  max-length="500"
+  name="full-example"
+  placeholder="Type here..."
+  readonly="false"
+  required="true"
+  rows="5"
+  tab-index="0"
+  value="Initial value"
+></modus-wc-textarea>
+
+<!-- Disabled textarea -->
+<modus-wc-textarea
+  aria-label="Disabled textarea"
+  disabled="true"
+  value="This textarea is disabled"
+></modus-wc-textarea>
+
+<!-- Required textarea -->
+<modus-wc-textarea
+  aria-label="Required textarea"
+  required="true"
+  placeholder="This field is required"
+></modus-wc-textarea>
+
+<!-- Readonly textarea -->
+<modus-wc-textarea
+  aria-label="Readonly textarea"
+  readonly="true"
+  value="This content is readonly"
+></modus-wc-textarea>
+
+<!-- RTL textarea -->
+<modus-wc-textarea
+  aria-label="RTL textarea"
+  dir="rtl"
+  placeholder="أدخل النص هنا"
+></modus-wc-textarea>
+
+<!-- Textarea with custom classes -->
+<modus-wc-textarea
+  aria-label="Styled textarea"
+  custom-class="my-custom-class"
+  daisy-class="modus-wc-textarea-bordered modus-wc-textarea-lg"
+  placeholder="This textarea has custom styling"
+></modus-wc-textarea>
+
+<!-- Textarea with event listeners -->
+<modus-wc-textarea
+  id="event-textarea"
+  aria-label="Textarea with events"
+  placeholder="Type here to see events in console"
+></modus-wc-textarea>
+
+<script>
+  const textarea = document.getElementById('event-textarea');
+  textarea.addEventListener('blur', (event) =>
+    console.log('Blur event:', event)
+  );
+  textarea.addEventListener('change', (event) =>
+    console.log('Change event:', event)
+  );
+  textarea.addEventListener('focus', (event) =>
+    console.log('Focus event:', event)
+  );
+</script>
+```
+
+
+
+## Properties
+
+| Property                 | Attribute          | Description                                               | Type                                    | Default     |
+| ------------------------ | ------------------ | --------------------------------------------------------- | --------------------------------------- | ----------- |
+| `ariaDescribedby`        | `aria-describedby` | The ID of the element that describes the textarea.        | `string \| undefined`                   | `undefined` |
+| `ariaInvalid`            | `aria-invalid`     | Indicates whether the textarea has an invalid input.      | `boolean \| undefined`                  | `undefined` |
+| `ariaLabel` _(required)_ | `aria-label`       | The aria-label attribute for accessibility.               | `string`                                | `undefined` |
+| `customClass`            | `custom-class`     | Custom CSS class to apply to the textarea element.        | `string`                                | `''`        |
+| `daisyClass`             | `daisy-class`      | DaisyUI CSS class to apply to the textarea element.       | `string`                                | `''`        |
+| `dir`                    | `dir`              | Specifies the text direction of the textarea content.     | `"auto" \| "ltr" \| "rtl" \| undefined` | `undefined` |
+| `disabled`               | `disabled`         | The disabled state of the textarea.                       | `boolean`                               | `false`     |
+| `id`                     | `id`               | The ID of the textarea element.                           | `string \| undefined`                   | `undefined` |
+| `maxLength`              | `max-length`       | The maximum number of characters allowed in the textarea. | `number \| undefined`                   | `undefined` |
+| `name`                   | `name`             | The name of the textarea.                                 | `string`                                | `''`        |
+| `placeholder`            | `placeholder`      | The placeholder text for the textarea.                    | `string`                                | `''`        |
+| `readonly`               | `readonly`         | The readonly state of the textarea.                       | `boolean`                               | `false`     |
+| `required`               | `required`         | The required state of the textarea.                       | `boolean`                               | `false`     |
+| `rows`                   | `rows`             | The number of visible text lines for the textarea.        | `number \| undefined`                   | `undefined` |
+| `tabIndex`               | `tab-index`        | The tabindex of the textarea.                             | `number \| undefined`                   | `undefined` |
+| `value`                  | `value`            | The value of the textarea.                                | `string`                                | `''`        |
+
+
+## Events
+
+| Event    | Description                              | Type                      |
+| -------- | ---------------------------------------- | ------------------------- |
+| `blur`   | Emitted when the textarea loses focus.   | `CustomEvent<FocusEvent>` |
+| `change` | Emitted when the textarea value changes. | `CustomEvent<string>`     |
+| `focus`  | Emitted when the textarea gains focus.   | `CustomEvent<FocusEvent>` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/atoms/modus-wc-textarea/usage/component-usage.md
+++ b/src/components/atoms/modus-wc-textarea/usage/component-usage.md
@@ -1,0 +1,83 @@
+```html
+<!-- Basic Usage -->
+<modus-wc-textarea
+  aria-label="Enter your comments"
+  placeholder="Type your comments here"
+></modus-wc-textarea>
+
+<!-- With all properties -->
+<modus-wc-textarea
+  aria-describedby="textarea-description"
+  aria-invalid="false"
+  aria-label="Full example textarea"
+  custom-class="my-custom-class"
+  daisy-class="modus-wc-textarea-custom"
+  dir="ltr"
+  disabled="false"
+  id="full-example"
+  max-length="500"
+  name="full-example"
+  placeholder="Type here..."
+  readonly="false"
+  required="true"
+  rows="5"
+  tab-index="0"
+  value="Initial value"
+></modus-wc-textarea>
+
+<!-- Disabled textarea -->
+<modus-wc-textarea
+  aria-label="Disabled textarea"
+  disabled="true"
+  value="This textarea is disabled"
+></modus-wc-textarea>
+
+<!-- Required textarea -->
+<modus-wc-textarea
+  aria-label="Required textarea"
+  required="true"
+  placeholder="This field is required"
+></modus-wc-textarea>
+
+<!-- Readonly textarea -->
+<modus-wc-textarea
+  aria-label="Readonly textarea"
+  readonly="true"
+  value="This content is readonly"
+></modus-wc-textarea>
+
+<!-- RTL textarea -->
+<modus-wc-textarea
+  aria-label="RTL textarea"
+  dir="rtl"
+  placeholder="أدخل النص هنا"
+></modus-wc-textarea>
+
+<!-- Textarea with custom classes -->
+<modus-wc-textarea
+  aria-label="Styled textarea"
+  custom-class="my-custom-class"
+  daisy-class="modus-wc-textarea-bordered modus-wc-textarea-lg"
+  placeholder="This textarea has custom styling"
+></modus-wc-textarea>
+
+<!-- Textarea with event listeners -->
+<modus-wc-textarea
+  id="event-textarea"
+  aria-label="Textarea with events"
+  placeholder="Type here to see events in console"
+></modus-wc-textarea>
+
+<script>
+  const textarea = document.getElementById('event-textarea');
+  textarea.addEventListener('blur', (event) =>
+    console.log('Blur event:', event)
+  );
+  textarea.addEventListener('change', (event) =>
+    console.log('Change event:', event)
+  );
+  textarea.addEventListener('focus', (event) =>
+    console.log('Focus event:', event)
+  );
+</script>
+```


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds the `modus-wc-textarea` component. It assumes the usage of Tailwind CSS and DaisyUI. It will remain unstyled until those libraries are implemented.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

100% code covered

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [x] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [x] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

AB#566232
