### PR TITLE
Adds a non-breaking space to required labels

### DIFF
--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.stories.ts
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.stories.ts
@@ -42,3 +42,24 @@ const Template: Story = {
 };
 
 export const Default: Story = { ...Template };
+
+export const Required: Story = { ...Template, args: { required: true } };
+
+export const RequiredTextarea: Story = {
+  ...Template,
+  args: {
+    'label-text': 'Very Long Label With Lots Of Words',
+    required: true,
+    'for-id': 'textarea-input',
+  },
+  render: (args) => html`
+    <modus-wc-input-label
+      for-id="${ifDefined(args['for-id'])}"
+      custom-class="${ifDefined(args['custom-class'])}"
+      label-dir="${ifDefined(args['label-dir'])}"
+      label-text="${ifDefined(args['label-text'])}"
+      ?required="${args['required']}"
+    ></modus-wc-input-label>
+    <modus-wc-textarea id="textarea-input" required></modus-wc-textarea>
+  `,
+};

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
@@ -44,7 +44,8 @@ export class ModusWcInputLabel {
           {this.labelText}
           {this.required && (
             <span aria-hidden="true" class="required-indicator">
-              {' *'}
+              {/* Non-breaking space */}
+              {'\u00A0*'}
             </span>
           )}
           <slot />


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Makes the wrapping no longer weird and confusing when on narrow/confined layouts using input labels.
Goes from 
![image](https://github.com/user-attachments/assets/266bab2f-affb-478e-a281-f2ad0e735844)

To looking like
![image](https://github.com/user-attachments/assets/b17a6b8b-0e43-4d80-9413-8bd1a150be1b)


### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [x] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Azure DevOps Work Item

[AB#584744](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/584744)
