### PR TITLE
chore: Replaces deprecated actions for releasing, simplification

### DIFF
--- a/.github/workflows/publish-react.yml
+++ b/.github/workflows/publish-react.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish-react:
     runs-on: ubuntu-latest
@@ -90,20 +93,14 @@ jobs:
           full_asset_path="${{ github.workspace }}/integrations/react/${asset_path}"
           echo "asset_path=$full_asset_path" >> $GITHUB_OUTPUT
 
+      - name: Rename the asset to package-react.tgz
+        run: mv ${{ steps.find-asset.outputs.asset_path }} package-react.tgz
+
       - name: Create GitHub release
-        id: create_release
-        uses: ncipollo/release-action@v1.14.0
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: modus-wc-react-${{ github.event.inputs.version }}
+          tag_name: modus-wc-react-${{ github.event.inputs.version }}
           name: Modus Web Components React ${{ github.event.inputs.version }}
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.find-asset.outputs.asset_path }}
-          asset_name: package-react.tgz
-          asset_content_type: application/gzip
+          files: |
+            package-react.tgz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish-wc:
     runs-on: ubuntu-latest
@@ -88,20 +91,14 @@ jobs:
         id: find-asset
         run: echo "asset_path=$(find . -name 'trimble-cms-modus-wc-*.tgz')" >> $GITHUB_OUTPUT
 
+      - name: Rename the asset to package.tgz
+        run: mv ${{ steps.find-asset.outputs.asset_path }} package.tgz
+
       - name: Create GitHub release
-        id: create_release
-        uses: ncipollo/release-action@v1.14.0
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: modus-wc-${{ github.event.inputs.version }}
+          tag_name: modus-wc-${{ github.event.inputs.version }}
           name: Modus Web Components ${{ github.event.inputs.version }}
-
-      - name: Upload release asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.find-asset.outputs.asset_path }}
-          asset_name: package.tgz
-          asset_content_type: application/gzip
+          files: |
+            package.tgz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   build-and-publish-wc:


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

https://github.com/actions/upload-release-asset has been unmaintained for 3 years+, and was using runners/syntax that is deprecated. I have switched over to GitHub's recommendation.
This also results in removing a now-needless step.

This is groundwork for `Add version support to React integration`

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

[AB#567093](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/567093)
