### PR TITLE
Refactors how the library handles aria attribute inheitance

### DIFF
--- a/src/components/atoms/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
+++ b/src/components/atoms/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-avatar should render with custom props 1`] = `
-<modus-wc-avatar alt="Custom avatar" aria-label="Custom avatar" custom-class="test-class" img-src="https://example.com/avatar.jpg" shape="square" size="sm">
-  <div aria-label="Avatar Custom avatar" class="modus-wc-avatar" tabindex="-1">
+<modus-wc-avatar alt="Custom avatar" custom-class="test-class" img-src="https://example.com/avatar.jpg" shape="square" size="sm">
+  <div aria-label="Custom avatar" class="modus-wc-avatar" tabindex="-1">
     <div class="modus-wc-rounded-lg modus-wc-w-12 test-class">
       <img alt="Custom avatar" src="https://example.com/avatar.jpg">
     </div>
@@ -11,8 +11,8 @@ exports[`modus-wc-avatar should render with custom props 1`] = `
 `;
 
 exports[`modus-wc-avatar should render with default props 1`] = `
-<modus-wc-avatar alt="Default avatar" aria-label="Default avatar">
-  <div aria-label="Avatar Default avatar" class="modus-wc-avatar" tabindex="-1">
+<modus-wc-avatar alt="Default avatar">
+  <div aria-label="Default avatar" class="modus-wc-avatar" tabindex="-1">
     <div class="modus-wc-rounded-full modus-wc-w-16">
       <img alt="Default avatar" src="">
     </div>

--- a/src/components/atoms/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/atoms/modus-wc-avatar/modus-wc-avatar.tsx
@@ -37,7 +37,6 @@ export class ModusWcAvatar {
   @Prop() size?: DaisySize = 'md';
 
   componentWillLoad() {
-    this.inheritedAttributes = inheritAriaAttributes(this.el);
     if (!this.alt || !this.el.ariaLabel) {
       console.warn(
         'ModusWcAvatar: alt and aria-label are required for accessibility. Using fallback label.'
@@ -45,6 +44,7 @@ export class ModusWcAvatar {
       this.el.ariaLabel = this.el.ariaLabel || `Avatar ${this.alt || 'image'}`;
       this.alt = this.alt || 'Avatar image';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -66,7 +66,6 @@ export class ModusWcAvatar {
     return (
       <Host>
         <div
-          aria-label={this.el.ariaLabel}
           class="modus-wc-avatar"
           tabindex={-1}
           {...this.inheritedAttributes}

--- a/src/components/atoms/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/atoms/modus-wc-avatar/modus-wc-avatar.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-avatar.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable avatar component used to create avatars with different images.
@@ -13,6 +14,8 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcAvatar {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -34,6 +37,7 @@ export class ModusWcAvatar {
   @Prop() size?: DaisySize = 'md';
 
   componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
     if (!this.alt || !this.el.ariaLabel) {
       console.warn(
         'ModusWcAvatar: alt and aria-label are required for accessibility. Using fallback label.'
@@ -65,6 +69,7 @@ export class ModusWcAvatar {
           aria-label={this.el.ariaLabel}
           class="modus-wc-avatar"
           tabindex={-1}
+          {...this.inheritedAttributes}
         >
           <div class={this.getClasses()}>
             <img src={this.imgSrc} alt={this.alt} />

--- a/src/components/atoms/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/atoms/modus-wc-avatar/modus-wc-avatar.tsx
@@ -44,6 +44,7 @@ export class ModusWcAvatar {
       this.el.ariaLabel = this.el.ariaLabel || `Avatar ${this.alt || 'image'}`;
       this.alt = this.alt || 'Avatar image';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-badge/__snapshots__/modus-wc-badge.spec.ts.snap
+++ b/src/components/atoms/modus-wc-badge/__snapshots__/modus-wc-badge.spec.ts.snap
@@ -2,33 +2,19 @@
 
 exports[`modus-wc-badge should render with alert role 1`] = `
 <modus-wc-badge color="warning">
-  <span aria-label="Custom Badge" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-warning" role="alert" tabindex="-1"></span>
+  <span class="modus-wc-badge modus-wc-badge-md modus-wc-badge-warning" role="alert" tabindex="-1"></span>
 </modus-wc-badge>
 `;
 
 exports[`modus-wc-badge should render with custom props 1`] = `
 <modus-wc-badge color="secondary" content="Test" custom-class="test-class" size="lg" variant="text">
-  <span aria-label="Custom Badge" class="modus-wc-badge modus-wc-badge-lg modus-wc-badge-secondary modus-wc-badge-text test-class" role="status" tabindex="-1">
+  <span class="modus-wc-badge modus-wc-badge-lg modus-wc-badge-secondary modus-wc-badge-text test-class" role="status" tabindex="-1">
     Test
   </span>
 </modus-wc-badge>
 `;
 
 exports[`modus-wc-badge should render with default props 1`] = `
-<modus-wc-badge>
-  <span aria-label="Default Badge" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1"></span>
-</modus-wc-badge>
-`;
-
-exports[`modus-wc-badge should set ariaLabel to "Badge {content}" if content is provided 1`] = `
-<modus-wc-badge content="5">
-  <span class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1">
-    5
-  </span>
-</modus-wc-badge>
-`;
-
-exports[`modus-wc-badge should set ariaLabel to "Badge" if content is not provided 1`] = `
 <modus-wc-badge>
   <span class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1"></span>
 </modus-wc-badge>

--- a/src/components/atoms/modus-wc-badge/__snapshots__/modus-wc-badge.spec.ts.snap
+++ b/src/components/atoms/modus-wc-badge/__snapshots__/modus-wc-badge.spec.ts.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-badge should render with alert role 1`] = `
-<modus-wc-badge aria-label="Custom Badge" color="warning">
-  <span aria-label="Badge" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-warning" role="alert" tabindex="-1"></span>
+<modus-wc-badge color="warning">
+  <span aria-label="Custom Badge" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-warning" role="alert" tabindex="-1"></span>
 </modus-wc-badge>
 `;
 
 exports[`modus-wc-badge should render with custom props 1`] = `
-<modus-wc-badge aria-label="Custom Badge" color="secondary" content="Test" custom-class="test-class" size="lg" variant="text">
-  <span aria-label="Badge Test" class="modus-wc-badge modus-wc-badge-lg modus-wc-badge-secondary modus-wc-badge-text test-class" role="status" tabindex="-1">
+<modus-wc-badge color="secondary" content="Test" custom-class="test-class" size="lg" variant="text">
+  <span aria-label="Custom Badge" class="modus-wc-badge modus-wc-badge-lg modus-wc-badge-secondary modus-wc-badge-text test-class" role="status" tabindex="-1">
     Test
   </span>
 </modus-wc-badge>
 `;
 
 exports[`modus-wc-badge should render with default props 1`] = `
-<modus-wc-badge aria-label="Default Badge">
-  <span aria-label="Badge" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1"></span>
+<modus-wc-badge>
+  <span aria-label="Default Badge" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1"></span>
 </modus-wc-badge>
 `;
 
 exports[`modus-wc-badge should set ariaLabel to "Badge {content}" if content is provided 1`] = `
 <modus-wc-badge content="5">
-  <span aria-label="Badge 5" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1">
+  <span class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1">
     5
   </span>
 </modus-wc-badge>
@@ -30,6 +30,6 @@ exports[`modus-wc-badge should set ariaLabel to "Badge {content}" if content is 
 
 exports[`modus-wc-badge should set ariaLabel to "Badge" if content is not provided 1`] = `
 <modus-wc-badge>
-  <span aria-label="Badge" class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1"></span>
+  <span class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1"></span>
 </modus-wc-badge>
 `;

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.spec.ts
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.spec.ts
@@ -2,41 +2,10 @@ import { newSpecPage } from '@stencil/core/testing';
 import { ModusWcBadge } from './modus-wc-badge';
 
 describe('modus-wc-badge', () => {
-  it('should warn if aria-label is not provided', async () => {
-    const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-    await newSpecPage({
-      components: [ModusWcBadge],
-      html: '<modus-wc-badge></modus-wc-badge>',
-    });
-
-    expect(consoleWarnSpy).toHaveBeenCalledWith(
-      'ModusWcBadge: aria-label is required for accessibility. Using fallback label.'
-    );
-
-    consoleWarnSpy.mockRestore();
-  });
-
-  it('should set ariaLabel to "Badge {content}" if content is provided', async () => {
-    const page = await newSpecPage({
-      components: [ModusWcBadge],
-      html: `<modus-wc-badge content="5"></modus-wc-badge>`,
-    });
-    expect(page.root).toMatchSnapshot();
-  });
-
-  it('should set ariaLabel to "Badge" if content is not provided', async () => {
-    const page = await newSpecPage({
-      components: [ModusWcBadge],
-      html: `<modus-wc-badge></modus-wc-badge>`,
-    });
-    expect(page.root).toMatchSnapshot();
-  });
-
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcBadge],
-      html: '<modus-wc-badge aria-label="Default Badge"></modus-wc-badge>',
+      html: '<modus-wc-badge></modus-wc-badge>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -44,7 +13,7 @@ describe('modus-wc-badge', () => {
   it('should render with custom props', async () => {
     const page = await newSpecPage({
       components: [ModusWcBadge],
-      html: '<modus-wc-badge aria-label="Custom Badge" color="secondary" content="Test" custom-class="test-class" size="lg" variant="text"></modus-wc-badge>',
+      html: '<modus-wc-badge color="secondary" content="Test" custom-class="test-class" size="lg" variant="text"></modus-wc-badge>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -52,7 +21,7 @@ describe('modus-wc-badge', () => {
   it('should render with alert role', async () => {
     const page = await newSpecPage({
       components: [ModusWcBadge],
-      html: '<modus-wc-badge aria-label="Custom Badge" color="warning"></modus-wc-badge>',
+      html: '<modus-wc-badge color="warning"></modus-wc-badge>',
     });
     expect(page.root).toMatchSnapshot();
   });

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-badge.tailwind';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 const ALERT_COLORS = ['success', 'warning', 'danger'];
 
@@ -15,6 +16,8 @@ const ALERT_COLORS = ['success', 'warning', 'danger'];
   shadow: false,
 })
 export class ModusWcBadge {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -47,6 +50,7 @@ export class ModusWcBadge {
       );
       this.el.ariaLabel = this.content ? `Badge ${this.content}` : 'Badge';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -71,9 +75,9 @@ export class ModusWcBadge {
       <Host>
         <span
           class={this.getClasses()}
-          aria-label={this.el.ariaLabel}
           role={isAlert ? 'alert' : 'status'}
           tabindex={-1}
+          {...this.inheritedAttributes}
         >
           {this.content}
         </span>

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
@@ -44,12 +44,6 @@ export class ModusWcBadge {
   @Prop() variant: 'counter' | 'filled' | 'text' = 'filled';
 
   componentWillLoad() {
-    if (!this.el.ariaLabel) {
-      console.warn(
-        'ModusWcBadge: aria-label is required for accessibility. Using fallback label.'
-      );
-      this.el.ariaLabel = this.content ? `Badge ${this.content}` : 'Badge';
-    }
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-button/__snapshots__/modus-wc-button.spec.ts.snap
+++ b/src/components/atoms/modus-wc-button/__snapshots__/modus-wc-button.spec.ts.snap
@@ -1,26 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-button should render with custom props 1`] = `
-<modus-wc-button aria-label="Custom Button" color="secondary" custom-class="test-class" full-width="true" label="Test" pressed="true" size="lg" type="submit" variant="outlined">
+<modus-wc-button color="secondary" custom-class="test-class" full-width="true" label="Test" pressed="true" size="lg" type="submit" variant="outlined">
   <!---->
-  <button aria-label="Test" aria-pressed="true" class="modus-wc-btn modus-wc-btn-block modus-wc-btn-lg modus-wc-btn-outline modus-wc-btn-secondary test-class" tabindex="0" type="submit">
+  <button aria-label="Custom Button" aria-pressed="true" class="modus-wc-btn modus-wc-btn-block modus-wc-btn-lg modus-wc-btn-outline modus-wc-btn-secondary test-class" tabindex="0" type="submit">
     Test
   </button>
 </modus-wc-button>
 `;
 
 exports[`modus-wc-button should render with default props 1`] = `
-<modus-wc-button aria-label="Default Button">
+<modus-wc-button>
   <!---->
-  <button aria-label="Button" class="modus-wc-btn modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
+  <button aria-label="Default Button" class="modus-wc-btn modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
   </button>
 </modus-wc-button>
 `;
 
 exports[`modus-wc-button should render with disabled attribute 1`] = `
-<modus-wc-button aria-label="Custom Button" disabled="true">
+<modus-wc-button disabled="true">
   <!---->
-  <button aria-label="Button" class="modus-wc-btn modus-wc-btn-disabled modus-wc-btn-md modus-wc-btn-primary" disabled="" tabindex="-1" type="button">
+  <button aria-label="Custom Button" class="modus-wc-btn modus-wc-btn-disabled modus-wc-btn-md modus-wc-btn-primary" disabled="" tabindex="-1" type="button">
   </button>
 </modus-wc-button>
 `;

