### PR TITLE
feat: add input label component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -248,6 +248,33 @@ export namespace Components {
         "size"?: 'sm' | 'md' | 'lg';
     }
     /**
+     * A customizable input label component.
+     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface ModusWcInputLabel {
+        /**
+          * Additional classes for custom styling.
+         */
+        "customClass"?: string;
+        /**
+          * The `for` attribute of the label, matching the `id` of the associated input.
+         */
+        "forId"?: string;
+        /**
+          * Specifies the text direction of the label content.
+         */
+        "labelDir"?: '' | 'ltr' | 'rtl' | 'auto';
+        /**
+          * The text to display within the label.
+         */
+        "labelText"?: string;
+        /**
+          * Whether the label indicates a required field.
+         */
+        "required"?: boolean;
+    }
+    /**
      * A customizable input component used to create text inputs with types.
      * Adheres to WCAG 2.2 standards.
      */
@@ -594,6 +621,17 @@ declare global {
         prototype: HTMLModusWcIconElement;
         new (): HTMLModusWcIconElement;
     };
+    /**
+     * A customizable input label component.
+     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface HTMLModusWcInputLabelElement extends Components.ModusWcInputLabel, HTMLStencilElement {
+    }
+    var HTMLModusWcInputLabelElement: {
+        prototype: HTMLModusWcInputLabelElement;
+        new (): HTMLModusWcInputLabelElement;
+    };
     interface HTMLModusWcTextInputElementEventMap {
         "inputBlur": FocusEvent;
         "inputChange": Event;
@@ -685,6 +723,7 @@ declare global {
         "modus-wc-checkbox": HTMLModusWcCheckboxElement;
         "modus-wc-divider": HTMLModusWcDividerElement;
         "modus-wc-icon": HTMLModusWcIconElement;
+        "modus-wc-input-label": HTMLModusWcInputLabelElement;
         "modus-wc-text-input": HTMLModusWcTextInputElement;
         "modus-wc-textarea": HTMLModusWcTextareaElement;
         "modus-wc-theme-provider": HTMLModusWcThemeProviderElement;
@@ -945,6 +984,33 @@ declare namespace LocalJSX {
           * The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon.
          */
         "size"?: 'sm' | 'md' | 'lg';
