### PR TITLE
chore: update angular build/publish workflows for versions

### DIFF
--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -10,6 +10,10 @@ jobs:
   build-angular:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        angular-version: [17, 18]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,19 +35,19 @@ jobs:
       - name: Pack modus-wc
         id: npm_pack
         run: |
-          modus_wc_tarball=$(npm pack --pack-destination integrations/angular/ng18 | tail -n 1)
+          modus_wc_tarball=$(npm pack --pack-destination integrations/angular/ng${{ matrix.angular-version }} | tail -n 1)
           echo "modus_wc_tarball=${modus_wc_tarball}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies for angular build
         run: npm ci
-        working-directory: integrations/angular/ng18
+        working-directory: integrations/angular/ng${{ matrix.angular-version }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install current modus-wc implementation for angular integration
         run: npm install ./${{ steps.npm_pack.outputs.modus_wc_tarball }}
-        working-directory: integrations/angular/ng18
+        working-directory: integrations/angular/ng${{ matrix.angular-version }}
 
       - name: Build angular integration
         run: npm run build
-        working-directory: integrations/angular/ng18
+        working-directory: integrations/angular/ng${{ matrix.angular-version }}

--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Build Stencil components
         run: npm run build:ci
 
-      - name: DEBUG - List stencil generated files in ng${{ matrix.angular-version }}
-        run: ls -la integrations/angular/ng${{ matrix.angular-version }}/projects/trimble-cms/modus-wc-angular/src/lib/stencil-generated
-
       - name: Pack modus-wc
         id: npm_pack
         run: |

--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -22,9 +22,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          cache: 'npm'
-
-      - uses: google/wireit@setup-github-actions-caching/v2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build Stencil components
         run: npm run build:ci
 
+      - name: DEBUG - List stencil generated files in ng${{ matrix.angular-version }}
+        run: ls -la integrations/angular/ng${{ matrix.angular-version }}/projects/trimble-cms/modus-wc-angular/src/lib/stencil-generated
+
       - name: Pack modus-wc
         id: npm_pack
         run: |

--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -23,10 +23,6 @@ jobs:
         with:
           node-version: ${{ vars.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: |
-            package-lock.json
-            integrations/angular/ng${{ matrix.angular-version }}/package-lock.json
-            integrations/angular/ng${{ matrix.angular-version }}/projects/trimble-cms/modus-wc-angular/package-lock.json
 
       - uses: google/wireit@setup-github-actions-caching/v2
 

--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -22,6 +22,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ vars.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            integrations/angular/ng${{ matrix.angular-version }}/package-lock.json
+            integrations/angular/ng${{ matrix.angular-version }}/projects/trimble-cms/modus-wc-angular/package-lock.json
+
+      - uses: google/wireit@setup-github-actions-caching/v2
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download tarball artifact
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: angular-${{ matrix.angular-version }}-distribution-v${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -19,10 +19,13 @@ permissions:
 jobs:
   build-and-publish-angular:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        angular-version: [17, 18]
 
     defaults:
       run:
-        working-directory: integrations/angular/ng18
+        working-directory: integrations/angular/ng${{ matrix.angular-version }}
 
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -38,8 +41,8 @@ jobs:
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json
-            integrations/angular/ng18/package-lock.json
-            integrations/angular/ng18/projects/trimble-cms/modus-wc-angular/package-lock.json
+            integrations/angular/ng${{ matrix.angular-version }}/package-lock.json
+            integrations/angular/ng${{ matrix.angular-version }}/projects/trimble-cms/modus-wc-angular/package-lock.json
 
       - uses: google/wireit@setup-github-actions-caching/v2
 
@@ -64,7 +67,7 @@ jobs:
       - name: Update package.json version
         run: |
           cd projects/trimble-cms/modus-wc-angular && \
-          jq --arg version "${{ github.event.inputs.version }}-ng18" \
+          jq --arg version "${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}" \
           '.version = $version' package.json > package.json.tmp && \
           mv package.json.tmp package.json
 
@@ -86,10 +89,13 @@ jobs:
   release-angular:
     needs: build-and-publish-angular
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        angular-version: [17, 18]
 
     defaults:
       run:
-        working-directory: integrations/angular/ng18
+        working-directory: integrations/angular/ng${{ matrix.angular-version }}
 
     steps:
       - name: Checkout code
@@ -105,16 +111,16 @@ jobs:
         id: find-asset
         run: |
           asset_path=$(find . -name 'trimble-cms-modus-wc-angular*.tgz')
-          full_asset_path="${{ github.workspace }}/integrations/angular/ng18/${asset_path}"
+          full_asset_path="${{ github.workspace }}/integrations/angular/ng${{ matrix.angular-version }}/${asset_path}"
           echo "asset_path=$full_asset_path" >> $GITHUB_OUTPUT
 
       - name: Rename release asset
-        run: mv ${{ steps.find-asset.outputs.asset_path }} package-angular-18.tgz
+        run: mv ${{ steps.find-asset.outputs.asset_path }} package-angular-${{ matrix.angular-version }}.tgz
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: modus-wc-angular-${{ github.event.inputs.version }}-ng18
-          name: Modus Web Components Angular ${{ github.event.inputs.version }}-ng18
-          files: package-angular-18.tgz
+          tag_name: modus-wc-angular-${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
+          name: Modus Web Components Angular ${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
+          files: package-angular-${{ matrix.angular-version }}.tgz

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -62,7 +62,7 @@ jobs:
           cd projects/trimble-cms/modus-wc-angular && \
           jq --arg version "${{ github.event.inputs.version }}" \
           '.peerDependencies["@trimble-cms/modus-wc"] = $version' package.json > package.json.tmp && \
-          mv package.json.tmp package.json && npm i
+          mv package.json.tmp package.json
 
       - name: Update package.json version
         run: |

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -117,7 +117,6 @@ jobs:
       - name: Rename release asset
         run: |
           mv ${{ steps.find-asset.outputs.asset_path }} package-ng${{ matrix.angular-version }}.tgz
-          ls -l
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -126,4 +126,4 @@ jobs:
           tag_name: modus-wc-angular-${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
           name: Modus Web Components Angular ${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
           files: |
-            package-ng${{ matrix.angular-version }}.tgz
+            **/package-ng${{ matrix.angular-version }}.tgz

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: angular-distribution
+          name: angular-${{ matrix.angular-version }}-distribution-v${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
           path: '**/*.tgz'
 
       - name: Publish distribution
@@ -104,7 +104,7 @@ jobs:
       - name: Download tarball artifact
         uses: actions/download-artifact@v4
         with:
-          name: angular-distribution
+          name: angular-${{ matrix.angular-version }}-distribution-v${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
           path: .
 
       - name: Find the release asset
@@ -115,7 +115,8 @@ jobs:
           echo "asset_path=$full_asset_path" >> $GITHUB_OUTPUT
 
       - name: Rename release asset
-        run: mv ${{ steps.find-asset.outputs.asset_path }} package-angular-${{ matrix.angular-version }}.tgz
+        run: |
+          mv ${{ steps.find-asset.outputs.asset_path }} package-angular-${{ matrix.angular-version }}-v${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}.tgz
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -123,4 +124,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: modus-wc-angular-${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
           name: Modus Web Components Angular ${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
-          files: package-angular-${{ matrix.angular-version }}.tgz
+          files: package-angular-${{ matrix.angular-version }}-v${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}.tgz

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -116,7 +116,8 @@ jobs:
 
       - name: Rename release asset
         run: |
-          mv ${{ steps.find-asset.outputs.asset_path }} package-angular-${{ matrix.angular-version }}-v${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}.tgz
+          mv ${{ steps.find-asset.outputs.asset_path }} package-ng${{ matrix.angular-version }}.tgz
+          ls -l
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -124,4 +125,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: modus-wc-angular-${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
           name: Modus Web Components Angular ${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}
-          files: package-angular-${{ matrix.angular-version }}-v${{ github.event.inputs.version }}-ng${{ matrix.angular-version }}.tgz
+          files: |
+            package-ng${{ matrix.angular-version }}.tgz

--- a/.github/workflows/publish-react.yml
+++ b/.github/workflows/publish-react.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Install Web Component dependencies
         run: npm ci
+        working-directory: .
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           cache: 'npm'
@@ -67,19 +68,19 @@ jobs:
           '.version = $version' package.json > package.json.tmp && \
           mv package.json.tmp package.json
 
-      - name: Build React integration
+      - name: Build distribution
         run: npm run build
 
-      - name: Pack the package
+      - name: Package distribution
         run: npm pack
 
-      - name: Upload tarball as artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: npm-tarball-react${{ matrix.react-version }}
+          name: react-${{ matrix.react-version }}-distribution-v${{ github.event.inputs.version }}-react${{ matrix.react-version }}
           path: '**/*.tgz'
 
-      - name: Publish
+      - name: Publish distribution
         run: npm publish
 
   release-react:
@@ -97,20 +98,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download tarball artifact
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: npm-tarball-react${{ matrix.react-version }}
+          name: react-${{ matrix.react-version }}-distribution-v${{ github.event.inputs.version }}-react${{ matrix.react-version }}
           path: .
 
-      - name: Find the asset
+      - name: Find the release asset
         id: find-asset
         run: |
           asset_path=$(find . -name 'trimble-cms-modus-wc-react*.tgz')
           full_asset_path="${{ github.workspace }}/integrations/react/v${{ matrix.react-version }}/${asset_path}"
           echo "asset_path=$full_asset_path" >> $GITHUB_OUTPUT
 
-      - name: Rename the asset to package-react${{ matrix.react-version }}.tgz
+      - name: Rename release asset
         run: mv ${{ steps.find-asset.outputs.asset_path }} package-react${{ matrix.react-version }}.tgz
 
       - name: Create GitHub release
@@ -120,4 +121,4 @@ jobs:
           tag_name: modus-wc-react-${{ github.event.inputs.version }}-react${{ matrix.react-version }}
           name: Modus Web Components React ${{ github.event.inputs.version }} (React ${{ matrix.react-version }})
           files: |
-            package-react${{ matrix.react-version }}.tgz
+            **/package-react${{ matrix.react-version }}.tgz

--- a/package.json
+++ b/package.json
@@ -176,7 +176,8 @@
         "dist/**",
         "loader/**",
         "integrations/react/stencil-generated/**",
-        "integrations/angular/ng18/projects/trimble-cms/modus-wc-angular/src/lib/stencil-generated/**"
+        "integrations/angular/ng18/projects/trimble-cms/modus-wc-angular/src/lib/stencil-generated/**",
+        "integrations/angular/ng17/projects/trimble-cms/modus-wc-angular/src/lib/stencil-generated/**"
       ]
     },
     "stencil:watch": {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Adds support for building and publishing multiple Angular versions.

Changes:
-  updates the angular build and publish workflows to use a matrix strategy to ensure each supported angular integration version is included in workflow runs
- fixes a bug in the react publish workflow with `working-directory`  in "Install Web Component dependencies" step
- fixes artifact handling and GitHub release step
- renames some steps for clarity

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Manually tested. 
Publish test runs: 
modus-wc: https://github.com/Trimble-Construction/modus-wc-2.0/actions/runs/11902350229
modus-wc-angular: https://github.com/Trimble-Construction/modus-wc-2.0/actions/runs/11902365887
modus-wc-react: https://github.com/Trimble-Construction/modus-wc-2.0/actions/runs/11902365842

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

[AB#575474](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/575474)