--- a/src/components/atoms/modus-wc-button/modus-wc-button.tsx
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.tsx
@@ -69,6 +69,7 @@ export class ModusWcButton {
       );
       this.el.ariaLabel = this.label || 'Button';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-button/modus-wc-button.tsx
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.tsx
@@ -10,6 +10,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-button.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable button component used to create buttons with different sizes, variants, and types.
@@ -22,6 +23,8 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcButton {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -66,6 +69,7 @@ export class ModusWcButton {
       );
       this.el.ariaLabel = this.label || 'Button';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -108,13 +112,13 @@ export class ModusWcButton {
       <Host>
         <button
           class={this.getClasses()}
-          aria-label={this.el.ariaLabel}
           aria-pressed={ariaPressed}
           disabled={this.disabled}
           onClick={this.handleClick}
           onKeyDown={this.handleKeyDown}
           tabIndex={this.disabled ? -1 : 0}
           type={this.type}
+          {...this.inheritedAttributes}
         >
           <slot name="left" />
           <slot />

--- a/src/components/atoms/modus-wc-checkbox/__snapshots__/modus-wc-checkbox.spec.ts.snap
+++ b/src/components/atoms/modus-wc-checkbox/__snapshots__/modus-wc-checkbox.spec.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-checkbox renders with default props 1`] = `
-<modus-wc-checkbox aria-label="Default checkbox">
-  <input aria-label="Checkbox" class="modus-wc-checkbox modus-wc-checkbox-md" type="checkbox">
+<modus-wc-checkbox>
+  <input aria-label="Default checkbox" class="modus-wc-checkbox modus-wc-checkbox-md" type="checkbox">
 </modus-wc-checkbox>
 `;
 
 exports[`modus-wc-checkbox should render indeterminate state 1`] = `
-<modus-wc-checkbox aria-label="Test checkbox" indeterminate="">
-  <input aria-checked="mixed" aria-label="Checkbox" class="modus-wc-checkbox modus-wc-checkbox-md" type="checkbox">
+<modus-wc-checkbox indeterminate="">
+  <input aria-checked="mixed" aria-label="Test checkbox" class="modus-wc-checkbox modus-wc-checkbox-md" type="checkbox">
 </modus-wc-checkbox>
 `;
 
 exports[`modus-wc-checkbox should render with custom props 1`] = `
-<modus-wc-checkbox aria-describedby="active" aria-label="Test checkbox" aria-labelledby="checkbox-label" custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" name="test-name" required="true" size="lg" value="">
-  <input aria-checked="" aria-describedby="active" aria-disabled="" aria-label="Checkbox" aria-labelledby="checkbox-label" checked="" class="modus-wc-checkbox modus-wc-checkbox-lg test-class" dir="rtl" disabled="" id="custom-id" name="test-name" required="" tabindex="1" type="checkbox">
+<modus-wc-checkbox custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" name="test-name" required="true" size="lg" value="">
+  <input aria-checked="" aria-describedby="active" aria-disabled="" aria-label="Test checkbox" aria-labelledby="checkbox-label" checked="" class="modus-wc-checkbox modus-wc-checkbox-lg test-class" dir="rtl" disabled="" id="custom-id" name="test-name" required="" tabindex="1" type="checkbox">
 </modus-wc-checkbox>
 `;

--- a/src/components/atoms/modus-wc-checkbox/modus-wc-checkbox.tsx
+++ b/src/components/atoms/modus-wc-checkbox/modus-wc-checkbox.tsx
@@ -83,6 +83,7 @@ export class ModusWcCheckbox {
       );
       this.el.ariaLabel = 'Checkbox';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-checkbox/modus-wc-checkbox.tsx
+++ b/src/components/atoms/modus-wc-checkbox/modus-wc-checkbox.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-checkbox.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable checkbox component.
@@ -21,14 +22,10 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcCheckbox {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the checkbox. */
-  @Prop() ariaDescribedby?: string;
-
-  /** The aria-labelledby attribute for usage with a label. */
-  @Prop() ariaLabelledby?: string;
 
   /** Custom CSS class to apply to the inner div. */
   @Prop() customClass?: string = '';
@@ -86,6 +83,7 @@ export class ModusWcCheckbox {
       );
       this.el.ariaLabel = 'Checkbox';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -117,10 +115,7 @@ export class ModusWcCheckbox {
       <Host>
         <input
           aria-checked={this.indeterminate ? 'mixed' : this.value}
-          aria-describedby={this.ariaDescribedby}
           aria-disabled={this.disabled}
-          aria-label={this.el.ariaLabel}
-          aria-labelledby={this.ariaLabelledby}
           checked={this.value}
           class={this.getClasses()}
           dir={this.inputDir}
@@ -133,6 +128,7 @@ export class ModusWcCheckbox {
           required={this.required}
           tabIndex={this.inputTabIndex}
           type="checkbox"
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
+++ b/src/components/atoms/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-date renders with default props 1`] = `
-<modus-wc-date aria-label="Default date" value="">
-  <input aria-label="Date input" class="modus-wc-date modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" type="date" value="">
+<modus-wc-date value="">
+  <input aria-label="Default date" class="modus-wc-date modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" type="date" value="">
 </modus-wc-date>
 `;
 
 exports[`modus-wc-date should render with custom props 1`] = `
-<modus-wc-date aria-describedby="description" aria-label="Test date" aria-labelledby="Another element" auto-focus="true" bordered="false" custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" max="11/25/2024" min="11/20/2024" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Test value">
-  <input aria-describedby="description" aria-label="Test placeholder" aria-labelledby="Another element" class="modus-wc-date modus-wc-input modus-wc-input-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="custom-id" max="11/25/2024" min="11/20/2024" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="date" value="Test value">
+<modus-wc-date auto-focus="true" bordered="false" custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" max="11/25/2024" min="11/20/2024" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Test value">
+  <input aria-describedby="description" aria-disabled="" aria-label="Test date" aria-labelledby="Another element" class="modus-wc-date modus-wc-input modus-wc-input-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="custom-id" max="11/25/2024" min="11/20/2024" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="date" value="Test value">
 </modus-wc-date>
 `;

--- a/src/components/atoms/modus-wc-date/modus-wc-date.tsx
+++ b/src/components/atoms/modus-wc-date/modus-wc-date.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-date.tailwind';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable date picker component used to create date inputs.
@@ -21,14 +22,10 @@ import { ModusSize } from '../../types';
   shadow: false,
 })
 export class ModusWcDate {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the input. */
-  @Prop() ariaDescribedby?: string;
-
-  /** The aria-labelledby attribute for usage with a label. */
-  @Prop() ariaLabelledby?: string;
 
   /** Indicates that the input should have a border. */
   @Prop() bordered?: boolean = true;
@@ -88,6 +85,7 @@ export class ModusWcDate {
       );
     }
     this.el.ariaLabel = this.placeholder || 'Date input';
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -120,9 +118,7 @@ export class ModusWcDate {
     return (
       <Host>
         <input
-          aria-describedby={this.ariaDescribedby}
-          aria-label={this.el.ariaLabel}
-          aria-labelledby={this.ariaLabelledby}
+          aria-disabled={this.disabled}
           class={this.getClasses()}
           dir={this.inputDir}
           disabled={this.disabled}
@@ -139,6 +135,7 @@ export class ModusWcDate {
           tabIndex={this.inputTabIndex}
           type="date"
           value={this.value}
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-divider/__snapshots__/modus-wc-divider.spec.ts.snap
+++ b/src/components/atoms/modus-wc-divider/__snapshots__/modus-wc-divider.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-divider should render with custom props 1`] = `
-<modus-wc-divider aria-label="Divider" color="primary" content="Test" custom-class="test-class" orientation="horizontal" position="start" responsive="false">
+<modus-wc-divider color="primary" content="Test" custom-class="test-class" orientation="horizontal" position="start" responsive="false">
   <div aria-label="Divider" class="modus-wc-divider modus-wc-divider-end modus-wc-divider-horizontal modus-wc-divider-primary test-class" role="separator" tabindex="-1">
     Test
   </div>
@@ -9,7 +9,7 @@ exports[`modus-wc-divider should render with custom props 1`] = `
 `;
 
 exports[`modus-wc-divider should render with default props 1`] = `
-<modus-wc-divider aria-label="Divider">
+<modus-wc-divider>
   <div aria-label="Divider" class="flex-grow modus-wc-divider modus-wc-divider-neutral modus-wc-divider-vertical place-items-center" role="separator" tabindex="-1"></div>
 </modus-wc-divider>
 `;

--- a/src/components/atoms/modus-wc-divider/modus-wc-divider.tsx
+++ b/src/components/atoms/modus-wc-divider/modus-wc-divider.tsx
@@ -51,6 +51,7 @@ export class ModusWcDivider {
       );
       this.el.ariaLabel = 'Divider';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-divider/modus-wc-divider.tsx
+++ b/src/components/atoms/modus-wc-divider/modus-wc-divider.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-divider.tailwind';
 import { Orientation } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable divider component used to separate content horizontally or vertically.
@@ -13,6 +14,8 @@ import { Orientation } from '../../types';
   shadow: false,
 })
 export class ModusWcDivider {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -48,6 +51,7 @@ export class ModusWcDivider {
       );
       this.el.ariaLabel = 'Divider';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -72,9 +76,9 @@ export class ModusWcDivider {
       <Host>
         <div
           class={this.getClasses()}
-          aria-label={this.el.ariaLabel}
           role="separator"
           tabindex={-1}
+          {...this.inheritedAttributes}
         >
           {this.content}
         </div>

--- a/src/components/atoms/modus-wc-icon/__snapshots__/modus-wc-icon.spec.ts.snap
+++ b/src/components/atoms/modus-wc-icon/__snapshots__/modus-wc-icon.spec.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-icon should render with custom props 1`] = `
-<modus-wc-icon aria-label="Custom icon" class="modus-wc-flex modus-wc-items-center" custom-class="test-class" decorative="false" size="sm">
-  <i aria-label="undefined icon" class="modus-icons modus-wc-icon--sm test-class" role="img" tabindex="-1"></i>
+<modus-wc-icon class="modus-wc-flex modus-wc-items-center" custom-class="test-class" decorative="false" size="sm">
+  <i aria-label="Custom icon" class="modus-icons modus-wc-icon--sm test-class" role="img" tabindex="-1"></i>
 </modus-wc-icon>
 `;
 
 exports[`modus-wc-icon should render with default props 1`] = `
-<modus-wc-icon aria-label="Default icon" class="modus-wc-flex modus-wc-items-center">
-  <i aria-hidden="true" class="modus-icons modus-wc-icon--md" tabindex="-1"></i>
+<modus-wc-icon class="modus-wc-flex modus-wc-items-center">
+  <i aria-hidden="true" aria-label="Default icon" class="modus-icons modus-wc-icon--md" tabindex="-1"></i>
 </modus-wc-icon>
 `;
 
 exports[`modus-wc-icon should render with size prop lg 1`] = `
-<modus-wc-icon aria-label="Custom icon" class="modus-wc-flex modus-wc-items-center" size="lg">
-  <i aria-hidden="true" class="modus-icons modus-wc-icon--lg" tabindex="-1"></i>
+<modus-wc-icon class="modus-wc-flex modus-wc-items-center" size="lg">
+  <i aria-hidden="true" aria-label="Custom icon" class="modus-icons modus-wc-icon--lg" tabindex="-1"></i>
 </modus-wc-icon>
 `;

--- a/src/components/atoms/modus-wc-icon/modus-wc-icon.tsx
+++ b/src/components/atoms/modus-wc-icon/modus-wc-icon.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable icon component used to render Modus icons.
@@ -14,6 +15,8 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcIcon {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -36,6 +39,7 @@ export class ModusWcIcon {
       );
       this.el.ariaLabel = `${this.name} icon`;
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -60,6 +64,7 @@ export class ModusWcIcon {
           class={this.getClasses()}
           role={role}
           tabindex={-1}
+          {...this.inheritedAttributes}
         >
           {this.name}
         </i>

--- a/src/components/atoms/modus-wc-icon/modus-wc-icon.tsx
+++ b/src/components/atoms/modus-wc-icon/modus-wc-icon.tsx
@@ -39,6 +39,7 @@ export class ModusWcIcon {
       );
       this.el.ariaLabel = `${this.name} icon`;
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
+++ b/src/components/atoms/modus-wc-input-label/modus-wc-input-label.tsx
@@ -1,4 +1,5 @@
-import { Component, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable input label component.
@@ -13,6 +14,11 @@ import { Component, h, Host, Prop } from '@stencil/core';
   shadow: false,
 })
 export class ModusWcInputLabel {
+  private inheritedAttributes: Attributes = {};
+
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
   /** The `for` attribute of the label, matching the `id` of the associated input. */
   @Prop() forId?: string;
 
@@ -28,6 +34,10 @@ export class ModusWcInputLabel {
   /** Whether the label indicates a required field. */
   @Prop() required?: boolean = false;
 
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
+
   private getClasses = (): string => {
     const classList = ['modus-wc-input-label'];
 
@@ -40,7 +50,11 @@ export class ModusWcInputLabel {
   render() {
     return (
       <Host dir={this.labelDir}>
-        <label class={this.getClasses()} htmlFor={this.forId}>
+        <label
+          class={this.getClasses()}
+          htmlFor={this.forId}
+          {...this.inheritedAttributes}
+        >
           {this.labelText}
           {this.required && (
             <span aria-hidden="true" class="required-indicator">

--- a/src/components/atoms/modus-wc-loader/__snapshots__/modus-wc-loader.spec.ts.snap
+++ b/src/components/atoms/modus-wc-loader/__snapshots__/modus-wc-loader.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-loader should render with custom props 1`] = `
-<modus-wc-loader aria-label="Loading loader" color="secondary" custom-class="test-class" size="lg" variant="dots">
-  <span aria-label="Loading" class="modus-wc-loader modus-wc-loader-dots modus-wc-loader-lg modus-wc-text-secondary test-class" role="status" tabindex="-1"></span>
+<modus-wc-loader color="secondary" custom-class="test-class" size="lg" variant="dots">
+  <span aria-label="Loading loader" class="modus-wc-loader modus-wc-loader-dots modus-wc-loader-lg modus-wc-text-secondary test-class" role="status" tabindex="-1"></span>
 </modus-wc-loader>
 `;
 
 exports[`modus-wc-loader should render with default props 1`] = `
-<modus-wc-loader aria-label="Loading loader">
-  <span aria-label="Loading" class="modus-wc-loader modus-wc-loader-md modus-wc-loader-spinner modus-wc-text-primary" role="status" tabindex="-1"></span>
+<modus-wc-loader>
+  <span aria-label="Loading loader" class="modus-wc-loader modus-wc-loader-md modus-wc-loader-spinner modus-wc-text-primary" role="status" tabindex="-1"></span>
 </modus-wc-loader>
 `;

--- a/src/components/atoms/modus-wc-loader/modus-wc-loader.tsx
+++ b/src/components/atoms/modus-wc-loader/modus-wc-loader.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-loader.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export type LoaderVariant =
   | 'ball'
@@ -31,6 +32,8 @@ export type LoaderColor =
   shadow: false,
 })
 export class ModusWcLoader {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -53,6 +56,7 @@ export class ModusWcLoader {
       );
       this.el.ariaLabel = 'Loading';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -75,10 +79,10 @@ export class ModusWcLoader {
     return (
       <Host>
         <span
-          aria-label={this.el.ariaLabel}
           class={this.getClasses()}
           role="status"
           tabindex={-1}
+          {...this.inheritedAttributes}
         ></span>
       </Host>
     );

--- a/src/components/atoms/modus-wc-loader/modus-wc-loader.tsx
+++ b/src/components/atoms/modus-wc-loader/modus-wc-loader.tsx
@@ -56,6 +56,7 @@ export class ModusWcLoader {
       );
       this.el.ariaLabel = 'Loading';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-menu/__snapshots__/modus-wc-menu.spec.ts.snap
+++ b/src/components/atoms/modus-wc-menu/__snapshots__/modus-wc-menu.spec.ts.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-menu renders with default props 1`] = `
-<modus-wc-menu aria-label="Default menu">
-  <ul aria-label="Menu" aria-orientation="vertical" class="modus-wc-border-2 modus-wc-border-solid modus-wc-menu modus-wc-menu-md modus-wc-rounded modus-wc-w-full" role="menu"></ul>
+<modus-wc-menu>
+  <ul aria-label="Default menu" aria-orientation="vertical" class="modus-wc-border-2 modus-wc-border-solid modus-wc-menu modus-wc-menu-md modus-wc-rounded modus-wc-w-full" role="menu"></ul>
 </modus-wc-menu>
 `;
 
 exports[`modus-wc-menu should render with custom props 1`] = `
-<modus-wc-menu active-item-value="2" aria-label="Test menu" bordered="false" custom-class="test-class" menu-title="Title" orientation="horizontal" size="lg">
-  <ul aria-label="Menu" aria-orientation="horizontal" class="modus-wc-menu modus-wc-menu-horizontal modus-wc-menu-lg modus-wc-w-full test-class" role="menubar">
+<modus-wc-menu active-item-value="2" bordered="false" custom-class="test-class" menu-title="Title" orientation="horizontal" size="lg">
+  <ul aria-label="Test menu" aria-orientation="horizontal" class="modus-wc-menu modus-wc-menu-horizontal modus-wc-menu-lg modus-wc-w-full test-class" role="menubar">
     <li class="modus-wc-menu-title" role="presentation">
       Title
     </li>

--- a/src/components/atoms/modus-wc-menu/modus-wc-menu.tsx
+++ b/src/components/atoms/modus-wc-menu/modus-wc-menu.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-menu.tailwind';
 import { ModusSize, Orientation } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface IMenuItem {
   disabled?: boolean;
@@ -27,6 +28,8 @@ export interface IMenuItem {
   shadow: false,
 })
 export class ModusWcMenu {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -61,6 +64,7 @@ export class ModusWcMenu {
       );
     }
     this.el.ariaLabel = 'Menu';
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -110,10 +114,10 @@ export class ModusWcMenu {
     return (
       <Host>
         <ul
-          aria-label={this.el.ariaLabel}
           aria-orientation={this.orientation}
           class={this.getClasses()}
           role={this.getMenuRole()}
+          {...this.inheritedAttributes}
         >
           {this.menuTitle && (
             <li class="modus-wc-menu-title" role="presentation">

--- a/src/components/atoms/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
+++ b/src/components/atoms/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-number-input should render with custom props 1`] = `
-<modus-wc-number-input aria-describedby="description" aria-label="Test number input" auto-complete="on" auto-focus="true" custom-class="test-class" disabled="true" input-aria-invalid="true" input-dir="rtl" input-id="test-id" input-mode="decimal" input-tab-index="1" max="10" min="1" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" step="2" type="range" value="test@example.com">
-  <input aria-describedby="description" aria-invalid="true" aria-label="Test placeholder" aria-placeholder="Test placeholder" aria-required="" autocomplete="on" class="modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="test-id" inputmode="decimal" max="10" min="1" name="test-name" placeholder="Test placeholder" required="" step="2" tabindex="1" type="range" value="test@example.com">
+<modus-wc-number-input auto-complete="on" auto-focus="true" custom-class="test-class" disabled="true" input-aria-invalid="true" input-dir="rtl" input-id="test-id" input-mode="decimal" input-tab-index="1" max="10" min="1" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" step="2" type="range" value="test@example.com">
+  <input aria-describedby="description" aria-label="Test number input" aria-placeholder="Test placeholder" aria-required="" autocomplete="on" class="modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="test-id" inputmode="decimal" max="10" min="1" name="test-name" placeholder="Test placeholder" required="" step="2" tabindex="1" type="range" value="test@example.com">
 </modus-wc-number-input>
 `;
 
 exports[`modus-wc-number-input should render with default props 1`] = `
-<modus-wc-number-input aria-label="Default input" value="">
-  <input aria-label="Number input" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="numeric" placeholder="" type="number" value="">
+<modus-wc-number-input value="">
+  <input aria-label="Default input" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="numeric" placeholder="" type="number" value="">
 </modus-wc-number-input>
 `;

--- a/src/components/atoms/modus-wc-number-input/modus-wc-number-input.tsx
+++ b/src/components/atoms/modus-wc-number-input/modus-wc-number-input.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-number-input.tailwind';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable input component used to create number inputs with types.
@@ -21,11 +22,10 @@ import { ModusSize } from '../../types';
   shadow: false,
 })
 export class ModusWcNumberInput {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the input. */
-  @Prop() ariaDescribedby?: string;
 
   /** Hint for form autofill feature. */
   @Prop() autoComplete?: 'on' | 'off';
@@ -38,9 +38,6 @@ export class ModusWcNumberInput {
 
   /** Whether the form control is disabled. */
   @Prop() disabled?: boolean = false;
-
-  /** Indicates whether the input has an invalid input. */
-  @Prop() inputAriaInvalid?: 'true' | 'false';
 
   /** Specifies the text direction of the input content. */
   @Prop() inputDir?: '' | 'ltr' | 'rtl' | 'auto';
@@ -103,6 +100,7 @@ export class ModusWcNumberInput {
       );
       this.el.ariaLabel = this.placeholder || 'Number input';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -135,9 +133,6 @@ export class ModusWcNumberInput {
     return (
       <Host>
         <input
-          aria-describedby={this.ariaDescribedby}
-          aria-invalid={this.inputAriaInvalid}
-          aria-label={this.el.ariaLabel}
           aria-placeholder={this.placeholder}
           aria-required={this.required}
           autocomplete={this.autoComplete}
@@ -159,6 +154,7 @@ export class ModusWcNumberInput {
           tabIndex={this.inputTabIndex}
           type={this.type}
           value={this.value}
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-number-input/modus-wc-number-input.tsx
+++ b/src/components/atoms/modus-wc-number-input/modus-wc-number-input.tsx
@@ -100,6 +100,7 @@ export class ModusWcNumberInput {
       );
       this.el.ariaLabel = this.placeholder || 'Number input';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
+++ b/src/components/atoms/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-progress should render indeterminate state 1`] = `
-<modus-wc-progress aria-label="Custom Progress Bar" indeterminate="" value="0">
-  <progress aria-hidden="true" aria-label="Progress" class="modus-wc-progress modus-wc-w-full"></progress>
+<modus-wc-progress indeterminate="" value="0">
+  <progress aria-hidden="true" aria-label="Custom Progress Bar" class="modus-wc-progress modus-wc-w-full"></progress>
 </modus-wc-progress>
 `;
 
 exports[`modus-wc-progress should render with custom props 1`] = `
-<modus-wc-progress aria-label="Custom Progress Bar" custom-class="test-class" max="50" value="25">
-  <progress aria-label="Progress" aria-valuemax="50" aria-valuemin="0" aria-valuenow="25" class="modus-wc-progress modus-wc-w-full test-class" max="50" value="25"></progress>
+<modus-wc-progress custom-class="test-class" max="50" value="25">
+  <progress aria-label="Custom Progress Bar" aria-valuemax="50" aria-valuemin="0" aria-valuenow="25" class="modus-wc-progress modus-wc-w-full test-class" max="50" value="25"></progress>
 </modus-wc-progress>
 `;
 
 exports[`modus-wc-progress should render with default props 1`] = `
-<modus-wc-progress aria-label="Default Progress Bar" value="0">
-  <progress aria-label="Progress" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
+<modus-wc-progress value="0">
+  <progress aria-label="Default Progress Bar" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
 </modus-wc-progress>
 `;

--- a/src/components/atoms/modus-wc-progress/modus-wc-progress.tsx
+++ b/src/components/atoms/modus-wc-progress/modus-wc-progress.tsx
@@ -1,4 +1,5 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 // import { convertPropsToClasses } from './modus-wc-progress.tailwind';
 
 /**
@@ -12,6 +13,8 @@ import { Component, Element, h, Host, Prop } from '@stencil/core';
   shadow: false,
 })
 export class ModusWcProgress {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -34,6 +37,7 @@ export class ModusWcProgress {
       );
       this.el.ariaLabel = 'Progress';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -62,9 +66,9 @@ export class ModusWcProgress {
     return (
       <Host>
         <progress
-          aria-label={this.el.ariaLabel}
           class={this.getClasses()}
           {...valueAttributes}
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-progress/modus-wc-progress.tsx
+++ b/src/components/atoms/modus-wc-progress/modus-wc-progress.tsx
@@ -37,6 +37,7 @@ export class ModusWcProgress {
       );
       this.el.ariaLabel = 'Progress';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-radio/__snapshots__/modus-wc-radio.spec.ts.snap
+++ b/src/components/atoms/modus-wc-radio/__snapshots__/modus-wc-radio.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-radio renders with default props 1`] = `
-<modus-wc-radio aria-label="Default radio">
-  <input aria-label="Radio button" class="modus-wc-radio modus-wc-radio-md" type="radio">
+<modus-wc-radio>
+  <input aria-label="Default radio" class="modus-wc-radio modus-wc-radio-md" type="radio">
 </modus-wc-radio>
 `;
 
 exports[`modus-wc-radio should render with custom props 1`] = `
-<modus-wc-radio aria-describedby="active" aria-label="Test radio" aria-labelledby="radio-label" custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" name="test-name" required="true" size="lg" value="">
-  <input aria-checked="" aria-describedby="active" aria-disabled="" aria-label="Radio button" aria-labelledby="radio-label" checked="" class="modus-wc-radio modus-wc-radio-lg test-class" dir="rtl" disabled="" id="custom-id" name="test-name" required="" tabindex="1" type="radio">
+<modus-wc-radio custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" name="test-name" required="true" size="lg" value="">
+  <input aria-checked="" aria-describedby="active" aria-disabled="" aria-label="Test radio" aria-labelledby="radio-label" checked="" class="modus-wc-radio modus-wc-radio-lg test-class" dir="rtl" disabled="" id="custom-id" name="test-name" required="" tabindex="1" type="radio">
 </modus-wc-radio>
 `;

--- a/src/components/atoms/modus-wc-radio/modus-wc-radio.tsx
+++ b/src/components/atoms/modus-wc-radio/modus-wc-radio.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-radio.tailwind';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable radio component.
@@ -21,14 +22,10 @@ import { ModusSize } from '../../types';
   shadow: false,
 })
 export class ModusWcRadio {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the radio. */
-  @Prop() ariaDescribedby?: string;
-
-  /** The aria-labelledby attribute for usage with a label. */
-  @Prop() ariaLabelledby?: string;
 
   /** Custom CSS class to apply to the inner div. */
   @Prop() customClass?: string = '';
@@ -73,6 +70,7 @@ export class ModusWcRadio {
       );
     }
     this.el.ariaLabel = 'Radio button';
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -104,10 +102,7 @@ export class ModusWcRadio {
       <Host>
         <input
           aria-checked={this.value}
-          aria-describedby={this.ariaDescribedby}
           aria-disabled={this.disabled}
-          aria-label={this.el.ariaLabel}
-          aria-labelledby={this.ariaLabelledby}
           checked={this.value}
           class={this.getClasses()}
           dir={this.inputDir}
@@ -120,6 +115,7 @@ export class ModusWcRadio {
           required={this.required}
           tabIndex={this.inputTabIndex}
           type="radio"
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-select/__snapshots__/modus-wc-select.spec.ts.snap
+++ b/src/components/atoms/modus-wc-select/__snapshots__/modus-wc-select.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-select renders with default props 1`] = `
-<modus-wc-select aria-label="Default select" value="">
-  <select aria-label="Select" class="modus-wc-select modus-wc-select-bordered modus-wc-select-md modus-wc-w-full"></select>
+<modus-wc-select value="">
+  <select aria-label="Default select" class="modus-wc-select modus-wc-select-bordered modus-wc-select-md modus-wc-w-full"></select>
 </modus-wc-select>
 `;
 
 exports[`modus-wc-select should render with custom props 1`] = `
-<modus-wc-select '1'="" 'option="" 1',="" aria-describedby="description" aria-label="Test select" auto-focus="true" bordered="false" custom-class="test-class" disabled="true" input-aria-invalid="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" label:="" name="test-name" options="{[{" required="true" size="lg" value="1" value:="" }]}="">
-  <select aria-describedby="description" aria-invalid="true" aria-label="Select" class="modus-wc-select modus-wc-select-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="custom-id" name="test-name" required="" tabindex="1"></select>
+<modus-wc-select '1'="" 'option="" 1',="" auto-focus="true" bordered="false" custom-class="test-class" disabled="true" input-aria-invalid="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" label:="" name="test-name" options="{[{" required="true" size="lg" value="1" value:="" }]}="">
+  <select aria-describedby="description" aria-label="Test select" class="modus-wc-select modus-wc-select-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="custom-id" name="test-name" required="" tabindex="1"></select>
 </modus-wc-select>
 `;

--- a/src/components/atoms/modus-wc-select/modus-wc-select.tsx
+++ b/src/components/atoms/modus-wc-select/modus-wc-select.tsx
@@ -82,6 +82,7 @@ export class ModusWcSelect {
       );
       this.el.ariaLabel = 'Select';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-select/modus-wc-select.tsx
+++ b/src/components/atoms/modus-wc-select/modus-wc-select.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-select.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface ISelectOption {
   disabled?: boolean;
@@ -27,11 +28,10 @@ export interface ISelectOption {
   shadow: false,
 })
 export class ModusWcSelect {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the input. */
-  @Prop() ariaDescribedby?: string;
 
   /** Indicates that the input should have a border. */
   @Prop() bordered?: boolean = true;
@@ -41,9 +41,6 @@ export class ModusWcSelect {
 
   /** Whether the form control is disabled. */
   @Prop() disabled?: boolean = false;
-
-  /** Indicates whether the input has an invalid input. */
-  @Prop() inputAriaInvalid?: 'true' | 'false';
 
   /** Specifies the text direction of the input content. */
   @Prop() inputDir?: '' | 'ltr' | 'rtl' | 'auto';
@@ -85,6 +82,7 @@ export class ModusWcSelect {
       );
       this.el.ariaLabel = 'Select';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -118,9 +116,6 @@ export class ModusWcSelect {
     return (
       <Host>
         <select
-          aria-describedby={this.ariaDescribedby}
-          aria-invalid={this.inputAriaInvalid}
-          aria-label={this.el.ariaLabel}
           class={this.getClasses()}
           dir={this.inputDir}
           disabled={this.disabled}
@@ -131,6 +126,7 @@ export class ModusWcSelect {
           onInput={this.handleInput}
           required={this.required}
           tabindex={this.inputTabIndex}
+          {...this.inheritedAttributes}
         >
           {this.options.map((option) => (
             <option

--- a/src/components/atoms/modus-wc-skeleton/__snapshots__/modus-wc-skeleton.spec.ts.snap
+++ b/src/components/atoms/modus-wc-skeleton/__snapshots__/modus-wc-skeleton.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`modus-wc-skeleton renders with default props 1`] = `
 `;
 
 exports[`modus-wc-skeleton should render with custom props 1`] = `
-<modus-wc-skeleton aria-hidden="false" custom-class="test-class" height="5rem" role="status" shape="circle" tabindex="1" width="5rem">
-  <div aria-hidden="true" class="modus-wc-rounded-full modus-wc-skeleton test-class" tabindex="-1" style="height: 5rem; width: 5rem;"></div>
+<modus-wc-skeleton custom-class="test-class" height="5rem" shape="circle" tabindex="1" width="5rem">
+  <div aria-hidden="false" class="modus-wc-rounded-full modus-wc-skeleton test-class" role="status" tabindex="-1" style="height: 5rem; width: 5rem;"></div>
 </modus-wc-skeleton>
 `;

--- a/src/components/atoms/modus-wc-skeleton/modus-wc-skeleton.tsx
+++ b/src/components/atoms/modus-wc-skeleton/modus-wc-skeleton.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-skeleton.tailwind';
 import { Attributes, inheritAriaAttributes } from '../../utils';
 
@@ -13,6 +13,11 @@ import { Attributes, inheritAriaAttributes } from '../../utils';
   shadow: false,
 })
 export class ModusWcSkeleton {
+  private inheritedAttributes: Attributes = {};
+
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
   /** Custom CSS class to apply to the inner div. */
   @Prop() customClass?: string = '';
 
@@ -24,6 +29,10 @@ export class ModusWcSkeleton {
 
   /** The width of the skeleton. */
   @Prop() width: string = '100%';
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
 
   private getClasses(): string {
     const classList = ['modus-wc-skeleton'];

--- a/src/components/atoms/modus-wc-skeleton/modus-wc-skeleton.tsx
+++ b/src/components/atoms/modus-wc-skeleton/modus-wc-skeleton.tsx
@@ -1,5 +1,6 @@
 import { Component, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-skeleton.tailwind';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable skeleton component used to create skeletons of various sizes and shapes.
@@ -50,6 +51,7 @@ export class ModusWcSkeleton {
           class={this.getClasses()}
           style={this.getStyles()}
           tabindex={-1}
+          {...this.inheritedAttributes}
         ></div>
       </Host>
     );

--- a/src/components/atoms/modus-wc-slider/__snapshots__/modus-wc-slider.spec.ts.snap
+++ b/src/components/atoms/modus-wc-slider/__snapshots__/modus-wc-slider.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-slider renders with default props 1`] = `
-<modus-wc-slider aria-label="Default slider" value="0">
-  <input aria-label="Slider" class="modus-wc-range modus-wc-range-xs" type="range" value="0">
+<modus-wc-slider value="0">
+  <input aria-label="Default slider" class="modus-wc-range modus-wc-range-xs" type="range" value="0">
 </modus-wc-slider>
 `;
 
 exports[`modus-wc-slider should render with custom props 1`] = `
-<modus-wc-slider aria-describedby="active" aria-label="Test slider" aria-labelledby="slider-label" custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" max="100" min="50" name="test-name" required="true" size="lg" step="50" value="NaN">
-  <input aria-describedby="active" aria-disabled="" aria-label="Slider" aria-labelledby="slider-label" class="modus-wc-range modus-wc-range-lg test-class" dir="rtl" disabled="" id="custom-id" max="100" min="50" name="test-name" required="" step="50" tabindex="1" type="range" value="NaN">
+<modus-wc-slider custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" max="100" min="50" name="test-name" required="true" size="lg" step="50" value="NaN">
+  <input aria-describedby="active" aria-disabled="" aria-label="Test slider" aria-labelledby="slider-label" class="modus-wc-range modus-wc-range-lg test-class" dir="rtl" disabled="" id="custom-id" max="100" min="50" name="test-name" required="" step="50" tabindex="1" type="range" value="NaN">
 </modus-wc-slider>
 `;

--- a/src/components/atoms/modus-wc-slider/modus-wc-slider.tsx
+++ b/src/components/atoms/modus-wc-slider/modus-wc-slider.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-slider.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable slider component.
@@ -21,14 +22,10 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcSlider {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the slider. */
-  @Prop() ariaDescribedby?: string;
-
-  /** The aria-labelledby attribute for usage with a label. */
-  @Prop() ariaLabelledby?: string;
 
   /** Custom CSS class to apply to the inner div. */
   @Prop() customClass?: string = '';
@@ -80,8 +77,9 @@ export class ModusWcSlider {
       console.warn(
         'ModusWcSlider: aria-label is required for accessibility. Using fallback label.'
       );
+      this.el.ariaLabel = 'Slider';
     }
-    this.el.ariaLabel = 'Slider';
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -112,10 +110,7 @@ export class ModusWcSlider {
     return (
       <Host>
         <input
-          aria-describedby={this.ariaDescribedby}
           aria-disabled={this.disabled}
-          aria-label={this.el.ariaLabel}
-          aria-labelledby={this.ariaLabelledby}
           class={this.getClasses()}
           dir={this.inputDir}
           disabled={this.disabled}
@@ -131,6 +126,7 @@ export class ModusWcSlider {
           tabIndex={this.inputTabIndex}
           type="range"
           value={this.value}
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-slider/modus-wc-slider.tsx
+++ b/src/components/atoms/modus-wc-slider/modus-wc-slider.tsx
@@ -79,6 +79,7 @@ export class ModusWcSlider {
       );
       this.el.ariaLabel = 'Slider';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
+++ b/src/components/atoms/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-text-input should render with custom props 1`] = `
-<modus-wc-text-input aria-describedby="description" aria-label="Test text input" auto-capitalize="words" auto-complete="on" auto-focus="true" custom-class="test-class" disabled="true" input-aria-invalid="grammar" input-dir="rtl" input-id="test-id" input-mode="numeric" input-spellcheck="true" input-tab-index="1" max-length="50" min-length="5" name="test-name" pattern="[A-Za-z]{3}" placeholder="Test placeholder" readonly="true" required="true" size="lg" type="email" value="test@example.com">
-  <input aria-describedby="description" aria-invalid="grammar" aria-label="Test placeholder" aria-placeholder="Test placeholder" aria-required="" autocapitalize="words" autocomplete="on" class="modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="test-id" inputmode="numeric" maxlength="50" minlength="5" name="test-name" pattern="[A-Za-z]{3}" placeholder="Test placeholder" required="" spellcheck="" tabindex="1" type="email" value="test@example.com">
+<modus-wc-text-input auto-capitalize="words" auto-complete="on" auto-focus="true" custom-class="test-class" disabled="true" input-aria-invalid="grammar" input-dir="rtl" input-id="test-id" input-mode="numeric" input-spellcheck="true" input-tab-index="1" max-length="50" min-length="5" name="test-name" pattern="[A-Za-z]{3}" placeholder="Test placeholder" readonly="true" required="true" size="lg" type="email" value="test@example.com">
+  <input aria-describedby="description" aria-label="Test text input" aria-placeholder="Test placeholder" aria-required="" autocapitalize="words" autocomplete="on" class="modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="test-id" inputmode="numeric" maxlength="50" minlength="5" name="test-name" pattern="[A-Za-z]{3}" placeholder="Test placeholder" required="" spellcheck="" tabindex="1" type="email" value="test@example.com">
 </modus-wc-text-input>
 `;
 
 exports[`modus-wc-text-input should render with default props 1`] = `
-<modus-wc-text-input aria-label="Default input" value="">
-  <input aria-label="Text input" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
+<modus-wc-text-input value="">
+  <input aria-label="Default input" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
 </modus-wc-text-input>
 `;

--- a/src/components/atoms/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/atoms/modus-wc-text-input/modus-wc-text-input.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-text-input.tailwind';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable input component used to create text inputs with types.
@@ -21,11 +22,10 @@ import { ModusSize } from '../../types';
   shadow: false,
 })
 export class ModusWcTextInput {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the input. */
-  @Prop() ariaDescribedby?: string;
 
   /** Controls automatic capitalization in inputted text. */
   @Prop() autoCapitalize?:
@@ -47,9 +47,6 @@ export class ModusWcTextInput {
 
   /** Whether the form control is disabled. */
   @Prop() disabled?: boolean = false;
-
-  /** Indicates whether the input has an invalid input. */
-  @Prop() inputAriaInvalid?: 'grammar' | 'spelling' | 'true' | 'false';
 
   /** Specifies the text direction of the input content. */
   @Prop() inputDir?: '' | 'ltr' | 'rtl' | 'auto';
@@ -127,6 +124,7 @@ export class ModusWcTextInput {
       );
       this.el.ariaLabel = this.placeholder || 'Text input';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -159,9 +157,6 @@ export class ModusWcTextInput {
     return (
       <Host>
         <input
-          aria-describedby={this.ariaDescribedby}
-          aria-invalid={this.inputAriaInvalid}
-          aria-label={this.el.ariaLabel}
           aria-placeholder={this.placeholder}
           aria-required={this.required}
           autocapitalize={this.autoCapitalize}
@@ -185,6 +180,7 @@ export class ModusWcTextInput {
           tabIndex={this.inputTabIndex}
           type={this.type}
           value={this.value}
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/atoms/modus-wc-text-input/modus-wc-text-input.tsx
@@ -124,6 +124,7 @@ export class ModusWcTextInput {
       );
       this.el.ariaLabel = this.placeholder || 'Text input';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-textarea/__snapshots__/modus-wc-textarea.spec.ts.snap
+++ b/src/components/atoms/modus-wc-textarea/__snapshots__/modus-wc-textarea.spec.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-textarea renders with default props 1`] = `
-<modus-wc-textarea aria-label="Default textarea" value=""><textarea aria-label="Text area" aria-placeholder="" class="modus-wc-textarea modus-wc-textarea-bordered modus-wc-textarea-md modus-wc-w-full" placeholder="" value=""></textarea>
+<modus-wc-textarea value=""><textarea aria-label="Default textarea" aria-placeholder="" class="modus-wc-textarea modus-wc-textarea-bordered modus-wc-textarea-md modus-wc-w-full" placeholder="" value=""></textarea>
 </modus-wc-textarea>
 `;
 
 exports[`modus-wc-textarea should render with custom props 1`] = `
-<modus-wc-textarea aria-describedby="description" aria-label="Test textarea" bordered="false" custom-class="test-class" disabled="true" input-aria-invalid="grammar" input-dir="rtl" input-id="custom-id" input-spellcheck="true" input-tab-index="1" max-length="100" name="test-name" placeholder="Test placeholder" readonly="true" required="true" rows="5" size="lg" value="Test value"><textarea aria-describedby="description" aria-invalid="grammar" aria-label="Test placeholder" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-textarea modus-wc-textarea-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="custom-id" maxlength="100" name="test-name" placeholder="Test placeholder" readonly="" required="" rows="5" spellcheck="" tabindex="1" value="Test value"></textarea>
+<modus-wc-textarea bordered="false" custom-class="test-class" disabled="true" input-aria-invalid="grammar" input-dir="rtl" input-id="custom-id" input-spellcheck="true" input-tab-index="1" max-length="100" name="test-name" placeholder="Test placeholder" readonly="true" required="true" rows="5" size="lg" value="Test value"><textarea aria-describedby="description" aria-label="Test textarea" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-textarea modus-wc-textarea-lg modus-wc-w-full test-class" dir="rtl" disabled="" id="custom-id" maxlength="100" name="test-name" placeholder="Test placeholder" readonly="" required="" rows="5" spellcheck="" tabindex="1" value="Test value"></textarea>
 </modus-wc-textarea>
 `;

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-textarea.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable textarea component.
@@ -21,11 +22,10 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcTextarea {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the textarea. */
-  @Prop() ariaDescribedby?: string;
 
   /** Indicates that the input should have a border. */
   @Prop() bordered?: boolean = true;
@@ -35,9 +35,6 @@ export class ModusWcTextarea {
 
   /** The disabled state of the textarea. */
   @Prop() disabled?: boolean = false;
-
-  /** Indicates whether the input is invalid. */
-  @Prop() inputAriaInvalid?: 'grammar' | 'spelling' | 'true' | 'false';
 
   /** Specifies the text direction of the input content. */
   @Prop() inputDir?: '' | 'ltr' | 'rtl' | 'auto';
@@ -94,6 +91,7 @@ export class ModusWcTextarea {
       );
       this.el.ariaLabel = this.placeholder || 'Text area';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -126,9 +124,6 @@ export class ModusWcTextarea {
     return (
       <Host>
         <textarea
-          aria-describedby={this.ariaDescribedby}
-          aria-invalid={this.inputAriaInvalid}
-          aria-label={this.el.ariaLabel}
           aria-placeholder={this.placeholder}
           aria-required={this.required}
           class={this.getClasses()}
@@ -147,6 +142,7 @@ export class ModusWcTextarea {
           spellcheck={this.inputSpellcheck}
           tabIndex={this.inputTabIndex}
           value={this.value}
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
+++ b/src/components/atoms/modus-wc-textarea/modus-wc-textarea.tsx
@@ -91,6 +91,7 @@ export class ModusWcTextarea {
       );
       this.el.ariaLabel = this.placeholder || 'Text area';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
+++ b/src/components/atoms/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-time-input should render with custom props 1`] = `
-<modus-wc-time-input aria-describedby="desc" aria-label="Time input" auto-complete="on" bordered="" custom-class="custom" datalist-id="time-options" disabled="" input-dir="ltr" input-id="time-input" input-tab-index="1" max="23:59" min="00:00" name="time" read-only="" required="" show-seconds="" size="lg" step="30" value="12:00">
+<modus-wc-time-input auto-complete="on" bordered="" custom-class="custom" datalist-id="time-options" disabled="" input-dir="ltr" input-id="time-input" input-tab-index="1" max="23:59" min="00:00" name="time" read-only="" required="" show-seconds="" size="lg" step="30" value="12:00">
   <input aria-describedby="desc" aria-label="Time input" aria-required="" autocomplete="on" class="custom modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-w-full" dir="ltr" disabled="" id="time-input" list="time-options" max="23:59" min="00:00" name="time" readonly="" required="" step="1" tabindex="1" type="time" value="12:00">
 </modus-wc-time-input>
 `;
 
 exports[`modus-wc-time-input should render with default props 1`] = `
-<modus-wc-time-input aria-label="Default input" datalist-id="test-list" value="">
-  <input aria-label="Time input" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" list="test-list" step="60" type="time" value="">
+<modus-wc-time-input datalist-id="test-list" value="">
+  <input aria-label="Default input" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" list="test-list" step="60" type="time" value="">
 </modus-wc-time-input>
 `;

--- a/src/components/atoms/modus-wc-time-input/modus-wc-time-input.tsx
+++ b/src/components/atoms/modus-wc-time-input/modus-wc-time-input.tsx
@@ -120,6 +120,7 @@ export class ModusWcTimeInput {
     if (!this.datalistId) {
       this.datalistId = this.internalDatalistId;
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/atoms/modus-wc-time-input/modus-wc-time-input.tsx
+++ b/src/components/atoms/modus-wc-time-input/modus-wc-time-input.tsx
@@ -10,6 +10,7 @@ import {
 import { convertPropsToClasses } from './modus-wc-time-input.tailwind';
 import { ModusSize } from '../../types';
 import { generateRandomId } from '../../utils';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable input component used to create time inputs.
@@ -22,11 +23,10 @@ import { generateRandomId } from '../../utils';
   shadow: false,
 })
 export class ModusWcTimeInput {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the input. */
-  @Prop() ariaDescribedby?: string;
 
   /** Hint for form autofill feature. */
   @Prop() autoComplete?: 'on' | 'off';
@@ -120,6 +120,7 @@ export class ModusWcTimeInput {
     if (!this.datalistId) {
       this.datalistId = this.internalDatalistId;
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -181,8 +182,6 @@ export class ModusWcTimeInput {
     return (
       <Host>
         <input
-          aria-describedby={this.ariaDescribedby}
-          aria-label={this.el.ariaLabel}
           aria-required={this.required}
           autocomplete={this.autoComplete}
           class={this.getClasses()}
@@ -202,6 +201,7 @@ export class ModusWcTimeInput {
           tabIndex={this.inputTabIndex}
           type="time"
           value={this.value}
+          {...this.inheritedAttributes}
         />
         {this.renderDatalist()}
       </Host>

--- a/src/components/atoms/modus-wc-toast/modus-wc-toast.tsx
+++ b/src/components/atoms/modus-wc-toast/modus-wc-toast.tsx
@@ -1,5 +1,6 @@
-import { Component, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-toast.tailwind';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export type ToastPosition =
   | 'top-start'
@@ -25,11 +26,20 @@ export type ToastPosition =
   shadow: false,
 })
 export class ModusWcToast {
+  private inheritedAttributes: Attributes = {};
+
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
   /** Additional classes for custom styling. */
   @Prop() customClass?: string = '';
 
   /** The position of the toast in the parent container. */
   @Prop() position?: ToastPosition = 'top-end';
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
 
   private getClasses = (): string => {
     const classList = ['modus-wc-toast'];
@@ -47,7 +57,7 @@ export class ModusWcToast {
   render() {
     return (
       <Host>
-        <div class={this.getClasses()}>
+        <div class={this.getClasses()} {...this.inheritedAttributes}>
           <slot />
         </div>
       </Host>

--- a/src/components/atoms/modus-wc-toggle/__snapshots__/modus-wc-toggle.spec.ts.snap
+++ b/src/components/atoms/modus-wc-toggle/__snapshots__/modus-wc-toggle.spec.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-toggle renders with default props 1`] = `
-<modus-wc-toggle aria-label="Default toggle">
-  <input aria-label="Toggle button" class="modus-wc-toggle modus-wc-toggle-md" type="checkbox">
+<modus-wc-toggle>
+  <input aria-label="Default toggle" class="modus-wc-toggle modus-wc-toggle-md" type="checkbox">
 </modus-wc-toggle>
 `;
 
 exports[`modus-wc-toggle should render indeterminate state 1`] = `
-<modus-wc-toggle aria-label="Test toggle" indeterminate="">
-  <input aria-checked="mixed" aria-label="Toggle button" class="modus-wc-toggle modus-wc-toggle-md" type="checkbox">
+<modus-wc-toggle indeterminate="">
+  <input aria-checked="mixed" aria-label="Test toggle" class="modus-wc-toggle modus-wc-toggle-md" type="checkbox">
 </modus-wc-toggle>
 `;
 
 exports[`modus-wc-toggle should render with custom props 1`] = `
-<modus-wc-toggle aria-describedby="active" aria-label="Test toggle" aria-labelledby="toggle-label" custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" name="test-name" required="true" size="lg" value="">
-  <input aria-checked="" aria-describedby="active" aria-disabled="" aria-label="Toggle button" aria-labelledby="toggle-label" checked="" class="modus-wc-toggle modus-wc-toggle-lg test-class" dir="rtl" disabled="" id="custom-id" required="" tabindex="1" type="checkbox">
+<modus-wc-toggle custom-class="test-class" disabled="true" input-dir="rtl" input-id="custom-id" input-tab-index="1" name="test-name" required="true" size="lg" value="">
+  <input aria-checked="" aria-describedby="active" aria-disabled="" aria-label="Test toggle" aria-labelledby="toggle-label" checked="" class="modus-wc-toggle modus-wc-toggle-lg test-class" dir="rtl" disabled="" id="custom-id" required="" tabindex="1" type="checkbox">
 </modus-wc-toggle>
 `;

--- a/src/components/atoms/modus-wc-toggle/modus-wc-toggle.tsx
+++ b/src/components/atoms/modus-wc-toggle/modus-wc-toggle.tsx
@@ -9,6 +9,7 @@ import {
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-toggle.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable checkbox component.
@@ -21,14 +22,10 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcToggle {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
-
-  /** The ID of the element that describes the toggle. */
-  @Prop() ariaDescribedby?: string;
-
-  /** The aria-labelledby attribute for usage with a label. */
-  @Prop() ariaLabelledby?: string;
 
   /** Custom CSS class to apply to the inner div. */
   @Prop() customClass?: string = '';
@@ -86,6 +83,7 @@ export class ModusWcToggle {
       );
     }
     this.el.ariaLabel = 'Toggle button';
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -117,10 +115,7 @@ export class ModusWcToggle {
       <Host>
         <input
           aria-checked={this.indeterminate ? 'mixed' : this.value}
-          aria-describedby={this.ariaDescribedby}
           aria-disabled={this.disabled}
-          aria-label={this.el.ariaLabel}
-          aria-labelledby={this.ariaLabelledby}
           checked={this.value}
           class={this.getClasses()}
           dir={this.inputDir}
@@ -132,6 +127,7 @@ export class ModusWcToggle {
           required={this.required}
           tabIndex={this.inputTabIndex}
           type="checkbox"
+          {...this.inheritedAttributes}
         />
       </Host>
     );

--- a/src/components/atoms/modus-wc-tooltip/modus-wc-tooltip.tsx
+++ b/src/components/atoms/modus-wc-tooltip/modus-wc-tooltip.tsx
@@ -1,5 +1,6 @@
-import { Component, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-tooltip.tailwind';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable tooltip component used to create tooltips with different content.
@@ -12,6 +13,11 @@ import { convertPropsToClasses } from './modus-wc-tooltip.tailwind';
   shadow: false,
 })
 export class ModusWcTooltip {
+  private inheritedAttributes: Attributes = {};
+
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
   /** The text content of the tooltip. */
   @Prop() content: string = '';
 
@@ -26,6 +32,10 @@ export class ModusWcTooltip {
 
   /** The position that the tooltip will render in relation to the element. */
   @Prop() position?: 'auto' | 'top' | 'right' | 'bottom' | 'left' = 'auto';
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
 
   private getClasses(): string {
     const classList: string[] = ['modus-wc-tooltip'];
@@ -50,6 +60,7 @@ export class ModusWcTooltip {
           data-tip={this.content}
           id={this.tooltipId}
           role="tooltip"
+          {...this.inheritedAttributes}
         >
           <slot />
         </div>

--- a/src/components/atoms/modus-wc-typography/modus-wc-typography.tsx
+++ b/src/components/atoms/modus-wc-typography/modus-wc-typography.tsx
@@ -1,6 +1,7 @@
-import { Component, h, Host, Prop } from '@stencil/core';
+import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-typography.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export type TypographyVariant =
   | 'body'
@@ -25,6 +26,11 @@ export type TypographyWeight = 'light' | 'normal' | 'bold';
   shadow: false,
 })
 export class ModusWCTypography {
+  private inheritedAttributes: Attributes = {};
+
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
   /** Custom CSS class to apply to the typography element. */
   @Prop() customClass?: string = '';
 
@@ -36,6 +42,10 @@ export class ModusWCTypography {
 
   /** The weight of the text. */
   @Prop() weight?: TypographyWeight = 'normal';
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
 
   private getClasses(): string {
     const classList = ['modus-wc-typography'];
@@ -58,7 +68,7 @@ export class ModusWCTypography {
 
     return (
       <Host>
-        <Element class={this.getClasses()}>
+        <Element class={this.getClasses()} {...this.inheritedAttributes}>
           <slot></slot>
         </Element>
       </Host>

--- a/src/components/molecules/modus-wc-accordion/__snapshots__/modus-wc-accordion.spec.ts.snap
+++ b/src/components/molecules/modus-wc-accordion/__snapshots__/modus-wc-accordion.spec.ts.snap
@@ -22,6 +22,10 @@ exports[`modus-wc-accordion should render with custom props 1`] = `
 exports[`modus-wc-accordion should render with default props 1`] = `
 <modus-wc-accordion>
   <!---->
-  <div></div>
+  <div>
+    <modus-wc-collapse bordered="" collapse-description="Sports played by a team." collapse-title="Team Sports" custom-class="test-class" expanded="" icon="people_group" iconarialabel="Team icon" size="md"></modus-wc-collapse>
+    <modus-wc-collapse bordered="" collapse-description="Sports played by individuals." collapse-title="Individual Sports" custom-class="test-class" icon="person" iconarialabel="Person icon" size="md"></modus-wc-collapse>
+    <modus-wc-collapse bordered="" collapse-description="Sports played in water." collapse-title="Water Sports" custom-class="test-class" icon="fog" iconarialabel="Water icon" size="md"></modus-wc-collapse>
+  </div>
 </modus-wc-accordion>
 `;

--- a/src/components/molecules/modus-wc-accordion/modus-wc-accordion.spec.ts
+++ b/src/components/molecules/modus-wc-accordion/modus-wc-accordion.spec.ts
@@ -34,6 +34,12 @@ describe('modus-wc-accordion', () => {
       components: [ModusWcAccordion],
       html: '<modus-wc-accordion />',
     });
+
+    const component = page.rootInstance as ModusWcAccordion;
+    component.items = items;
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 

--- a/src/components/molecules/modus-wc-accordion/modus-wc-accordion.tsx
+++ b/src/components/molecules/modus-wc-accordion/modus-wc-accordion.tsx
@@ -57,6 +57,7 @@ export class ModusWcAccordion {
     if (!this.items || this.items.length === 0) {
       console.error('ModusWcAccordion: accordion items data is required.');
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/molecules/modus-wc-accordion/modus-wc-accordion.tsx
+++ b/src/components/molecules/modus-wc-accordion/modus-wc-accordion.tsx
@@ -8,6 +8,7 @@ import {
   Event as StencilEvent,
 } from '@stencil/core';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface IModusWcAccordionItem {
   customClass?: string;
@@ -29,6 +30,8 @@ export interface IModusWcAccordionItem {
   shadow: false,
 })
 export class ModusWcAccordion {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -54,6 +57,7 @@ export class ModusWcAccordion {
     if (!this.items || this.items.length === 0) {
       console.error('ModusWcAccordion: accordion items data is required.');
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -75,7 +79,7 @@ export class ModusWcAccordion {
   render() {
     return (
       <Host>
-        <div class={this.getClasses()}>
+        <div class={this.getClasses()} {...this.inheritedAttributes}>
           {this.items.map((item, index) => (
             <modus-wc-collapse
               bordered={this.bordered}

--- a/src/components/molecules/modus-wc-alert/modus-wc-alert.tsx
+++ b/src/components/molecules/modus-wc-alert/modus-wc-alert.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-alert.tailwind';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable alert component used to inform the user about important events.
@@ -12,6 +13,8 @@ import { convertPropsToClasses } from './modus-wc-alert.tailwind';
   shadow: false,
 })
 export class ModusWcAlert {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -29,6 +32,10 @@ export class ModusWcAlert {
 
   /** The variant of the alert. */
   @Prop() variant?: 'error' | 'info' | 'success' | 'warning';
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
 
   private getClasses(): string {
     const classList = ['modus-wc-alert'];
@@ -63,7 +70,11 @@ export class ModusWcAlert {
   render() {
     return (
       <Host>
-        <div class={this.getClasses()} role="alert">
+        <div
+          class={this.getClasses()}
+          role="alert"
+          {...this.inheritedAttributes}
+        >
           <modus-wc-icon name={this.getIconName()} />
           <div>
             <modus-wc-typography variant="h3" weight="bold">

--- a/src/components/molecules/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
+++ b/src/components/molecules/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-autocomplete should render with custom props 1`] = `
-<modus-wc-autocomplete .items="[{&quot;label&quot;:&quot;Item" 1","value":"1"},{"label":"item="" 2","value":"2"},{"label":"item="" 3","value":"3"}]="" active-item-value="1" aria-describedby="description" aria-label="Test autocomplete" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" dir="rtl" disabled="true" input-dir="rtl" input-id="test-id" input-tab-index="1" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1">
-  <modus-wc-text-input aria-label="Autocomplete input" value="Item 1">
-    <input aria-describedby="description" aria-label="Test placeholder" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-input modus-wc-input-lg modus-wc-w-full" disabled="" id="test-id" inputmode="text" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="text" value="Item 1">
+<modus-wc-autocomplete .items="[{&quot;label&quot;:&quot;Item" 1","value":"1"},{"label":"item="" 2","value":"2"},{"label":"item="" 3","value":"3"}]="" active-item-value="1" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" dir="rtl" disabled="true" input-dir="rtl" input-id="test-id" input-tab-index="1" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1">
+  <modus-wc-text-input value="Item 1">
+    <input aria-describedby="description" aria-label="Test autocomplete" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-input modus-wc-input-lg modus-wc-w-full" disabled="" id="test-id" inputmode="text" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="text" value="Item 1">
   </modus-wc-text-input>
 </modus-wc-autocomplete>
 `;
 
 exports[`modus-wc-autocomplete should render with default props 1`] = `
-<modus-wc-autocomplete aria-label="Default autocomplete" class="modus-wc-autocomplete" value="">
-  <modus-wc-text-input aria-label="Autocomplete input" value="">
-    <input aria-label="Text input" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
+<modus-wc-autocomplete class="modus-wc-autocomplete" value="">
+  <modus-wc-text-input value="">
+    <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
   </modus-wc-text-input>
 </modus-wc-autocomplete>
 `;

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -10,6 +10,7 @@ import {
 } from '@stencil/core';
 import { IMenuItem } from '../../atoms/modus-wc-menu/modus-wc-menu';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable autocomplete component used to create searchable text inputs.
@@ -23,6 +24,7 @@ import { ModusSize } from '../../types';
 })
 export class ModusWcAutocomplete {
   private debounceTimer?: number;
+  private inheritedAttributes: Attributes = {};
 
   /** Reference to the host element */
   @Element() el!: HTMLElement;
@@ -31,9 +33,6 @@ export class ModusWcAutocomplete {
 
   /** The active menu item value, used to show an item as selected. */
   @Prop() activeItemValue?: string;
-
-  /** The ID of the element that describes the input. */
-  @Prop() ariaDescribedby?: string;
 
   /** Indicates that the autocomplete should have a border. */
   @Prop() bordered?: boolean = true;
@@ -106,6 +105,13 @@ export class ModusWcAutocomplete {
     }
   }
 
+  componentWillLoad() {
+    if (!this.el.ariaLabel) {
+      this.el.ariaLabel = 'Autocomplete input';
+    }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
+
   private getClasses(): string {
     const classList: string[] = ['modus-wc-autocomplete'];
 
@@ -167,14 +173,8 @@ export class ModusWcAutocomplete {
 
   render() {
     return (
-      <Host
-        aria-label={this.el.ariaLabel}
-        class={this.getClasses()}
-        dir={this.inputDir}
-      >
+      <Host class={this.getClasses()} dir={this.inputDir}>
         <modus-wc-text-input
-          ariaDescribedby={this.ariaDescribedby}
-          aria-label="Autocomplete input"
           bordered={this.bordered}
           disabled={this.disabled}
           inputId={this.inputId}
@@ -188,6 +188,7 @@ export class ModusWcAutocomplete {
           required={this.required}
           size={this.size}
           value={this.value}
+          {...this.inheritedAttributes}
         />
         {this.menuVisible && (
           <modus-wc-menu

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -109,6 +109,7 @@ export class ModusWcAutocomplete {
     if (!this.el.ariaLabel) {
       this.el.ariaLabel = 'Autocomplete input';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/molecules/modus-wc-breadcrumbs/__snapshots__/modus-wc-breadcrumbs.spec.ts.snap
+++ b/src/components/molecules/modus-wc-breadcrumbs/__snapshots__/modus-wc-breadcrumbs.spec.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-breadcrumbs should render with custom props 1`] = `
-<modus-wc-breadcrumbs aria-label="Default breadcrumbs" custom-class="test-class" size="lg">
-  <nav aria-label="Breadcrumbs" class="modus-wc-breadcrumbs modus-wc-text-lg test-class">
+<modus-wc-breadcrumbs custom-class="test-class" size="lg">
+  <nav aria-label="Default breadcrumbs" class="modus-wc-breadcrumbs modus-wc-text-lg test-class">
     <ol>
       <li>
         <a href="#">
@@ -25,9 +25,25 @@ exports[`modus-wc-breadcrumbs should render with custom props 1`] = `
 `;
 
 exports[`modus-wc-breadcrumbs should render with default props 1`] = `
-<modus-wc-breadcrumbs aria-label="Default breadcrumbs">
-  <nav aria-label="Breadcrumbs" class="modus-wc-breadcrumbs modus-wc-text-md">
-    <ol></ol>
+<modus-wc-breadcrumbs>
+  <nav aria-label="Default breadcrumbs" class="modus-wc-breadcrumbs modus-wc-text-md">
+    <ol>
+      <li>
+        <a href="#">
+          Root
+        </a>
+      </li>
+      <li>
+        <a href="#">
+          Subpage
+        </a>
+      </li>
+      <li aria-current="page">
+        <span>
+          Current Page
+        </span>
+      </li>
+    </ol>
   </nav>
 </modus-wc-breadcrumbs>
 `;

--- a/src/components/molecules/modus-wc-breadcrumbs/modus-wc-breadcrumbs.spec.ts
+++ b/src/components/molecules/modus-wc-breadcrumbs/modus-wc-breadcrumbs.spec.ts
@@ -20,10 +20,15 @@ describe('modus-wc-breadcrumbs', () => {
   it('should warn when aria-label is not provided', async () => {
     const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-    await newSpecPage({
+    const page = await newSpecPage({
       components: [ModusWcBreadcrumbs],
       html: '<modus-wc-breadcrumbs></modus-wc-breadcrumbs>',
     });
+
+    const component = page.rootInstance as ModusWcBreadcrumbs;
+    component.items = items;
+
+    await page.waitForChanges();
 
     expect(consoleWarnSpy).toHaveBeenCalledWith(
       'ModusWcBreadcrumbs: aria-label is required for accessibility. Using fallback label.'
@@ -37,6 +42,12 @@ describe('modus-wc-breadcrumbs', () => {
       components: [ModusWcBreadcrumbs],
       html: '<modus-wc-breadcrumbs aria-label="Default breadcrumbs"></modus-wc-breadcrumbs>',
     });
+
+    const component = page.rootInstance as ModusWcBreadcrumbs;
+    component.items = items;
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 

--- a/src/components/molecules/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
+++ b/src/components/molecules/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-breadcrumbs.tailwind';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface IModusWcBreadcrumb {
   /** The text to render in the breadcrumb. */
@@ -21,6 +22,8 @@ export interface IModusWcBreadcrumb {
   shadow: false,
 })
 export class ModusWcBreadcrumbs {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -44,6 +47,7 @@ export class ModusWcBreadcrumbs {
     if (!this.items || this.items.length === 0) {
       console.error('ModusWcBreadcrumbs: breadcrumb items data is required.');
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -63,7 +67,7 @@ export class ModusWcBreadcrumbs {
   render() {
     return (
       <Host>
-        <nav aria-label={this.el.ariaLabel} class={this.getClasses()}>
+        <nav class={this.getClasses()} {...this.inheritedAttributes}>
           <ol>
             {this.items.map((item, index) => {
               const isCurrentPage = index === this.items.length - 1;

--- a/src/components/molecules/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
+++ b/src/components/molecules/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
@@ -47,6 +47,7 @@ export class ModusWcBreadcrumbs {
     if (!this.items || this.items.length === 0) {
       console.error('ModusWcBreadcrumbs: breadcrumb items data is required.');
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/molecules/modus-wc-collapse/__snapshots__/modus-wc-collapse.spec.ts.snap
+++ b/src/components/molecules/modus-wc-collapse/__snapshots__/modus-wc-collapse.spec.ts.snap
@@ -46,7 +46,7 @@ exports[`modus-wc-collapse should render with custom props 1`] = `
     <div class="modus-wc-collapse-title modus-wc-inline-flex modus-wc-items-center modus-wc-justify-between modus-wc-min-h-4 modus-wc-pb-3 modus-wc-pl-3 modus-wc-pt-3" id="test-title-title">
       <div class="modus-wc-font-medium modus-wc-inline-flex modus-wc-items-center modus-wc-text-lg">
         <modus-wc-icon class="modus-wc-flex modus-wc-items-center">
-          <i aria-hidden="true" class="modus-icons modus-wc-icon--sm" tabindex="-1">
+          <i aria-hidden="true" aria-label="Alert icon" class="modus-icons modus-wc-icon--sm" tabindex="-1">
             alert
           </i>
         </modus-wc-icon>

--- a/src/components/molecules/modus-wc-collapse/modus-wc-collapse.tsx
+++ b/src/components/molecules/modus-wc-collapse/modus-wc-collapse.tsx
@@ -15,6 +15,7 @@ import {
   convertPropsToTitleDivClasses,
 } from './modus-wc-collapse.tailwind';
 import { DaisySize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A customizable collapse component used for showing and hiding content.
@@ -29,6 +30,8 @@ import { DaisySize } from '../../types';
   shadow: false,
 })
 export class ModusWcCollapse {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -90,6 +93,10 @@ export class ModusWcCollapse {
       this.handleClick();
     }
   };
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
 
   private getOuterDivClasses(): string {
     const classList: string[] = ['modus-wc-collapse modus-wc-collapse-arrow'];
@@ -153,7 +160,7 @@ export class ModusWcCollapse {
 
     return (
       <Host>
-        <div class={this.getOuterDivClasses()}>
+        <div class={this.getOuterDivClasses()} {...this.inheritedAttributes}>
           <input
             aria-controls={contentId}
             aria-expanded={this.expanded}
@@ -168,6 +175,7 @@ export class ModusWcCollapse {
             <div class={this.getTitleChildDivClasses()}>
               {this.icon && (
                 <modus-wc-icon
+                  aria-label={this.iconAriaLabel}
                   decorative={true}
                   name={this.icon}
                   size={this.size}

--- a/src/components/molecules/modus-wc-tabs/__snapshots__/modus-wc-tabs.spec.ts.snap
+++ b/src/components/molecules/modus-wc-tabs/__snapshots__/modus-wc-tabs.spec.ts.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-tabs should render with custom props 1`] = `
-<modus-wc-tabs aria-label="Custom Tab Group" custom-class="test-class" size="sm" tab-style="boxed">
+<modus-wc-tabs custom-class="test-class" size="sm" tab-style="boxed">
   <!---->
-  <div aria-label="Tab Group" class="modus-wc-tabs modus-wc-tabs-boxed modus-wc-tabs-sm test-class" role="tablist">
+  <div aria-label="Custom Tab Group" class="modus-wc-tabs modus-wc-tabs-boxed modus-wc-tabs-sm test-class" role="tablist">
     <button aria-label="Tab 1 tab" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
       <span>
         Tab 1
@@ -47,7 +47,7 @@ exports[`modus-wc-tabs should render with custom props 1`] = `
 `;
 
 exports[`modus-wc-tabs should render with default props (empty tabs) 1`] = `
-<modus-wc-tabs aria-label="Tab Group">
+<modus-wc-tabs>
   <!---->
   <div aria-label="Tab Group" class="modus-wc-tabs modus-wc-tabs-bordered modus-wc-tabs-md" role="tablist"></div>
   <div class="modus-wc-tab-panel" role="tabpanel" tabindex="0"></div>
@@ -55,7 +55,7 @@ exports[`modus-wc-tabs should render with default props (empty tabs) 1`] = `
 `;
 
 exports[`modus-wc-tabs should render with default props (with tab data) 1`] = `
-<modus-wc-tabs aria-label="Tab Group">
+<modus-wc-tabs>
   <!---->
   <div aria-label="Tab Group" class="modus-wc-tabs modus-wc-tabs-bordered modus-wc-tabs-md" role="tablist">
     <button aria-label="Tab 1 tab" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
@@ -101,7 +101,7 @@ exports[`modus-wc-tabs should render with default props (with tab data) 1`] = `
 `;
 
 exports[`modus-wc-tabs should render with default props (with tab panel) 1`] = `
-<modus-wc-tabs aria-label="Tab Group">
+<modus-wc-tabs>
   <!---->
   <div aria-label="Tab Group" class="modus-wc-tabs modus-wc-tabs-bordered modus-wc-tabs-md" role="tablist">
     <button aria-label="Tab 1 tab" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">

--- a/src/components/molecules/modus-wc-tabs/modus-wc-tabs.tsx
+++ b/src/components/molecules/modus-wc-tabs/modus-wc-tabs.tsx
@@ -13,6 +13,7 @@ import {
   convertPropsToClassesTab as convertPropsToTabClasses,
 } from './modus-wc-tabs.tailwind';
 import { ModusSize } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface IModusWcTab {
   /** Custom CSS class to apply to the inner button. */
@@ -42,6 +43,8 @@ export interface IModusWcTab {
   shadow: false,
 })
 export class ModusWcTabs {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -77,6 +80,7 @@ export class ModusWcTabs {
     if (!this.tabs || this.tabs.length === 0) {
       console.error('ModusWcTabs: tab data is required.');
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private handleClick(tab: IModusWcTab, index: number) {
@@ -149,8 +153,8 @@ export class ModusWcTabs {
       <Host>
         <div
           role="tablist"
-          aria-label={this.el.ariaLabel}
           class={this.getClasses()}
+          {...this.inheritedAttributes}
         >
           {tabs}
         </div>

--- a/src/components/molecules/modus-wc-tabs/modus-wc-tabs.tsx
+++ b/src/components/molecules/modus-wc-tabs/modus-wc-tabs.tsx
@@ -80,6 +80,7 @@ export class ModusWcTabs {
     if (!this.tabs || this.tabs.length === 0) {
       console.error('ModusWcTabs: tab data is required.');
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/molecules/modus-wc-theme-switcher/modus-wc-theme-switcher.tsx
+++ b/src/components/molecules/modus-wc-theme-switcher/modus-wc-theme-switcher.tsx
@@ -12,6 +12,7 @@ import {
 } from '@stencil/core';
 import { themeStore } from '../../../providers/theme/theme.store';
 import { IThemeConfig } from '../../../providers/theme/theme.types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 /**
  * A theme switcher component used to toggle the application theme and/or mode.
@@ -26,6 +27,8 @@ import { IThemeConfig } from '../../../providers/theme/theme.types';
   shadow: false,
 })
 export class ModusWcThemeSwitcher {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -45,6 +48,7 @@ export class ModusWcThemeSwitcher {
       );
       this.el.ariaLabel = 'Switch between light and dark theme';
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   connectedCallback() {
@@ -77,7 +81,7 @@ export class ModusWcThemeSwitcher {
 
   render() {
     return (
-      <label class={this.getClasses()} aria-label={this.el.ariaLabel}>
+      <label class={this.getClasses()} {...this.inheritedAttributes}>
         <input
           aria-checked={this.isDarkMode}
           checked={this.isDarkMode}

--- a/src/components/molecules/modus-wc-theme-switcher/modus-wc-theme-switcher.tsx
+++ b/src/components/molecules/modus-wc-theme-switcher/modus-wc-theme-switcher.tsx
@@ -48,6 +48,7 @@ export class ModusWcThemeSwitcher {
       );
       this.el.ariaLabel = 'Switch between light and dark theme';
     }
+
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/organisms/modus-wc-table/__snapshots__/modus-wc-table.spec.tsx.snap
+++ b/src/components/organisms/modus-wc-table/__snapshots__/modus-wc-table.spec.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-table renders with default props (empty table) 1`] = `
-<modus-wc-table aria-label="Default table">
-  <div class="modus-wc-overflow-x-auto">
+<modus-wc-table>
+  <div aria-label="Default table" class="modus-wc-overflow-x-auto">
     <table class="modus-wc-table">
       <thead>
         <tr></tr>
@@ -14,8 +14,8 @@ exports[`modus-wc-table renders with default props (empty table) 1`] = `
 `;
 
 exports[`modus-wc-table should render with custom props 1`] = `
-<modus-wc-table aria-label="Default table" custom-class="test-class" density="compact" zebra="true">
-  <div class="modus-wc-overflow-x-auto">
+<modus-wc-table custom-class="test-class" density="compact" zebra="true">
+  <div aria-label="Default table" class="modus-wc-overflow-x-auto">
     <table class="modus-wc-table modus-wc-table-xs modus-wc-table-zebra test-class">
       <thead>
         <tr>

--- a/src/components/organisms/modus-wc-table/modus-wc-table.tsx
+++ b/src/components/organisms/modus-wc-table/modus-wc-table.tsx
@@ -11,6 +11,7 @@ import {
 } from '@stencil/core';
 import { convertTablePropsToClasses } from './modus-wc-table.tailwind';
 import { Density } from '../../types';
+import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface ITableColumn {
   /** Key to access data from row object */
@@ -38,6 +39,8 @@ export interface ITableColumn {
   shadow: false,
 })
 export class ModusWcTable {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -77,6 +80,7 @@ export class ModusWcTable {
     if (!this.data) {
       console.error('ModusWcTable: data is required.');
     }
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getClasses(): string {
@@ -114,7 +118,7 @@ export class ModusWcTable {
   render() {
     return (
       <Host>
-        <div class="modus-wc-overflow-x-auto">
+        <div class="modus-wc-overflow-x-auto" {...this.inheritedAttributes}>
           <table class={this.getClasses()}>
             <thead>
               <tr>

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -8,3 +8,113 @@ export function generateRandomId(length: number = 8): string {
     .toString(36)
     .substring(2, 2 + length);
 }
+
+export type Attributes = { [key: string]: string };
+
+/**
+ * Elements inside of web components sometimes need to inherit global attributes
+ * set on the host. For example, the inner input in `ion-input` should inherit
+ * the `title` attribute that developers set directly on `ion-input`. This
+ * helper function should be called in componentWillLoad and assigned to a variable
+ * that is later used in the render function.
+ *
+ * This does not need to be reactive as changing attributes on the host element
+ * does not trigger a re-render.
+ */
+export const inheritAttributes = (
+  el: HTMLElement,
+  attributes: string[] = []
+) => {
+  const attributeObject: Attributes = {};
+
+  attributes.forEach((attr) => {
+    if (el.hasAttribute(attr)) {
+      const value = el.getAttribute(attr);
+      if (value !== null) {
+        attributeObject[attr] = value;
+      }
+      el.removeAttribute(attr);
+    }
+  });
+
+  return attributeObject;
+};
+
+/**
+ * List of available ARIA attributes + `role`.
+ * Removed deprecated attributes.
+ * https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes
+ */
+const ariaAttributes = [
+  'role',
+  'aria-activedescendant',
+  'aria-atomic',
+  'aria-autocomplete',
+  'aria-braillelabel',
+  'aria-brailleroledescription',
+  'aria-busy',
+  'aria-checked',
+  'aria-colcount',
+  'aria-colindex',
+  'aria-colindextext',
+  'aria-colspan',
+  'aria-controls',
+  'aria-current',
+  'aria-describedby',
+  'aria-description',
+  'aria-details',
+  'aria-disabled',
+  'aria-errormessage',
+  'aria-expanded',
+  'aria-flowto',
+  'aria-haspopup',
+  'aria-hidden',
+  'aria-invalid',
+  'aria-keyshortcuts',
+  'aria-label',
+  'aria-labelledby',
+  'aria-level',
+  'aria-live',
+  'aria-multiline',
+  'aria-multiselectable',
+  'aria-orientation',
+  'aria-owns',
+  'aria-placeholder',
+  'aria-posinset',
+  'aria-pressed',
+  'aria-readonly',
+  'aria-relevant',
+  'aria-required',
+  'aria-roledescription',
+  'aria-rowcount',
+  'aria-rowindex',
+  'aria-rowindextext',
+  'aria-rowspan',
+  'aria-selected',
+  'aria-setsize',
+  'aria-sort',
+  'aria-valuemax',
+  'aria-valuemin',
+  'aria-valuenow',
+  'aria-valuetext',
+];
+
+/**
+ * Returns an array of aria attributes that should be copied from
+ * the shadow host element to a target within the light DOM.
+ * @param el The element that the attributes should be copied from.
+ * @param ignoreList The list of aria-attributes to ignore reflecting and removing from the host.
+ * Use this in instances where we manually specify aria attributes on the `<Host>` element.
+ */
+export const inheritAriaAttributes = (
+  el: HTMLElement,
+  ignoreList?: string[]
+) => {
+  let attributesToInherit = ariaAttributes;
+  if (ignoreList && ignoreList.length > 0) {
+    attributesToInherit = attributesToInherit.filter(
+      (attr) => !ignoreList.includes(attr)
+    );
+  }
+  return inheritAttributes(el, attributesToInherit);
+};


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Essentially, instead of manually defining props on components for setting aria attributes, we automatically inherit set values down into the actual functional component. 
Props for further-inner aria values have not been changed, such as `<modus-wc-collapse>`'s `iconAriaLabel`.

This is a large mass-replace PR so it'll appear extremely big. The changes can be grouped as follows:
* Adding `@Element() el` where it was not present.
* Creating a private `inheritedAttributes` variable on every component, setting it **at the end** of `componentWillLoad()`, and spreading it into our inner elements.
* Removing old direct aria props.
* Adding the actual functional code, which is @ src/components/utils.ts, originally under MIT from [ionic-framework](https://github.com/ionic-team/ionic-framework/blob/295fa00527dc180480180a6c261373b90ef231fb/core/src/utils/helpers.ts#L92)

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other


### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

[AB#580403](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/580403)
