### PR TITLE
chore: Remove eslint caching (for wireit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,11 +111,7 @@
       ]
     },
     "format:eslint": {
-      "command": "eslint --color --cache --cache-location .eslintcache --fix .",
-      "files": [
-        "src/**/*.{ts,tsx,js,jsx}",
-        "eslint.config.js"
-      ]
+      "command": "eslint --color --cache --cache-location .eslintcache --fix ."
     },
     "format:prettier": {
       "command": "prettier --write .",
@@ -131,18 +127,7 @@
       ]
     },
     "lint:eslint": {
-      "command": "eslint --color --cache --cache-location .eslintcache .",
-      "clean": false,
-      "files": [
-        "src/**/*.{ts,tsx,js,jsx}",
-        "!src/components.d.ts",
-        "eslint.config.js"
-      ],
-      "output": [
-        "src/**/*.{ts,tsx,js,jsx}",
-        "!src/components.d.ts",
-        ".eslintcache"
-      ]
+      "command": "eslint --color --cache --cache-location .eslintcache ."
     },
     "lint:prettier": {
       "command": "prettier --check .",


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This keeps causing so many actions failures and assorted annoyances it's not worth the 3 second time save, at least currently.
The native eslint cache is kept, since that seems not to be causing any problems locally.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #576805
