### PR TITLE
fix: components losing styling

### DIFF
--- a/src/components/atoms/modus-wc-avatar/modus-wc-avatar.scss
+++ b/src/components/atoms/modus-wc-avatar/modus-wc-avatar.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.scss
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
@@ -58,7 +58,7 @@ export class ModusWcBadge {
   }
 
   private getClasses(): string {
-    const classList: string[] = [];
+    const classList = ['modus-wc-badge'];
     const propClasses = convertPropsToClasses({
       color: this.color,
       size: this.size,
@@ -67,7 +67,6 @@ export class ModusWcBadge {
 
     // The order CSS classes are added matters to CSS specificity
     if (propClasses) classList.push(propClasses);
-    classList.push('modus-wc-badge');
     if (this.customClass) classList.push(this.customClass);
 
     return classList.join(' ');

--- a/src/components/atoms/modus-wc-button/modus-wc-button.scss
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/src/components/atoms/modus-wc-button/modus-wc-button.tsx
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.tsx
@@ -83,7 +83,7 @@ export class ModusWcButton {
   }
 
   private getClasses(): string {
-    const classList = [];
+    const classList = ['modus-wc-btn'];
     const propClasses = convertPropsToClasses({
       color: this.color,
       disabled: this.disabled,
@@ -94,7 +94,6 @@ export class ModusWcButton {
 
     // The order CSS classes are added matters to CSS specificity
     if (propClasses) classList.push(propClasses);
-    classList.push('modus-wc-btn');
     if (this.customClass) classList.push(this.customClass);
 
     return classList.join(' ');

--- a/src/components/atoms/modus-wc-divider/modus-wc-divider.scss
+++ b/src/components/atoms/modus-wc-divider/modus-wc-divider.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/src/components/atoms/modus-wc-divider/modus-wc-divider.tsx
+++ b/src/components/atoms/modus-wc-divider/modus-wc-divider.tsx
@@ -61,7 +61,7 @@ export class ModusWcDivider {
   }
 
   private getClasses(): string {
-    const classList = [];
+    const classList = ['modus-wc-divider'];
 
     const propClasses = convertPropsToClasses({
       color: this.color,
@@ -72,7 +72,6 @@ export class ModusWcDivider {
 
     // The order CSS classes are added matters to CSS specificity
     if (propClasses) classList.push(propClasses);
-    classList.push('modus-wc-divider');
     if (this.customClass) classList.push(this.customClass);
 
     return classList.join(' ');

--- a/src/components/atoms/modus-wc-text-input/modus-wc-text-input.scss
+++ b/src/components/atoms/modus-wc-text-input/modus-wc-text-input.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.scss
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/src/components/atoms/modus-wc-typography/modus-wc-typography.scss
+++ b/src/components/atoms/modus-wc-typography/modus-wc-typography.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/src/components/atoms/modus-wc-typography/modus-wc-typography.tsx
+++ b/src/components/atoms/modus-wc-typography/modus-wc-typography.tsx
@@ -60,7 +60,7 @@ export class ModusWCTypography {
   }
 
   private getClasses(): string {
-    const classList = [];
+    const classList = ['modus-wc-typography'];
 
     const propClasses = convertPropsToClasses({
       size: this.size,
@@ -70,7 +70,6 @@ export class ModusWCTypography {
 
     // The order CSS classes are added matters to CSS specificity
     if (propClasses) classList.push(propClasses);
-    classList.push('modus-wc-typography');
     if (this.customClass) classList.push(this.customClass);
 
     return classList.join(' ');

--- a/src/components/molecules/modus-wc-theme-switcher/modus-wc-theme-switcher.scss
+++ b/src/components/molecules/modus-wc-theme-switcher/modus-wc-theme-switcher.scss
@@ -1,5 +1,3 @@
-@import '../../../styles/output.css';
-
 /**
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -6,7 +6,6 @@ import angularValueAccessorBindings from './angular-value-acessor-bindings';
 import tailwind, {
   setPluginConfigurationDefaults,
   tailwindGlobal,
-  tailwindHMR,
 } from 'stencil-tailwind-plugin';
 import tailwindConfig from './tailwind.config';
 
@@ -57,11 +56,10 @@ export const config: Config = {
   ],
   plugins: [
     sass({
-      injectGlobalPaths: ['src/styles/global.scss'],
+      injectGlobalPaths: ['src/styles/global.scss', 'src/styles/output.css'],
     }),
     tailwindGlobal(),
     tailwind(),
-    tailwindHMR(),
   ],
   devServer: {
     reloadStrategy: 'pageReload',


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR fixes a bug where components would lose styling when re-rendered due to excessive imports of output.css (now global) and tailwind HMR.

This was easily reproduced in Storybook by navigating to the badge component and refreshing the page.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

[AB#571581](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/571581)