+    }
+    /**
+     * A customizable input label component.
+     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface ModusWcInputLabel {
+        /**
+          * Additional classes for custom styling.
+         */
+        "customClass"?: string;
+        /**
+          * The `for` attribute of the label, matching the `id` of the associated input.
+         */
+        "forId"?: string;
+        /**
+          * Specifies the text direction of the label content.
+         */
+        "labelDir"?: '' | 'ltr' | 'rtl' | 'auto';
+        /**
+          * The text to display within the label.
+         */
+        "labelText"?: string;
+        /**
+          * Whether the label indicates a required field.
+         */
+        "required"?: boolean;
     }
     /**
      * A customizable input component used to create text inputs with types.
@@ -1221,6 +1287,7 @@ declare namespace LocalJSX {
         "modus-wc-checkbox": ModusWcCheckbox;
         "modus-wc-divider": ModusWcDivider;
         "modus-wc-icon": ModusWcIcon;
+        "modus-wc-input-label": ModusWcInputLabel;
         "modus-wc-text-input": ModusWcTextInput;
         "modus-wc-textarea": ModusWcTextarea;
         "modus-wc-theme-provider": ModusWcThemeProvider;
@@ -1263,6 +1330,12 @@ declare module "@stencil/core" {
              * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-icon": LocalJSX.ModusWcIcon & JSXBase.HTMLAttributes<HTMLModusWcIconElement>;
+            /**
+             * A customizable input label component.
+             * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
+             * Adheres to WCAG 2.2 standards.
+             */
+            "modus-wc-input-label": LocalJSX.ModusWcInputLabel & JSXBase.HTMLAttributes<HTMLModusWcInputLabelElement>;
             /**
              * A customizable input component used to create text inputs with types.
              * Adheres to WCAG 2.2 standards.

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.scss
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.scss
@@ -18,7 +18,34 @@
 
   &.modus-wc-badge-text {
     background-color: transparent;
-    color: var(--modus-wc-color-base-content);
     border: none;
+
+    &.modus-wc-badge-primary {
+      color: var(--modus-wc-color-trimble-blue);
+    }
+
+    &.modus-wc-badge-secondary {
+      color: var(--modus-wc-color-gray-6);
+    }
+
+    &.modus-wc-badge-neutral {
+      color: var(--modus-wc-color-gray-1);
+    }
+
+    &.modus-wc-badge-high-contrast {
+      color: var(--modus-wc-color-base-content);
+    }
+
+    &.modus-wc-badge-success {
+      color: var(--modus-wc-color-success);
+    }
+
+    &.modus-wc-badge-warning {
+      color: var(--modus-wc-color-warning);
+    }
+
+    &.modus-wc-badge-error {
+      color: var(--modus-wc-color-error);
+    }
   }
 }

--- a/src/components/atoms/modus-wc-checkbox/modus-wc-checkbox.stories.ts
+++ b/src/components/atoms/modus-wc-checkbox/modus-wc-checkbox.stories.ts
@@ -56,7 +56,7 @@ export default meta;
 
 type Story = StoryObj<CheckboxArgs>;
 
-const Template: Story = {
+export const Template: Story = {
   render: (args) => {
     return html`
       <modus-wc-checkbox
@@ -78,4 +78,32 @@ const Template: Story = {
   },
 };
 
-export const Default: Story = { ...Template };
+export const CheckboxWithLabel: Story = {
+  render: () => {
+    return html`
+      <form action="" class="form-example" method="get">
+        <div class="form-example">
+          <modus-wc-checkbox
+            aria-label="Example checkbox"
+            checkbox-id="checkbox-input"
+            name="example-checkbox"
+          ></modus-wc-checkbox>
+          <modus-wc-input-label
+            for-id="checkbox-input"
+            label-text="Example checkbox"
+          ></modus-wc-input-label>
+        </div>
+      </form>
+      <style>
+        .form-example {
+          display: flex;
+        }
+        modus-wc-checkbox {
+          padding-inline-end: 8px;
+        }
+      </style>
+    `;
+  },
+};
+
+// export const Default: Story = { ...Template};

--- a/src/components/atoms/modus-wc-input-label/__snapshots__/modus-wc-input-label.spec.ts.snap
+++ b/src/components/atoms/modus-wc-input-label/__snapshots__/modus-wc-input-label.spec.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modus-wc-input-label should render with content in the primary slot 1`] = `
+<modus-wc-input-label>
+  <!---->
+  <label class="modus-wc-input-label">
+    <span>
+      Slot content
+    </span>
+  </label>
+</modus-wc-input-label>
+`;
+
+exports[`modus-wc-input-label should render with custom props 1`] = `
+<modus-wc-input-label custom-class="test-class" dir="rtl" for-id="input-id" label-dir="rtl" label-text="Custom label" required="true">
+  <!---->
+  <label class="modus-wc-input-label test-class" htmlfor="input-id">
+    Custom label
+    <span aria-hidden="true" class="required-indicator">
+      *
+    </span>
+  </label>
+</modus-wc-input-label>
+`;
+
+exports[`modus-wc-input-label should render with default props 1`] = `
+<modus-wc-input-label>
+  <!---->
+  <label class="modus-wc-input-label"></label>
+</modus-wc-input-label>
+`;

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.scss
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.scss
@@ -1,0 +1,4 @@
+/**
+* This component uses Tailwind CSS and DaisyUI.
+* Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
+*/

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.scss
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.scss
@@ -2,3 +2,9 @@
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
+
+.modus-wc-input-label {
+  .required-indicator {
+    color: var(--modus-wc-color-error);
+  }
+}

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.spec.ts
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.spec.ts
@@ -1,0 +1,28 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ModusWcInputLabel } from './modus-wc-input-label';
+
+describe('modus-wc-input-label', () => {
+  it('should render with default props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputLabel],
+      html: '<modus-wc-input-label></modus-wc-input-label>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with custom props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputLabel],
+      html: '<modus-wc-input-label for-id="input-id" custom-class="test-class" label-dir="rtl" label-text="Custom label" required="true"></modus-wc-input-label>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with content in the primary slot', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputLabel],
+      html: '<modus-wc-input-label><span>Slot content</span></modus-wc-input-label>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+});

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.stories.ts
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.stories.ts
@@ -1,0 +1,44 @@
+import { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+interface InputLabelArgs {
+  'for-id'?: string;
+  'custom-class'?: string;
+  'label-dir'?: '' | 'ltr' | 'rtl' | 'auto';
+  'label-text'?: string;
+  required?: boolean;
+}
+
+const meta: Meta<InputLabelArgs> = {
+  title: 'Components/Atoms/Input Label',
+  component: 'modus-wc-input-label',
+  args: {
+    'label-text': 'Label',
+    required: false,
+  },
+  argTypes: {
+    'label-dir': {
+      control: { type: 'inline-radio' },
+      options: ['ltr', 'rtl', 'auto'],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<InputLabelArgs>;
+
+const Template: Story = {
+  render: (args) => html`
+    <modus-wc-input-label
+      for-id="${ifDefined(args['for-id'])}"
+      custom-class="${ifDefined(args['custom-class'])}"
+      label-dir="${ifDefined(args['label-dir'])}"
+      label-text="${ifDefined(args['label-text'])}"
+      ?required="${args['required']}"
+    ></modus-wc-input-label>
+  `,
+};
+
+export const Default: Story = { ...Template };

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
@@ -1,0 +1,65 @@
+import { Component, h, Host, Prop } from '@stencil/core';
+
+/**
+ * A customizable input label component.
+ *
+ * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
+ *
+ * Adheres to WCAG 2.2 standards.
+ */
+@Component({
+  tag: 'modus-wc-input-label',
+  styleUrl: 'modus-wc-input-label.scss',
+  shadow: false,
+})
+export class ModusWcInputLabel {
+  /**
+   * The `for` attribute of the label, matching the `id` of the associated input.
+   * */
+  @Prop() forId?: string;
+
+  /**
+   * Additional classes for custom styling.
+   * */
+  @Prop() customClass?: string = '';
+
+  /**
+   * Specifies the text direction of the label content.
+   */
+  @Prop() labelDir?: '' | 'ltr' | 'rtl' | 'auto';
+
+  /**
+   * The text to display within the label.
+   * */
+  @Prop() labelText?: string;
+
+  /**
+   * Whether the label indicates a required field.
+   * */
+  @Prop() required?: boolean = false;
+
+  private getClasses = (): string => {
+    const classList = ['modus-wc-input-label'];
+
+    // The order CSS classes are added matters to CSS specificity
+    if (this.customClass) classList.push(this.customClass);
+
+    return classList.join(' ');
+  };
+
+  render() {
+    return (
+      <Host dir={this.labelDir}>
+        <label class={this.getClasses()} htmlFor={this.forId}>
+          {this.labelText}
+          {this.required && (
+            <span class="required-indicator" aria-hidden="true">
+              {' *'}
+            </span>
+          )}
+          <slot />
+        </label>
+      </Host>
+    );
+  }
+}

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
@@ -53,7 +53,7 @@ export class ModusWcInputLabel {
         <label class={this.getClasses()} htmlFor={this.forId}>
           {this.labelText}
           {this.required && (
-            <span class="required-indicator" aria-hidden="true">
+            <span aria-hidden="true" class="required-indicator">
               {' *'}
             </span>
           )}

--- a/src/components/atoms/modus-wc-input-label/readme.md
+++ b/src/components/atoms/modus-wc-input-label/readme.md
@@ -1,0 +1,29 @@
+# modus-wc-input-label
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+A customizable input label component.
+
+The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
+
+Adheres to WCAG 2.2 standards.
+
+## Properties
+
+| Property      | Attribute      | Description                                                                  | Type                                          | Default     |
+| ------------- | -------------- | ---------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `customClass` | `custom-class` | Additional classes for custom styling.                                       | `string \| undefined`                         | `''`        |
+| `forId`       | `for-id`       | The `for` attribute of the label, matching the `id` of the associated input. | `string \| undefined`                         | `undefined` |
+| `labelDir`    | `label-dir`    | Specifies the text direction of the label content.                           | `"" \| "auto" \| "ltr" \| "rtl" \| undefined` | `undefined` |
+| `labelText`   | `label-text`   | The text to display within the label.                                        | `string \| undefined`                         | `undefined` |
+| `required`    | `required`     | Whether the label indicates a required field.                                | `boolean \| undefined`                        | `false`     |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -661,6 +661,86 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A customizable input label component.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "name": "ModusWcInputLabel",
+          "members": [
+            {
+              "kind": "method",
+              "name": "render"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "custom-class",
+              "fieldName": "customClass",
+              "type": {
+                "text": "string"
+              },
+              "description": "Additional classes for custom styling."
+            },
+            {
+              "name": "for-id",
+              "fieldName": "forId",
+              "type": {
+                "text": "string"
+              },
+              "description": "The `for` attribute of the label, matching the `id` of the associated input."
+            },
+            {
+              "name": "label-dir",
+              "fieldName": "labelDir",
+              "type": {
+                "text": "'' | 'ltr' | 'rtl' | 'auto'"
+              },
+              "description": "Specifies the text direction of the label content."
+            },
+            {
+              "name": "label-text",
+              "fieldName": "labelText",
+              "type": {
+                "text": "string"
+              },
+              "description": "The text to display within the label."
+            },
+            {
+              "name": "required",
+              "fieldName": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Whether the label indicates a required field."
+            }
+          ],
+          "tagName": "modus-wc-input-label",
+          "events": [],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ModusWcInputLabel",
+          "declaration": {
+            "name": "ModusWcInputLabel",
+            "module": "src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "modus-wc-input-label",
+          "declaration": {
+            "name": "ModusWcInputLabel",
+            "module": "src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/atoms/modus-wc-text-input/modus-wc-text-input.tsx",
       "declarations": [
         {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds the `modus-wc-input-label` component, stories, and tests.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Added unit tests

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [x] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

[AB#574611](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/574611)
