### PR TITLE
fix: loader size attribute specificity

### DIFF
--- a/src/components/atoms/modus-wc-loader/modus-wc-loader.scss
+++ b/src/components/atoms/modus-wc-loader/modus-wc-loader.scss
@@ -14,7 +14,6 @@
   mask-repeat: no-repeat;
   mask-position: center;
   pointer-events: none;
-  width: 1.5rem; /* equivalent to w-6 in Tailwind CSS */
 
   // Variants
   &.modus-wc-loader-ball {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -269,7 +269,7 @@
               "name": "variant",
               "fieldName": "variant",
               "type": {
-                "text": "'filled' | 'outlined' | 'text'"
+                "text": "'borderless' | 'filled' | 'outlined'"
               },
               "description": "The variant of the button."
             }


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR fixes the specificity bug observed in the loader component.

I removed the `width` css attribute from the base `modus-wc-loader` class and just let the component use the `size` prop to exclusively set the `width` value (defaults to `md` size). This avoids the `width` attribute from being overridden when applying various sizes.

After this PR is checked in I will run our release/publish workflow which will have version number `0.0.20`.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Verified `width` not overridden in storybook:

![chrome_0og9eY7Ad6](https://github.com/user-attachments/assets/1902cade-dc0d-4543-858b-f1af2296b26a)

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [x] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

[AB#582861](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/582861)
