### PR TITLE
fix: revert change event back to emitting strings for textarea, text input components

### DIFF
--- a/integrations/react/src/components.ts
+++ b/integrations/react/src/components.ts
@@ -9,7 +9,7 @@
 
 import type { EventName, StencilReactComponent } from '@stencil/react-output-target/runtime';
 import { createComponent } from '@stencil/react-output-target/runtime';
-import { type Event, type ModusWcButtonCustomEvent, type ModusWcTextInputCustomEvent, type ModusWcTextareaCustomEvent } from "@trimble-cms/modus-wc";
+import { type ModusWcButtonCustomEvent, type ModusWcTextInputCustomEvent, type ModusWcTextareaCustomEvent } from "@trimble-cms/modus-wc";
 import { ModusWcAvatar as ModusWcAvatarElement, defineCustomElement as defineModusWcAvatar } from "@trimble-cms/modus-wc/dist/components/modus-wc-avatar.js";
 import { ModusWcBadge as ModusWcBadgeElement, defineCustomElement as defineModusWcBadge } from "@trimble-cms/modus-wc/dist/components/modus-wc-badge.js";
 import { ModusWcButton as ModusWcButtonElement, defineCustomElement as defineModusWcButton } from "@trimble-cms/modus-wc/dist/components/modus-wc-button.js";
@@ -61,7 +61,7 @@ export const ModusWcDivider: StencilReactComponent<ModusWcDividerElement, ModusW
 
 type ModusWcTextInputEvents = {
     onBlur: EventName<ModusWcTextInputCustomEvent<FocusEvent>>,
-    onChange: EventName<ModusWcTextInputCustomEvent<Event>>,
+    onChange: EventName<CustomEvent<string>>,
     onFocus: EventName<ModusWcTextInputCustomEvent<FocusEvent>>
 };
 
@@ -79,7 +79,7 @@ export const ModusWcTextInput: StencilReactComponent<ModusWcTextInputElement, Mo
 
 type ModusWcTextareaEvents = {
     onBlur: EventName<ModusWcTextareaCustomEvent<FocusEvent>>,
-    onChange: EventName<ModusWcTextareaCustomEvent<Event>>,
+    onChange: EventName<CustomEvent<string>>,
     onFocus: EventName<ModusWcTextareaCustomEvent<FocusEvent>>
 };
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,9 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { Event } from "@stencil/core";
 import { TypographyBodySize, TypographyVariant } from "./components/atoms/modus-wc-typography/modus-wc-typography";
-export { Event } from "@stencil/core";
 export { TypographyBodySize, TypographyVariant } from "./components/atoms/modus-wc-typography/modus-wc-typography";
 export namespace Components {
     /**
@@ -418,7 +416,7 @@ declare global {
     };
     interface HTMLModusWcTextInputElementEventMap {
         "blur": FocusEvent;
-        "change": Event;
+        "change": string;
         "focus": FocusEvent;
     }
     /**
@@ -441,7 +439,7 @@ declare global {
     };
     interface HTMLModusWcTextareaElementEventMap {
         "blur": FocusEvent;
-        "change": Event;
+        "change": string;
         "focus": FocusEvent;
     }
     /**
@@ -707,7 +705,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when the input value changes.
          */
-        "onChange"?: (event: ModusWcTextInputCustomEvent<Event>) => void;
+        "onChange"?: (event: ModusWcTextInputCustomEvent<string>) => void;
         /**
           * Event emitted when the input gains focus.
          */
@@ -793,7 +791,7 @@ declare namespace LocalJSX {
         /**
           * Emitted when the textarea value changes.
          */
-        "onChange"?: (event: ModusWcTextareaCustomEvent<Event>) => void;
+        "onChange"?: (event: ModusWcTextareaCustomEvent<string>) => void;
         /**
           * Emitted when the textarea gains focus.
          */

--- a/src/components/atoms/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/atoms/modus-wc-text-input/modus-wc-text-input.tsx
@@ -146,7 +146,7 @@ export class ModusWcTextInput {
   /**
    * Event emitted when the input value changes.
    */
-  @Event() change!: EventEmitter<Event>;
+  @Event() change!: EventEmitter<string>;
 
   /**
    * Event emitted when the input gains focus.
@@ -164,7 +164,9 @@ export class ModusWcTextInput {
   };
 
   private handleChange = (event: Event) => {
-    this.change.emit(event);
+    const input = event.target as HTMLInputElement;
+    this.value = input.value;
+    this.change.emit(this.value);
   };
 
   private handleFocus = (event: FocusEvent) => {

--- a/src/components/atoms/modus-wc-text-input/readme.md
+++ b/src/components/atoms/modus-wc-text-input/readme.md
@@ -72,7 +72,7 @@ Adheres to WCAG 2.2 standards.
 | Event    | Description                                 | Type                      |
 | -------- | ------------------------------------------- | ------------------------- |
 | `blur`   | Event emitted when the input loses focus.   | `CustomEvent<FocusEvent>` |
-| `change` | Event emitted when the input value changes. | `CustomEvent<Event>`      |
+| `change` | Event emitted when the input value changes. | `CustomEvent<string>`     |
 | `focus`  | Event emitted when the input gains focus.   | `CustomEvent<FocusEvent>` |
 
 

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
@@ -94,7 +94,7 @@ export class ModusWcTextarea {
   /**
    * Emitted when the textarea value changes.
    */
-  @Event() change!: EventEmitter<Event>;
+  @Event() change!: EventEmitter<string>;
 
   /**
    * Emitted when the textarea gains focus.
@@ -112,7 +112,9 @@ export class ModusWcTextarea {
   };
 
   private handleChange = (event: Event) => {
-    this.change.emit(event);
+    const input = event.target as HTMLTextAreaElement;
+    this.value = input.value;
+    this.change.emit(this.value);
   };
 
   private handleFocus = (event: FocusEvent) => {

--- a/src/components/atoms/modus-wc-textarea/readme.md
+++ b/src/components/atoms/modus-wc-textarea/readme.md
@@ -125,7 +125,7 @@ Adheres to WCAG 2.2 standards.
 | Event    | Description                              | Type                      |
 | -------- | ---------------------------------------- | ------------------------- |
 | `blur`   | Emitted when the textarea loses focus.   | `CustomEvent<FocusEvent>` |
-| `change` | Emitted when the textarea value changes. | `CustomEvent<Event>`      |
+| `change` | Emitted when the textarea value changes. | `CustomEvent<string>`     |
 | `focus`  | Emitted when the textarea gains focus.   | `CustomEvent<FocusEvent>` |
 
 


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR addresses an issue with the change event in the `modus-wc-textarea` and `modus-wc-text-input` components. 

Previously, the change event for these components were emitting an `Event` object, which caused build errors in the stencil auto-generated Angular integration and may be related to this [open issue](https://github.com/ionic-team/stencil-ds-output-targets/issues/481) with stencil. The event type has been changed to emit a `string` instead, which resolves the integration build issues and is also how Modus 1.0 does it.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Changes were tested with the Angular 18 integration build and verified no more build failures. 


### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

[AB#570779](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/570779)
