### PR TITLE
fix: convert collapse event to complex object

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1531,7 +1531,7 @@ declare global {
         new (): HTMLModusWcCheckboxElement;
     };
     interface HTMLModusWcCollapseElementEventMap {
-        "expandedChange": boolean;
+        "expandedChange": { expanded: boolean };
     }
     /**
      * A customizable collapse component used for showing and hiding content.
@@ -2359,7 +2359,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when the expanded prop is internally changed.
          */
-        "onExpandedChange"?: (event: ModusWcCollapseCustomEvent<boolean>) => void;
+        "onExpandedChange"?: (event: ModusWcCollapseCustomEvent<{ expanded: boolean }>) => void;
         /**
           * Sets the size of the collapse component.
          */

--- a/src/components/molecules/modus-wc-accordion/modus-wc-accordion.spec.ts
+++ b/src/components/molecules/modus-wc-accordion/modus-wc-accordion.spec.ts
@@ -67,7 +67,7 @@ describe('modus-wc-accordion', () => {
     const collapsePanel = page.root?.querySelector('modus-wc-collapse');
     collapsePanel?.dispatchEvent(
       new CustomEvent('expandedChange', {
-        detail: false, // Simulating collapse
+        detail: { expanded: false }, // Simulating collapse
       })
     );
     await page.waitForChanges();

--- a/src/components/molecules/modus-wc-accordion/modus-wc-accordion.tsx
+++ b/src/components/molecules/modus-wc-accordion/modus-wc-accordion.tsx
@@ -66,10 +66,10 @@ export class ModusWcAccordion {
   }
 
   private handleCollapseExpandedChange = (
-    e: CustomEvent<boolean>,
+    e: CustomEvent<{ expanded: boolean }>,
     index: number
   ) => {
-    this.expandedChange.emit({ expanded: e.detail, index });
+    this.expandedChange.emit({ expanded: e.detail.expanded, index });
   };
 
   render() {
@@ -85,7 +85,7 @@ export class ModusWcAccordion {
               expanded={item.expanded}
               icon={item.icon}
               iconAriaLabel={item.iconAriaLabel}
-              onExpandedChange={(e: CustomEvent<boolean>) =>
+              onExpandedChange={(e: CustomEvent<{ expanded: boolean }>) =>
                 this.handleCollapseExpandedChange(e, index)
               }
               size={this.size}

--- a/src/components/molecules/modus-wc-collapse/modus-wc-collapse.spec.ts
+++ b/src/components/molecules/modus-wc-collapse/modus-wc-collapse.spec.ts
@@ -55,7 +55,9 @@ describe('modus-wc-collapse', () => {
     expect(expandedChangeSpy).toHaveBeenCalled();
     expect(expandedChangeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        detail: true,
+        detail: {
+          expanded: true,
+        },
       })
     );
   });
@@ -80,7 +82,9 @@ describe('modus-wc-collapse', () => {
     expect(expandedChangeSpy).toHaveBeenCalled();
     expect(expandedChangeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        detail: true,
+        detail: {
+          expanded: true,
+        },
       })
     );
   });
@@ -105,7 +109,9 @@ describe('modus-wc-collapse', () => {
     expect(expandedChangeSpy).toHaveBeenCalled();
     expect(expandedChangeSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        detail: true,
+        detail: {
+          expanded: true,
+        },
       })
     );
   });

--- a/src/components/molecules/modus-wc-collapse/modus-wc-collapse.stories.ts
+++ b/src/components/molecules/modus-wc-collapse/modus-wc-collapse.stories.ts
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -32,7 +33,11 @@ const meta: Meta<CollapseArgs> = {
       options: ['xs', 'sm', 'md', 'lg'],
     },
   },
+  decorators: [withActions],
   parameters: {
+    actions: {
+      handles: ['expandedChange'],
+    },
     layout: 'padded',
   },
 };

--- a/src/components/molecules/modus-wc-collapse/modus-wc-collapse.tsx
+++ b/src/components/molecules/modus-wc-collapse/modus-wc-collapse.tsx
@@ -57,7 +57,7 @@ export class ModusWcCollapse {
   @Prop() size?: DaisySize = 'md';
 
   /** Event emitted when the expanded prop is internally changed. */
-  @StencilEvent() expandedChange!: EventEmitter<boolean>;
+  @StencilEvent() expandedChange!: EventEmitter<{ expanded: boolean }>;
 
   @Watch('expanded')
   expandedChanged(newValue: boolean) {
@@ -77,7 +77,7 @@ export class ModusWcCollapse {
 
   private handleClick = () => {
     this.expanded = !this.expanded;
-    this.expandedChange.emit(this.expanded);
+    this.expandedChange.emit({ expanded: this.expanded });
   };
 
   private handleContentClick = (event: Event) => {

--- a/src/components/molecules/modus-wc-collapse/readme.md
+++ b/src/components/molecules/modus-wc-collapse/readme.md
@@ -29,9 +29,9 @@ Adheres to WCAG 2.2 standards.
 
 ## Events
 
-| Event            | Description                                                 | Type                   |
-| ---------------- | ----------------------------------------------------------- | ---------------------- |
-| `expandedChange` | Event emitted when the expanded prop is internally changed. | `CustomEvent<boolean>` |
+| Event            | Description                                                 | Type                                  |
+| ---------------- | ----------------------------------------------------------- | ------------------------------------- |
+| `expandedChange` | Event emitted when the expanded prop is internally changed. | `CustomEvent<{ expanded: boolean; }>` |
 
 
 ## Dependencies

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -3767,7 +3767,7 @@
               "kind": "field",
               "name": "expandedChange",
               "type": {
-                "text": "EventEmitter<boolean>"
+                "text": "EventEmitter<{ expanded: boolean }>"
               },
               "description": "Event emitted when the expanded prop is internally changed."
             }


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR converts the `expandedChange` event on the collapse component to a complex object. This allows for extensibility in the future.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Updated unit tests

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #
