### PR TITLE
feat: add multi-select capability to the autocomplete component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -82,10 +82,6 @@ export namespace Components {
      */
     interface ModusWcAutocomplete {
         /**
-          * The active menu item value, used to show an item as selected.
-         */
-        "activeItemValue"?: string;
-        /**
           * Indicates that the autocomplete should have a border.
          */
         "bordered"?: boolean;
@@ -555,6 +551,10 @@ export namespace Components {
      * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcMenu {
+        /**
+          * Indicates that the menu should have a border.
+         */
+        "bordered"?: boolean;
         /**
           * Custom CSS class to apply to the ul element.
          */
@@ -1401,6 +1401,7 @@ declare global {
         new (): HTMLModusWcAlertElement;
     };
     interface HTMLModusWcAutocompleteElementEventMap {
+        "chipRemove": IAutocompleteItem;
         "inputBlur": FocusEvent;
         "inputChange": Event;
         "inputFocus": FocusEvent;
@@ -2037,10 +2038,6 @@ declare namespace LocalJSX {
      */
     interface ModusWcAutocomplete {
         /**
-          * The active menu item value, used to show an item as selected.
-         */
-        "activeItemValue"?: string;
-        /**
           * Indicates that the autocomplete should have a border.
          */
         "bordered"?: boolean;
@@ -2080,6 +2077,10 @@ declare namespace LocalJSX {
           * Name of the form control. Submitted with the form as part of a name/value pair.
          */
         "name"?: string;
+        /**
+          * Event emitted when a selected item chip is removed.
+         */
+        "onChipRemove"?: (event: ModusWcAutocompleteCustomEvent<IAutocompleteItem>) => void;
         /**
           * Event emitted when the input loses focus.
          */
@@ -2558,6 +2559,10 @@ declare namespace LocalJSX {
      * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcMenu {
+        /**
+          * Indicates that the menu should have a border.
+         */
+        "bordered"?: boolean;
         /**
           * Custom CSS class to apply to the ul element.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -110,13 +110,17 @@ export namespace Components {
          */
         "inputTabIndex"?: number;
         /**
-          * The items to display in the menu.
+          * The items to display in the menu. Creating a new array of items will ensure proper component re-render.
          */
         "items": IAutocompleteItem[];
         /**
           * The minimum number of characters required to render the menu.
          */
         "minChars": number;
+        /**
+          * Whether the input allows multiple items to be selected.
+         */
+        "multiSelect"?: boolean;
         /**
           * Name of the form control. Submitted with the form as part of a name/value pair.
          */
@@ -2066,13 +2070,17 @@ declare namespace LocalJSX {
          */
         "inputTabIndex"?: number;
         /**
-          * The items to display in the menu.
+          * The items to display in the menu. Creating a new array of items will ensure proper component re-render.
          */
         "items"?: IAutocompleteItem[];
         /**
           * The minimum number of characters required to render the menu.
          */
         "minChars"?: number;
+        /**
+          * Whether the input allows multiple items to be selected.
+         */
+        "multiSelect"?: boolean;
         /**
           * Name of the form control. Submitted with the form as part of a name/value pair.
          */

--- a/src/components/atoms/modus-wc-button/readme.md
+++ b/src/components/atoms/modus-wc-button/readme.md
@@ -32,6 +32,19 @@ Adheres to WCAG 2.2 standards.
 | `buttonClick` | Event emitted when the button is clicked or activated via keyboard. | `CustomEvent<KeyboardEvent \| MouseEvent>` |
 
 
+## Dependencies
+
+### Used by
+
+ - [modus-wc-autocomplete](../../molecules/modus-wc-autocomplete)
+
+### Graph
+```mermaid
+graph TD;
+  modus-wc-autocomplete --> modus-wc-button
+  style modus-wc-button fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/atoms/modus-wc-icon/readme.md
+++ b/src/components/atoms/modus-wc-icon/readme.md
@@ -28,6 +28,7 @@ Adheres to WCAG 2.2 standards.
 ### Used by
 
  - [modus-wc-alert](../../molecules/modus-wc-alert)
+ - [modus-wc-autocomplete](../../molecules/modus-wc-autocomplete)
  - [modus-wc-collapse](../../molecules/modus-wc-collapse)
  - [modus-wc-menu-item](../modus-wc-menu-item)
  - [modus-wc-tabs](../../molecules/modus-wc-tabs)
@@ -36,6 +37,7 @@ Adheres to WCAG 2.2 standards.
 ```mermaid
 graph TD;
   modus-wc-alert --> modus-wc-icon
+  modus-wc-autocomplete --> modus-wc-icon
   modus-wc-collapse --> modus-wc-icon
   modus-wc-menu-item --> modus-wc-icon
   modus-wc-tabs --> modus-wc-icon

--- a/src/components/atoms/modus-wc-menu/__snapshots__/modus-wc-menu.spec.ts.snap
+++ b/src/components/atoms/modus-wc-menu/__snapshots__/modus-wc-menu.spec.ts.snap
@@ -8,8 +8,8 @@ exports[`modus-wc-menu renders with default props 1`] = `
 `;
 
 exports[`modus-wc-menu should render with custom props 1`] = `
-<modus-wc-menu custom-class="test-class" orientation="horizontal" size="lg">
+<modus-wc-menu bordered="true" custom-class="test-class" orientation="horizontal" size="lg">
   <!---->
-  <ul aria-label="Test menu" aria-orientation="horizontal" class="modus-wc-menu modus-wc-menu-horizontal modus-wc-menu-lg modus-wc-w-full test-class" role="menubar"></ul>
+  <ul aria-label="Test menu" aria-orientation="horizontal" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-horizontal modus-wc-menu-lg modus-wc-w-full test-class" role="menubar"></ul>
 </modus-wc-menu>
 `;

--- a/src/components/atoms/modus-wc-menu/modus-wc-menu.scss
+++ b/src/components/atoms/modus-wc-menu/modus-wc-menu.scss
@@ -6,6 +6,10 @@
 ul.modus-wc-menu {
   border-radius: var(--modus-wc-border-radius-sm);
   padding: 0;
+
+  &.modus-wc-menu--bordered {
+    border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-0);
+  }
 }
 
 [data-theme='modus-classic-light'] ul.modus-wc-menu {

--- a/src/components/atoms/modus-wc-menu/modus-wc-menu.scss
+++ b/src/components/atoms/modus-wc-menu/modus-wc-menu.scss
@@ -4,7 +4,7 @@
 */
 
 ul.modus-wc-menu {
-  border-radius: var(--modus-wc-border-radius-sm);
+  border-radius: var(--modus-wc-border-radius-md);
   padding: 0;
 
   &.modus-wc-menu--bordered {

--- a/src/components/atoms/modus-wc-menu/modus-wc-menu.spec.ts
+++ b/src/components/atoms/modus-wc-menu/modus-wc-menu.spec.ts
@@ -30,6 +30,7 @@ describe('modus-wc-menu', () => {
       components: [ModusWcMenu],
       html: `<modus-wc-menu
         aria-label="Test menu"
+        bordered="true"
         custom-class="test-class"
         orientation="horizontal"
         size="lg"

--- a/src/components/atoms/modus-wc-menu/modus-wc-menu.stories.ts
+++ b/src/components/atoms/modus-wc-menu/modus-wc-menu.stories.ts
@@ -5,6 +5,7 @@ import { ModusSize, Orientation } from '../../types';
 
 interface MenuArgs {
   'aria-label': string;
+  bordered?: boolean;
   'custom-class'?: string;
   orientation?: Orientation;
   size?: ModusSize;
@@ -39,8 +40,9 @@ export const Template: Story = {
     // prettier-ignore
     return html`
 <modus-wc-menu
-  aria-label="${args['aria-label']}"
-  custom-class="${ifDefined(args['custom-class'])}"
+  aria-label=${args['aria-label']}
+  ?bordered=${args.bordered}
+  custom-class=${ifDefined(args['custom-class'])}
   orientation=${ifDefined(args.orientation)}
   size=${ifDefined(args.size)}
 >
@@ -56,14 +58,14 @@ export const Template: Story = {
     size="lg"
   ></modus-wc-menu-item>
   <modus-wc-menu-item
-    label="With Sub-label"
-    value="3"
-    sub-label="Sub-label"
-  ></modus-wc-menu-item>
-  <modus-wc-menu-item
     label="Bordered"
     value="3"
     bordered="true"
+  ></modus-wc-menu-item>
+  <modus-wc-menu-item
+    label="With Sub-label"
+    value="3"
+    sub-label="Sub-label"
   ></modus-wc-menu-item>
   <modus-wc-menu-item
     label="Selected"

--- a/src/components/atoms/modus-wc-menu/modus-wc-menu.tailwind.ts
+++ b/src/components/atoms/modus-wc-menu/modus-wc-menu.tailwind.ts
@@ -1,10 +1,18 @@
 import { ModusSize, Orientation } from '../../types';
 
 export const convertPropsToClasses = (props: {
+  bordered?: boolean;
   orientation?: Orientation;
   size?: ModusSize;
 }): string => {
   let classes = '';
+
+  if (
+    Object.prototype.hasOwnProperty.call(props, 'bordered') &&
+    !!props.bordered
+  ) {
+    classes = `${classes} modus-wc-menu--bordered`;
+  }
 
   if (
     Object.prototype.hasOwnProperty.call(props, 'orientation') &&

--- a/src/components/atoms/modus-wc-menu/modus-wc-menu.tsx
+++ b/src/components/atoms/modus-wc-menu/modus-wc-menu.tsx
@@ -21,6 +21,9 @@ export class ModusWcMenu {
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
+  /** Indicates that the menu should have a border. */
+  @Prop() bordered?: boolean;
+
   /** Custom CSS class to apply to the ul element. */
   @Prop() customClass?: string = '';
 
@@ -44,6 +47,7 @@ export class ModusWcMenu {
     const classList: string[] = ['modus-wc-menu modus-wc-w-full'];
 
     const propClasses = convertPropsToClasses({
+      bordered: this.bordered,
       orientation: this.orientation,
       size: this.size,
     });

--- a/src/components/atoms/modus-wc-menu/readme.md
+++ b/src/components/atoms/modus-wc-menu/readme.md
@@ -15,11 +15,12 @@ Adheres to WCAG 2.2 standards.
 
 ## Properties
 
-| Property      | Attribute      | Description                                  | Type                                      | Default      |
-| ------------- | -------------- | -------------------------------------------- | ----------------------------------------- | ------------ |
-| `customClass` | `custom-class` | Custom CSS class to apply to the ul element. | `string \| undefined`                     | `''`         |
-| `orientation` | `orientation`  | The orientation of the menu.                 | `"horizontal" \| "vertical" \| undefined` | `'vertical'` |
-| `size`        | `size`         | The size of the menu.                        | `"lg" \| "md" \| "sm" \| undefined`       | `'md'`       |
+| Property      | Attribute      | Description                                   | Type                                      | Default      |
+| ------------- | -------------- | --------------------------------------------- | ----------------------------------------- | ------------ |
+| `bordered`    | `bordered`     | Indicates that the menu should have a border. | `boolean \| undefined`                    | `undefined`  |
+| `customClass` | `custom-class` | Custom CSS class to apply to the ul element.  | `string \| undefined`                     | `''`         |
+| `orientation` | `orientation`  | The orientation of the menu.                  | `"horizontal" \| "vertical" \| undefined` | `'vertical'` |
+| `size`        | `size`         | The size of the menu.                         | `"lg" \| "md" \| "sm" \| undefined`       | `'md'`       |
 
 
 ## Dependencies

--- a/src/components/molecules/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
+++ b/src/components/molecules/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
@@ -1,12 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`modus-wc-autocomplete should render with custom props 1`] = `
-<modus-wc-autocomplete active-item-value="1" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" dir="rtl" disabled="true" input-dir="rtl" input-id="test-id" input-tab-index="1" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1">
-  <div class="modus-wc-autocomplete-top">
-    <modus-wc-text-input value="Item 1">
-      <input aria-describedby="description" aria-label="Test autocomplete" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-input modus-wc-input-lg modus-wc-w-full" disabled="" id="test-id" inputmode="text" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="text" value="Item 1">
+exports[`modus-wc-autocomplete should render multi select with selected items 1`] = `
+<modus-wc-autocomplete class="modus-wc-autocomplete" multi-select="true" value="">
+  <div class="modus-wc-autocomplete-multi-select modus-wc-autocomplete-multi-select--bordered">
+    <div class="chip">
+      <modus-wc-button aria-label="Remove item button" color="secondary" shape="circle" size="xs">
+        <modus-wc-icon decorative="" name="close"></modus-wc-icon>
+      </modus-wc-button>
+      <div class="label">
+        Item 1
+      </div>
+    </div>
+    <div class="chip">
+      <modus-wc-button aria-label="Remove item button" color="secondary" shape="circle" size="xs">
+        <modus-wc-icon decorative="" name="close"></modus-wc-icon>
+      </modus-wc-button>
+      <div class="label">
+        Item 2
+      </div>
+    </div>
+    <modus-wc-text-input value="">
+      <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-input modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
     </modus-wc-text-input>
   </div>
+  <modus-wc-menu>
+    <!---->
+    <ul aria-label="Autocomplete menu" aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-md modus-wc-w-full" role="menu">
+      <modus-wc-menu-item label="Item 1" selected="" value="1"></modus-wc-menu-item>
+      <modus-wc-menu-item label="Item 2" selected="" value="2"></modus-wc-menu-item>
+      <modus-wc-menu-item label="Item 3" value="3"></modus-wc-menu-item>
+    </ul>
+  </modus-wc-menu>
+</modus-wc-autocomplete>
+`;
+
+exports[`modus-wc-autocomplete should render multi select without border 1`] = `
+<modus-wc-autocomplete bordered="false" class="modus-wc-autocomplete" multi-select="true" value="">
+  <div class="modus-wc-autocomplete-multi-select">
+    <div class="chip">
+      <modus-wc-button aria-label="Remove item button" color="secondary" shape="circle" size="xs">
+        <modus-wc-icon decorative="" name="close"></modus-wc-icon>
+      </modus-wc-button>
+      <div class="label">
+        Item 1
+      </div>
+    </div>
+    <div class="chip">
+      <modus-wc-button aria-label="Remove item button" color="secondary" shape="circle" size="xs">
+        <modus-wc-icon decorative="" name="close"></modus-wc-icon>
+      </modus-wc-button>
+      <div class="label">
+        Item 2
+      </div>
+    </div>
+    <modus-wc-text-input value="">
+      <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-input modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
+    </modus-wc-text-input>
+  </div>
+  <modus-wc-menu>
+    <!---->
+    <ul aria-label="Autocomplete menu" aria-orientation="vertical" class="modus-wc-menu modus-wc-menu-md modus-wc-w-full" role="menu">
+      <modus-wc-menu-item label="Item 1" selected="" value="1"></modus-wc-menu-item>
+      <modus-wc-menu-item label="Item 2" selected="" value="2"></modus-wc-menu-item>
+      <modus-wc-menu-item label="Item 3" value="3"></modus-wc-menu-item>
+    </ul>
+  </modus-wc-menu>
+</modus-wc-autocomplete>
+`;
+
+exports[`modus-wc-autocomplete should render with custom props 1`] = `
+<modus-wc-autocomplete active-item-value="1" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" dir="rtl" disabled="true" input-dir="rtl" input-id="test-id" input-tab-index="1" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1">
+  <modus-wc-text-input value="Item 1">
+    <input aria-describedby="description" aria-label="Test autocomplete" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-input modus-wc-input-lg modus-wc-w-full" disabled="" id="test-id" inputmode="text" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="text" value="Item 1">
+  </modus-wc-text-input>
   <modus-wc-menu>
     <!---->
     <ul aria-label="Autocomplete menu" aria-orientation="vertical" class="modus-wc-menu modus-wc-menu-lg modus-wc-w-full" role="menu">
@@ -56,10 +122,8 @@ exports[`modus-wc-autocomplete should render with custom props 1`] = `
 
 exports[`modus-wc-autocomplete should render with default props 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="">
-  <div class="modus-wc-autocomplete-top modus-wc-autocomplete-top--bordered">
-    <modus-wc-text-input value="">
-      <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-input modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
-    </modus-wc-text-input>
-  </div>
+  <modus-wc-text-input value="">
+    <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
+  </modus-wc-text-input>
 </modus-wc-autocomplete>
 `;

--- a/src/components/molecules/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
+++ b/src/components/molecules/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
@@ -1,17 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-autocomplete should render with custom props 1`] = `
-<modus-wc-autocomplete .items="[{&quot;label&quot;:&quot;Item" 1","value":"1"},{"label":"item="" 2","value":"2"},{"label":"item="" 3","value":"3"}]="" active-item-value="1" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" dir="rtl" disabled="true" input-dir="rtl" input-id="test-id" input-tab-index="1" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1">
-  <modus-wc-text-input value="Item 1">
-    <input aria-describedby="description" aria-label="Test autocomplete" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-input modus-wc-input-lg modus-wc-w-full" disabled="" id="test-id" inputmode="text" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="text" value="Item 1">
-  </modus-wc-text-input>
+<modus-wc-autocomplete active-item-value="1" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" dir="rtl" disabled="true" input-dir="rtl" input-id="test-id" input-tab-index="1" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1">
+  <div class="modus-wc-autocomplete-top">
+    <modus-wc-text-input value="Item 1">
+      <input aria-describedby="description" aria-label="Test autocomplete" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-input modus-wc-input-lg modus-wc-w-full" disabled="" id="test-id" inputmode="text" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="text" value="Item 1">
+    </modus-wc-text-input>
+  </div>
+  <modus-wc-menu>
+    <!---->
+    <ul aria-label="Autocomplete menu" aria-orientation="vertical" class="modus-wc-menu modus-wc-menu-lg modus-wc-w-full" role="menu">
+      <modus-wc-menu-item>
+        <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
+          <button type="button">
+            <div class="modus-wc-menu-item-content">
+              <div class="modus-wc-menu-item-labels">
+                <div>
+                  Item 1
+                </div>
+              </div>
+            </div>
+          </button>
+        </li>
+      </modus-wc-menu-item>
+      <modus-wc-menu-item>
+        <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
+          <button type="button">
+            <div class="modus-wc-menu-item-content">
+              <div class="modus-wc-menu-item-labels">
+                <div>
+                  Item 2
+                </div>
+              </div>
+            </div>
+          </button>
+        </li>
+      </modus-wc-menu-item>
+      <modus-wc-menu-item>
+        <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
+          <button type="button">
+            <div class="modus-wc-menu-item-content">
+              <div class="modus-wc-menu-item-labels">
+                <div>
+                  Item 3
+                </div>
+              </div>
+            </div>
+          </button>
+        </li>
+      </modus-wc-menu-item>
+    </ul>
+  </modus-wc-menu>
 </modus-wc-autocomplete>
 `;
 
 exports[`modus-wc-autocomplete should render with default props 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="">
-  <modus-wc-text-input value="">
-    <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
-  </modus-wc-text-input>
+  <div class="modus-wc-autocomplete-top modus-wc-autocomplete-top--bordered">
+    <modus-wc-text-input value="">
+      <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-input modus-wc-input-md modus-wc-w-full" inputmode="text" placeholder="" type="text" value="">
+    </modus-wc-text-input>
+  </div>
 </modus-wc-autocomplete>
 `;

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -6,7 +6,7 @@
 .modus-wc-autocomplete {
   .modus-wc-input-bordered {
     border-radius: var(--modus-wc-border-radius-md)
-    var(--modus-wc-border-radius-md) 0 0;
+      var(--modus-wc-border-radius-md) 0 0;
   }
 
   .modus-wc-autocomplete-multi-select {
@@ -44,7 +44,7 @@
 
   .modus-wc-menu {
     border-radius: 0 0 var(--modus-wc-border-radius-md)
-    var(--modus-wc-border-radius-md)
+      var(--modus-wc-border-radius-md);
   }
 }
 

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -6,6 +6,7 @@
 .modus-wc-autocomplete {
   .modus-wc-autocomplete-top {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     padding: var(--modus-wc-spacing-sm);
 

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -8,6 +8,7 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    gap: .5rem;
     padding: var(--modus-wc-spacing-sm);
 
     &.modus-wc-autocomplete-top--bordered {
@@ -21,7 +22,6 @@
       align-items: center;
       background-color: var(--modus-wc-color-gray-1);
       border-radius: var(--modus-wc-border-radius-xl);
-      margin-right: var(--modus-wc-spacing-sm);
 
       button {
         i {

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -2,3 +2,53 @@
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
+
+.modus-wc-autocomplete {
+  .modus-wc-autocomplete-top {
+    display: flex;
+    align-items: center;
+    padding: var(--modus-wc-spacing-sm);
+
+    &.modus-wc-autocomplete-top--bordered {
+      border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-0);
+      border-radius: var(--modus-wc-border-radius-md) var(--modus-wc-border-radius-md) 0 0;
+    }
+
+    /** TODO - chip styling is temporary, remove once chip component is implemented */
+    .chip {
+      display: flex;
+      align-items: center;
+      background-color: var(--modus-wc-color-gray-1);
+      border-radius: var(--modus-wc-border-radius-xl);
+      margin-right: var(--modus-wc-spacing-sm);
+
+      button {
+        i {
+          font-size: .75rem;
+        }
+      }
+
+      .label {
+        font-size: var(--modus-wc-font-size-md);
+        padding: 0 var(--modus-wc-spacing-xs);
+      }
+    }
+  }
+}
+
+[data-theme='modus-classic-light'] .modus-wc-autocomplete,
+[data-theme='modus-classic-dark'] .modus-wc-autocomplete {
+  .modus-wc-autocomplete-top--bordered {
+    border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-6);
+
+    &:focus-within {
+      border-color: var(--modus-wc-color-highlight-blue);
+      border-width: 2px;
+    }
+  }
+
+  ul.modus-wc-menu {
+    box-shadow: 0 0 4px 0 rgba(54, 53, 69, 0.30);
+  }
+}
+

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -4,14 +4,19 @@
 */
 
 .modus-wc-autocomplete {
-  .modus-wc-autocomplete-top {
+  .modus-wc-input-bordered {
+    border-radius: var(--modus-wc-border-radius-md)
+    var(--modus-wc-border-radius-md) 0 0;
+  }
+
+  .modus-wc-autocomplete-multi-select {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 0.5rem;
-    padding: var(--modus-wc-spacing-sm);
+    padding: var(--modus-wc-spacing-xs);
 
-    &.modus-wc-autocomplete-top--bordered {
+    &.modus-wc-autocomplete-multi-select--bordered {
       border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-0);
       border-radius: var(--modus-wc-border-radius-md)
         var(--modus-wc-border-radius-md) 0 0;
@@ -36,11 +41,16 @@
       }
     }
   }
+
+  .modus-wc-menu {
+    border-radius: 0 0 var(--modus-wc-border-radius-md)
+    var(--modus-wc-border-radius-md)
+  }
 }
 
 [data-theme='modus-classic-light'] .modus-wc-autocomplete,
 [data-theme='modus-classic-dark'] .modus-wc-autocomplete {
-  .modus-wc-autocomplete-top--bordered {
+  .modus-wc-autocomplete-multi-select--bordered {
     border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-6);
 
     &:focus-within {

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -8,12 +8,13 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: .5rem;
+    gap: 0.5rem;
     padding: var(--modus-wc-spacing-sm);
 
     &.modus-wc-autocomplete-top--bordered {
       border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-0);
-      border-radius: var(--modus-wc-border-radius-md) var(--modus-wc-border-radius-md) 0 0;
+      border-radius: var(--modus-wc-border-radius-md)
+        var(--modus-wc-border-radius-md) 0 0;
     }
 
     /** TODO - chip styling is temporary, remove once chip component is implemented */
@@ -25,7 +26,7 @@
 
       button {
         i {
-          font-size: .75rem;
+          font-size: 0.75rem;
         }
       }
 
@@ -49,7 +50,6 @@
   }
 
   ul.modus-wc-menu {
-    box-shadow: 0 0 4px 0 rgba(54, 53, 69, 0.30);
+    box-shadow: 0 0 4px 0 rgba(54, 53, 69, 0.3);
   }
 }
-

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -4,6 +4,8 @@
 */
 
 .modus-wc-autocomplete {
+  position: relative;
+
   .modus-wc-input-bordered {
     border-radius: var(--modus-wc-border-radius-md)
       var(--modus-wc-border-radius-md) 0 0;
@@ -43,6 +45,8 @@
   }
 
   .modus-wc-menu {
+    position: absolute;
+    z-index: 99;
     border-radius: 0 0 var(--modus-wc-border-radius-md)
       var(--modus-wc-border-radius-md);
   }

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -4,6 +4,7 @@ import {
   ModusWcAutocomplete,
 } from './modus-wc-autocomplete';
 import { ModusWcMenu } from '../../atoms/modus-wc-menu/modus-wc-menu';
+import { ModusWcMenuItem } from '../../atoms/modus-wc-menu-item/modus-wc-menu-item';
 import { ModusWcTextInput } from '../../atoms/modus-wc-text-input/modus-wc-text-input';
 
 describe('modus-wc-autocomplete', () => {
@@ -23,7 +24,12 @@ describe('modus-wc-autocomplete', () => {
 
   it('should render with custom props', async () => {
     const page = await newSpecPage({
-      components: [ModusWcAutocomplete, ModusWcMenu, ModusWcTextInput],
+      components: [
+        ModusWcAutocomplete,
+        ModusWcMenu,
+        ModusWcMenuItem,
+        ModusWcTextInput,
+      ],
       html: `<modus-wc-autocomplete
         active-item-value="1"
         aria-describedby="description"
@@ -35,7 +41,6 @@ describe('modus-wc-autocomplete', () => {
         input-dir="rtl"
         input-id="test-id"
         input-tab-index="1"
-        .items=${JSON.stringify(items)}
         min-chars="2"
         name="test-name"
         placeholder="Test placeholder"
@@ -45,6 +50,17 @@ describe('modus-wc-autocomplete', () => {
         value="Item 1"
       ></modus-wc-autocomplete>`,
     });
+
+    // Set items attribute
+    const component = page.rootInstance as ModusWcAutocomplete;
+    component.items = items;
+
+    // Focus input so the menu is visible
+    const input = page.root!.querySelector('input');
+    input?.focus();
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 
@@ -53,6 +69,7 @@ describe('modus-wc-autocomplete', () => {
       components: [ModusWcAutocomplete, ModusWcTextInput],
       html: '<modus-wc-autocomplete aria-label="Blur test"></modus-wc-autocomplete>',
     });
+
     const input = page.root!.querySelector('input');
     expect(input).not.toBeNull();
     const blurSpy = jest.fn();
@@ -69,6 +86,7 @@ describe('modus-wc-autocomplete', () => {
       components: [ModusWcAutocomplete, ModusWcTextInput],
       html: '<modus-wc-autocomplete aria-label="Change test"></modus-wc-autocomplete>',
     });
+
     const input = page.root!.querySelector('input');
     expect(input).not.toBeNull();
     const changeSpy = jest.fn();
@@ -91,6 +109,7 @@ describe('modus-wc-autocomplete', () => {
       components: [ModusWcAutocomplete, ModusWcTextInput],
       html: '<modus-wc-autocomplete aria-label="Change test"></modus-wc-autocomplete>',
     });
+
     const input = page.root!.querySelector('input');
     expect(input).not.toBeNull();
     const focusSpy = jest.fn();

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -9,9 +9,9 @@ import { ModusWcTextInput } from '../../atoms/modus-wc-text-input/modus-wc-text-
 
 describe('modus-wc-autocomplete', () => {
   const items: IAutocompleteItem[] = [
-    { label: 'Item 1', value: '1' },
-    { label: 'Item 2', value: '2' },
-    { label: 'Item 3', value: '3' },
+    { label: 'Item 1', value: '1', visibleInMenu: true },
+    { label: 'Item 2', value: '2', visibleInMenu: true },
+    { label: 'Item 3', value: '3', visibleInMenu: true },
   ];
 
   it('should render with default props', async () => {

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -64,6 +64,46 @@ describe('modus-wc-autocomplete', () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it('should render multi select with selected items', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcAutocomplete, ModusWcMenu, ModusWcTextInput],
+      html: '<modus-wc-autocomplete aria-label="Default autocomplete" multi-select="true"></modus-wc-autocomplete>',
+    });
+
+    // Set items attribute
+    const component = page.rootInstance as ModusWcAutocomplete;
+    items[0].selected = true;
+    items[1].selected = true;
+    component.items = items;
+
+    // Focus input so the menu is visible
+    const input = page.root!.querySelector('input');
+    input?.focus();
+
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render multi select without border', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcAutocomplete, ModusWcMenu, ModusWcTextInput],
+      html: '<modus-wc-autocomplete aria-label="Default autocomplete" bordered="false" multi-select="true"></modus-wc-autocomplete>',
+    });
+
+    // Set items attribute
+    const component = page.rootInstance as ModusWcAutocomplete;
+    component.items = items;
+
+    // Focus input so the menu is visible
+    const input = page.root!.querySelector('input');
+    input?.focus();
+
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+  });
+
   it('should emit blur event', async () => {
     const page = await newSpecPage({
       components: [ModusWcAutocomplete, ModusWcTextInput],

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -1,22 +1,21 @@
 import { withActions } from '@storybook/addon-actions/decorator';
-import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { IAutocompleteItem } from './modus-wc-autocomplete';
 import { ModusSize } from '../../types';
 
-const fruits: IAutocompleteItem[] = [
-  { label: 'Apple', value: 'apple' },
-  { label: 'Banana', value: 'banana' },
-  { label: 'Blueberry', value: 'blueberry' },
-  { label: 'Cherry', value: 'cherry', selected: true },
-  { label: 'Grape', value: 'grape' },
-  { label: 'Lemon', value: 'lemon' },
-  { label: 'Orange', value: 'orange' },
-  { label: 'Peach', value: 'peach', selected: true },
-  { label: 'Pear', value: 'pear' },
-  { label: 'Strawberry', value: 'strawberry' },
+const items: IAutocompleteItem[] = [
+  { label: 'Apple', value: 'apple', visibleInMenu: true },
+  { label: 'Banana', value: 'banana', visibleInMenu: true },
+  { label: 'Blueberry', value: 'blueberry', visibleInMenu: true },
+  { label: 'Cherry', value: 'cherry', visibleInMenu: true },
+  { label: 'Grape', value: 'grape', visibleInMenu: true },
+  { label: 'Lemon', value: 'lemon', visibleInMenu: true },
+  { label: 'Orange', value: 'orange', visibleInMenu: true },
+  { label: 'Peach', value: 'peach', visibleInMenu: true },
+  { label: 'Pear', value: 'pear', visibleInMenu: true },
+  { label: 'Strawberry', value: 'strawberry', visibleInMenu: true },
 ];
 
 interface AutocompleteArgs {
@@ -31,6 +30,7 @@ interface AutocompleteArgs {
   'input-tab-index'?: number;
   items: IAutocompleteItem[];
   'min-chars': number;
+  'multi-select'?: boolean;
   name?: string;
   placeholder?: string;
   'read-only'?: boolean;
@@ -47,8 +47,9 @@ const meta: Meta<AutocompleteArgs> = {
     bordered: true,
     'debounce-ms': 300,
     disabled: false,
-    items: fruits,
+    items: items,
     'min-chars': 0,
+    'multi-select': false,
     placeholder: 'Search for fruits...',
     size: 'md',
     value: '',
@@ -79,30 +80,26 @@ type Story = StoryObj<AutocompleteArgs>;
 
 const Template: Story = {
   render: (args) => {
-    const [, updateArgs] = useArgs();
-
-    const handleChipRemove = (e: CustomEvent<IAutocompleteItem>) => {
-      const fruit = fruits.find((fruit) => fruit.value === e.detail.value);
-      if (fruit) {
-        fruit.selected = false;
-        updateArgs({ items: [...fruits] });
-      }
-    };
-
     const handleInputChange = (e: CustomEvent<Event>) => {
       if (!e.detail?.target) return;
-
-      const input = e.detail.target as HTMLInputElement;
-      const searchText = input.value.toLowerCase();
-      const filteredFruits = fruits.filter((fruit) =>
-        fruit.label.toLowerCase().includes(searchText)
-      );
 
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );
+
       if (autocomplete) {
-        autocomplete.items = filteredFruits;
+        const input = e.detail.target as HTMLInputElement;
+        const searchText = input.value.toLowerCase();
+
+        // Create a new array, updating the values of 'selected' and 'visibleInMenu'.
+        const updatedItems = items.map((item) => ({
+          ...item,
+          selected: searchText ? item.selected : false,
+          visibleInMenu: item.label.toLowerCase().includes(searchText),
+        }));
+
+        // Ensuring that a new array is created when updating items is critical to component re-render.
+        autocomplete.items = [...updatedItems];
         autocomplete.value = input.value;
       }
     };
@@ -113,41 +110,249 @@ const Template: Story = {
       );
 
       if (autocomplete) {
-        const fruit = fruits.find((fruit) => fruit.value === e.detail.value);
-        if (fruit) {
-          fruit.selected = true;
-          updateArgs({ items: [...fruits] });
+        const label = e.detail.label;
+        if (label) {
+          autocomplete.value = label;
+        }
+
+        // Clear the previous selection.
+        items.forEach((item) => (item.selected = false));
+
+        // Mark the user selected menu item as selected and create a new array to update items.
+        const foundItem = items.find((item) => item.value === e.detail.value);
+        if (foundItem) {
+          foundItem.selected = true;
+          autocomplete.items = [...items];
         }
       }
     };
 
+    // prettier-ignore
     return html`
-      <modus-wc-autocomplete
-        aria-describedby=${ifDefined(args['aria-describedby'])}
-        aria-label=${args['aria-label']}
-        ?bordered=${args.bordered}
-        custom-class=${ifDefined(args['custom-class'])}
-        debounce-ms=${ifDefined(args['debounce-ms'])}
-        ?disabled=${args.disabled}
-        input-dir=${ifDefined(args['input-dir'])}
-        input-id=${ifDefined(args['input-id'])}
-        input-tab-index=${ifDefined(args['input-tab-index'])}
-        .items=${args.items}
-        min-chars=${args['min-chars']}
-        name=${ifDefined(args.name)}
-        placeholder=${ifDefined(args.placeholder)}
-        ?read-only=${args['read-only']}
-        ?required=${args.required}
-        size=${ifDefined(args.size)}
-        value=${args.value}
-        @chipRemove=${handleChipRemove}
-        @inputChange=${handleInputChange}
-        @itemSelect=${handleItemSelect}
-      ></modus-wc-autocomplete>
+<script>
+  const handleInputChange = (e) => {
+    if (!e.detail?.target) return;
+
+    const autocomplete = (e.target as HTMLInputElement).closest(
+      'modus-wc-autocomplete'
+    );
+
+    if (autocomplete) {
+      const input = e.detail.target as HTMLInputElement;
+      const searchText = input.value.toLowerCase();
+
+      // Create a new array, updating the values of 'selected' and 'visibleInMenu'.
+      const updatedItems = items.map((item) => ({
+        ...item,
+        selected: searchText ? item.selected : false,
+        visibleInMenu: item.label.toLowerCase().includes(searchText),
+      }));
+
+      // Ensuring that a new array is created when updating items is critical to component re-render.
+      autocomplete.items = [...updatedItems];
+      autocomplete.value = input.value;
+    }
+  };
+
+  const handleItemSelect = (e) => {
+    const autocomplete = (e.target as HTMLInputElement).closest(
+      'modus-wc-autocomplete'
+    );
+
+    if (autocomplete) {
+      // Clear the previous selection.
+      items.forEach((item) => (item.selected = false));
+
+      // Mark the user selected menu item as selected and create a new array to update items.
+      const foundItem = items.find((item) => item.value === e.detail.value);
+      if (foundItem) {
+        foundItem.selected = true;
+        autocomplete.items = [...items];
+      }
+    }
+  };
+</script>
+<modus-wc-autocomplete
+  aria-describedby=${ifDefined(args['aria-describedby'])}
+  aria-label=${args['aria-label']}
+  ?bordered=${args.bordered}
+  custom-class=${ifDefined(args['custom-class'])}
+  debounce-ms=${ifDefined(args['debounce-ms'])}
+  ?disabled=${args.disabled}
+  input-dir=${ifDefined(args['input-dir'])}
+  input-id=${ifDefined(args['input-id'])}
+  input-tab-index=${ifDefined(args['input-tab-index'])}
+  .items=${args.items}
+  min-chars=${args['min-chars']}
+  ?multi-select=${false}
+  name=${ifDefined(args.name)}
+  placeholder=${ifDefined(args.placeholder)}
+  ?read-only=${args['read-only']}
+  ?required=${args.required}
+  size=${ifDefined(args.size)}
+  value=${args.value}
+  @inputChange=${handleInputChange}
+  @itemSelect=${handleItemSelect}
+></modus-wc-autocomplete>
     `;
   },
 };
 
 export const Default: Story = {
   ...Template,
+};
+
+export const MultiSelect: Story = {
+  render: (args) => {
+    const handleChipRemove = (e: CustomEvent<IAutocompleteItem>) => {
+      const autocomplete = (e.target as HTMLInputElement).closest(
+        'modus-wc-autocomplete'
+      );
+
+      if (autocomplete) {
+        // Update the 'selected' value of the removed item.
+        const foundItem = items.find((item) => item.value === e.detail.value);
+        if (foundItem) {
+          foundItem.selected = false;
+          autocomplete.items = [...items];
+        }
+      }
+    };
+
+    const handleInputChange = (e: CustomEvent<Event>) => {
+      if (!e.detail?.target) return;
+
+      const autocomplete = (e.target as HTMLInputElement).closest(
+        'modus-wc-autocomplete'
+      );
+
+      if (autocomplete) {
+        const input = e.detail.target as HTMLInputElement;
+        const searchText = input.value.toLowerCase();
+
+        // Create a new array, updating the values of 'selected' and 'visibleInMenu'.
+        const updatedItems = items.map((item) => ({
+          ...item,
+          visibleInMenu: item.label.toLowerCase().includes(searchText),
+        }));
+
+        // Ensuring that a new array is created when updating items is critical to component re-render.
+        autocomplete.items = [...updatedItems];
+        autocomplete.value = input.value;
+      }
+    };
+
+    const handleItemSelect = (e: CustomEvent<IAutocompleteItem>) => {
+      const autocomplete = (e.target as HTMLInputElement).closest(
+        'modus-wc-autocomplete'
+      );
+
+      if (autocomplete) {
+        // Reset autocomplete 'value' and update the value of 'visibleInMenu' for all items.
+        autocomplete.value = '';
+        autocomplete.items = items.map((item) => ({
+          ...item,
+          visibleInMenu: true,
+        }));
+
+        // Mark the user selected item as selected.
+        const fruit = items.find((fruit) => fruit.value === e.detail.value);
+        if (fruit) {
+          fruit.selected = true;
+        }
+      }
+    };
+
+    // prettier-ignore
+    return html`
+<script>
+  const handleChipRemove = (e) => {
+    const autocomplete = (e.target as HTMLInputElement).closest(
+      'modus-wc-autocomplete'
+    );
+
+    if (autocomplete) {
+      // Update the 'selected' value of the removed item.
+      const foundItem = items.find((item) => item.value === e.detail.value);
+      if (foundItem) {
+        foundItem.selected = false;
+        autocomplete.items = [...items];
+      }
+    }
+  };
+  
+  const handleInputChange = (e) => {
+    if (!e.detail?.target) return;
+
+    const autocomplete = (e.target as HTMLInputElement).closest(
+      'modus-wc-autocomplete'
+    );
+    
+    if (autocomplete) {
+      const input = e.detail.target as HTMLInputElement;
+      const searchText = input.value.toLowerCase();
+
+      // Create a new array, updating the values of 'selected' and 'visibleInMenu'.
+      const updatedItems = items.map((item) => ({
+        ...item,
+        selected: searchText ? item.selected : false,
+        visibleInMenu: item.label.toLowerCase().includes(searchText),
+      }));
+      
+      // Ensuring that a new array is created when updating items is critical to component re-render.
+      autocomplete.items = [...updatedItems];
+      autocomplete.value = input.value;
+    }
+  };
+  
+  const handleItemSelect = (e) => {
+    const autocomplete = (e.target
+    as
+    HTMLInputElement
+  ).
+    closest(
+      'modus-wc-autocomplete'
+    );
+
+    if (autocomplete) {
+      // Reset autocomplete 'value' and update the value of 'visibleInMenu' for all items.
+      autocomplete.value = '';
+      autocomplete.items = items.map((item) => ({
+        ...item,
+        visibleInMenu: true,
+      }));
+
+      // Mark the user selected item as selected.
+      const fruit = items.find((fruit) => fruit.value === e.detail.value);
+      if (fruit) {
+        fruit.selected = true;
+      }
+    }
+  };
+</script>
+<modus-wc-autocomplete
+  aria-describedby=${ifDefined(args['aria-describedby'])}
+  aria-label=${args['aria-label']}
+  ?bordered=${args.bordered}
+  custom-class=${ifDefined(args['custom-class'])}
+  debounce-ms=${ifDefined(args['debounce-ms'])}
+  ?disabled=${args.disabled}
+  input-dir=${ifDefined(args['input-dir'])}
+  input-id=${ifDefined(args['input-id'])}
+  input-tab-index=${ifDefined(args['input-tab-index'])}
+  .items=${args.items}
+  min-chars=${args['min-chars']}
+  ?multi-select=${true}
+  name=${ifDefined(args.name)}
+  placeholder=${ifDefined(args.placeholder)}
+  ?read-only=${args['read-only']}
+  ?required=${args.required}
+  size=${ifDefined(args.size)}
+  value=${args.value}
+  @chipRemove=${handleChipRemove}
+  @inputChange=${handleInputChange}
+  @itemSelect=${handleItemSelect}
+></modus-wc-autocomplete>
+    `;
+  },
 };

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -129,6 +129,12 @@ const Template: Story = {
 
     // prettier-ignore
     return html`
+<style>
+  /* Only for Storybook */
+  div[id^="story--components-forms-autocomplete--default"] {
+    height: 400px;
+  }
+</style>
 <script>
   const handleInputChange = (e) => {
     if (!e.detail?.target) return;
@@ -265,6 +271,12 @@ export const MultiSelect: Story = {
 
     // prettier-ignore
     return html`
+<style>
+  /* Only for Storybook */
+  div#story--components-forms-autocomplete--multi-select-inner {
+    height: 400px;
+  }
+</style>
 <script>
   const handleChipRemove = (e) => {
     const autocomplete = (e.target as HTMLInputElement).closest(

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -1,4 +1,5 @@
 import { withActions } from '@storybook/addon-actions/decorator';
+import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -9,17 +10,16 @@ const fruits: IAutocompleteItem[] = [
   { label: 'Apple', value: 'apple' },
   { label: 'Banana', value: 'banana' },
   { label: 'Blueberry', value: 'blueberry' },
-  { label: 'Cherry', value: 'cherry' },
+  { label: 'Cherry', value: 'cherry', selected: true },
   { label: 'Grape', value: 'grape' },
   { label: 'Lemon', value: 'lemon' },
   { label: 'Orange', value: 'orange' },
-  { label: 'Peach', value: 'peach' },
+  { label: 'Peach', value: 'peach', selected: true },
   { label: 'Pear', value: 'pear' },
   { label: 'Strawberry', value: 'strawberry' },
 ];
 
 interface AutocompleteArgs {
-  'active-item-value'?: string;
   'aria-describedby'?: string;
   'aria-label': string;
   bordered?: boolean;
@@ -44,6 +44,7 @@ const meta: Meta<AutocompleteArgs> = {
   component: 'modus-wc-autocomplete',
   args: {
     'aria-label': 'Fruit selection autocomplete',
+    bordered: true,
     'debounce-ms': 300,
     disabled: false,
     items: fruits,
@@ -61,7 +62,13 @@ const meta: Meta<AutocompleteArgs> = {
   decorators: [withActions],
   parameters: {
     actions: {
-      handles: ['inputBlur', 'inputChange', 'inputFocus', 'itemSelect'],
+      handles: [
+        'chipRemove',
+        'inputBlur',
+        'inputChange',
+        'inputFocus',
+        'itemSelect',
+      ],
     },
   },
 };
@@ -72,6 +79,16 @@ type Story = StoryObj<AutocompleteArgs>;
 
 const Template: Story = {
   render: (args) => {
+    const [, updateArgs] = useArgs();
+
+    const handleChipRemove = (e: CustomEvent<IAutocompleteItem>) => {
+      const fruit = fruits.find((fruit) => fruit.value === e.detail.value);
+      if (fruit) {
+        fruit.selected = false;
+        updateArgs({ items: [...fruits] });
+      }
+    };
+
     const handleInputChange = (e: CustomEvent<Event>) => {
       if (!e.detail?.target) return;
 
@@ -87,8 +104,6 @@ const Template: Story = {
       if (autocomplete) {
         autocomplete.items = filteredFruits;
         autocomplete.value = input.value;
-
-        if (!searchText) autocomplete.activeItemValue = input.value;
       }
     };
 
@@ -96,15 +111,18 @@ const Template: Story = {
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );
+
       if (autocomplete) {
-        autocomplete.activeItemValue = e.detail.value;
-        autocomplete.value = e.detail.label;
+        const fruit = fruits.find((fruit) => fruit.value === e.detail.value);
+        if (fruit) {
+          fruit.selected = true;
+          updateArgs({ items: [...fruits] });
+        }
       }
     };
 
     return html`
       <modus-wc-autocomplete
-        active-item-value=${ifDefined(args['active-item-value'])}
         aria-describedby=${ifDefined(args['aria-describedby'])}
         aria-label=${args['aria-label']}
         ?bordered=${args.bordered}
@@ -122,6 +140,7 @@ const Template: Story = {
         ?required=${args.required}
         size=${ifDefined(args.size)}
         value=${args.value}
+        @chipRemove=${handleChipRemove}
         @inputChange=${handleInputChange}
         @itemSelect=${handleItemSelect}
       ></modus-wc-autocomplete>

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -19,8 +19,6 @@ const items: IAutocompleteItem[] = [
 ];
 
 interface AutocompleteArgs {
-  'aria-describedby'?: string;
-  'aria-label': string;
   bordered?: boolean;
   'custom-class'?: string;
   'debounce-ms'?: number;
@@ -43,7 +41,6 @@ const meta: Meta<AutocompleteArgs> = {
   title: 'Components/Forms/Autocomplete',
   component: 'modus-wc-autocomplete',
   args: {
-    'aria-label': 'Fruit selection autocomplete',
     bordered: true,
     'debounce-ms': 300,
     disabled: false,
@@ -179,8 +176,7 @@ const Template: Story = {
   };
 </script>
 <modus-wc-autocomplete
-  aria-describedby=${ifDefined(args['aria-describedby'])}
-  aria-label=${args['aria-label']}
+  aria-label="Fruit autocomplete"
   ?bordered=${args.bordered}
   custom-class=${ifDefined(args['custom-class'])}
   debounce-ms=${ifDefined(args['debounce-ms'])}
@@ -343,8 +339,7 @@ export const MultiSelect: Story = {
   };
 </script>
 <modus-wc-autocomplete
-  aria-describedby=${ifDefined(args['aria-describedby'])}
-  aria-label=${args['aria-label']}
+  aria-label="Fruit autocomplete"
   ?bordered=${args.bordered}
   custom-class=${ifDefined(args['custom-class'])}
   debounce-ms=${ifDefined(args['debounce-ms'])}

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -14,6 +14,7 @@ import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface IAutocompleteItem {
   label: string;
+  selected?: boolean;
   value: string;
 }
 
@@ -35,9 +36,6 @@ export class ModusWcAutocomplete {
   @Element() el!: HTMLElement;
 
   @State() private menuVisible: boolean = false;
-
-  /** The active menu item value, used to show an item as selected. */
-  @Prop() activeItemValue?: string;
 
   /** Indicates that the autocomplete should have a border. */
   @Prop() bordered?: boolean = true;
@@ -86,6 +84,9 @@ export class ModusWcAutocomplete {
 
   /** The value of the control. */
   @Prop({ mutable: true, reflect: true }) value: string = '';
+
+  /** Event emitted when a selected item chip is removed. */
+  @StencilEvent() chipRemove!: EventEmitter<IAutocompleteItem>;
 
   /** Event emitted when the input loses focus. */
   @StencilEvent() inputBlur!: EventEmitter<FocusEvent>;
@@ -179,7 +180,36 @@ export class ModusWcAutocomplete {
     this.itemSelect.emit(item);
   };
 
+  private handleChipRemove = (item: IAutocompleteItem) => {
+    this.chipRemove.emit(item);
+  };
+
   render() {
+    const getChips = () => {
+      const selectedItems = this.items.filter((item) => item.selected);
+
+      // TODO - use `<modus-wc-chip>` elements once completed
+      return (
+        <Fragment>
+          {selectedItems.map((item) => (
+            <div class="chip">
+              <modus-wc-button
+                aria-label="Remove item button"
+                color="secondary"
+                onClick={() => this.handleChipRemove(item)}
+                shape="circle"
+                size="xs"
+              >
+                <modus-wc-icon decorative={true} name="close" />
+              </modus-wc-button>
+              <div class="label">{item.label}</div>
+            </div>
+          ))}
+        </Fragment>
+      );
+    };
+
+    // TODO - to improve flexibility, allow users to pass their own `<modus-wc-menu-item>` elements
     // TODO - add code coverage once autocomplete is updated
     // istanbul ignore next
     const getMenuItems = () => {
@@ -187,9 +217,9 @@ export class ModusWcAutocomplete {
         <Fragment>
           {this.items.map((item) => (
             <modus-wc-menu-item
-              bordered={true}
               label={item.label}
               onItemSelect={() => this.handleItemSelect(item)}
+              selected={item.selected}
               value={item.value}
             />
           ))}
@@ -199,22 +229,27 @@ export class ModusWcAutocomplete {
 
     return (
       <Host class={this.getClasses()} dir={this.inputDir}>
-        <modus-wc-text-input
-          bordered={this.bordered}
-          disabled={this.disabled}
-          inputId={this.inputId}
-          inputTabIndex={this.inputTabIndex}
-          name={this.name}
-          onInputBlur={this.handleBlur}
-          onInputChange={this.handleChange}
-          onInputFocus={this.handleFocus}
-          placeholder={this.placeholder}
-          readOnly={this.readOnly}
-          required={this.required}
-          size={this.size}
-          value={this.value}
-          {...this.inheritedAttributes}
-        />
+        <div
+          class={`modus-wc-autocomplete-top ${this.bordered ? 'modus-wc-autocomplete-top--bordered' : ''}`}
+        >
+          {getChips()}
+          <modus-wc-text-input
+            bordered={false}
+            disabled={this.disabled}
+            inputId={this.inputId}
+            inputTabIndex={this.inputTabIndex}
+            name={this.name}
+            onInputBlur={this.handleBlur}
+            onInputChange={this.handleChange}
+            onInputFocus={this.handleFocus}
+            placeholder={this.placeholder}
+            readOnly={this.readOnly}
+            required={this.required}
+            size={this.size}
+            value={this.value}
+            {...this.inheritedAttributes}
+          />
+        </div>
         {this.menuVisible && (
           <modus-wc-menu aria-label="Autocomplete menu" size={this.size}>
             {getMenuItems()}

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -13,9 +13,17 @@ import { ModusSize } from '../../types';
 import { Attributes, inheritAriaAttributes } from '../../utils';
 
 export interface IAutocompleteItem {
+  /** The display text shown for the autocomplete item */
   label: string;
+
+  /** Whether the item is currently selected */
   selected?: boolean;
+
+  /** The unique value identifier for the item */
   value: string;
+
+  /** Whether the item should be shown in the dropdown menu */
+  visibleInMenu: boolean;
 }
 
 /**
@@ -61,11 +69,17 @@ export class ModusWcAutocomplete {
   /** Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). */
   @Prop() inputTabIndex?: number;
 
-  /** The items to display in the menu. */
+  /**
+   * The items to display in the menu.
+   * Creating a new array of items will ensure proper component re-render.
+   **/
   @Prop() items: IAutocompleteItem[] = [];
 
   /** The minimum number of characters required to render the menu. */
   @Prop() minChars: number = 0;
+
+  /** Whether the input allows multiple items to be selected.  */
+  @Prop() multiSelect?: boolean = false;
 
   /** Name of the form control. Submitted with the form as part of a name/value pair. */
   @Prop() name?: string;
@@ -195,7 +209,7 @@ export class ModusWcAutocomplete {
       // istanbul ignore next
       return (
         <Fragment>
-          {selectedItems.map((item) => (
+          {selectedItems?.map((item) => (
             <div class="chip">
               <modus-wc-button
                 aria-label="Remove item button"
@@ -213,13 +227,34 @@ export class ModusWcAutocomplete {
       );
     };
 
+    const getInput = () => (
+      <modus-wc-text-input
+        bordered={this.bordered && !this.multiSelect}
+        disabled={this.disabled}
+        inputId={this.inputId}
+        inputTabIndex={this.inputTabIndex}
+        name={this.name}
+        onInputBlur={this.handleBlur}
+        onInputChange={this.handleChange}
+        onInputFocus={this.handleFocus}
+        placeholder={this.placeholder}
+        readOnly={this.readOnly}
+        required={this.required}
+        size={this.size}
+        value={this.value}
+        {...this.inheritedAttributes}
+      />
+    );
+
     // TODO - to improve flexibility, allow users to pass their own `<modus-wc-menu-item>` elements
     // TODO - add code coverage once autocomplete is updated
     // istanbul ignore next
     const getMenuItems = () => {
+      const menuItems = this.items.filter((item) => item.visibleInMenu);
+
       return (
         <Fragment>
-          {this.items.map((item) => (
+          {menuItems.map((item) => (
             <modus-wc-menu-item
               label={item.label}
               onItemSelect={() => this.handleItemSelect(item)}
@@ -233,29 +268,22 @@ export class ModusWcAutocomplete {
 
     return (
       <Host class={this.getClasses()} dir={this.inputDir}>
-        <div
-          class={`modus-wc-autocomplete-top ${this.bordered ? 'modus-wc-autocomplete-top--bordered' : ''}`}
-        >
-          {getChips()}
-          <modus-wc-text-input
-            bordered={false}
-            disabled={this.disabled}
-            inputId={this.inputId}
-            inputTabIndex={this.inputTabIndex}
-            name={this.name}
-            onInputBlur={this.handleBlur}
-            onInputChange={this.handleChange}
-            onInputFocus={this.handleFocus}
-            placeholder={this.placeholder}
-            readOnly={this.readOnly}
-            required={this.required}
-            size={this.size}
-            value={this.value}
-            {...this.inheritedAttributes}
-          />
-        </div>
+        {this.multiSelect ? (
+          <div
+            class={`modus-wc-autocomplete-multi-select ${this.bordered ? 'modus-wc-autocomplete-multi-select--bordered' : ''}`}
+          >
+            {getChips()}
+            {getInput()}
+          </div>
+        ) : (
+          <Fragment>{getInput()}</Fragment>
+        )}
         {this.menuVisible && (
-          <modus-wc-menu aria-label="Autocomplete menu" size={this.size}>
+          <modus-wc-menu
+            aria-label="Autocomplete menu"
+            bordered={this.bordered}
+            size={this.size}
+          >
             {getMenuItems()}
           </modus-wc-menu>
         )}

--- a/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/molecules/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -180,6 +180,8 @@ export class ModusWcAutocomplete {
     this.itemSelect.emit(item);
   };
 
+  // TODO - add code coverage once chip component is implemented
+  // istanbul ignore next
   private handleChipRemove = (item: IAutocompleteItem) => {
     this.chipRemove.emit(item);
   };
@@ -188,7 +190,9 @@ export class ModusWcAutocomplete {
     const getChips = () => {
       const selectedItems = this.items.filter((item) => item.selected);
 
-      // TODO - use `<modus-wc-chip>` elements once completed
+      // TODO - use chip component
+      // TODO - add code coverage once chip component is implemented
+      // istanbul ignore next
       return (
         <Fragment>
           {selectedItems.map((item) => (

--- a/src/components/molecules/modus-wc-autocomplete/readme.md
+++ b/src/components/molecules/modus-wc-autocomplete/readme.md
@@ -13,30 +13,30 @@ Adheres to WCAG 2.2 standards.
 
 ## Properties
 
-| Property          | Attribute           | Description                                                                                             | Type                                          | Default     |
-| ----------------- | ------------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
-| `activeItemValue` | `active-item-value` | The active menu item value, used to show an item as selected.                                           | `string \| undefined`                         | `undefined` |
-| `bordered`        | `bordered`          | Indicates that the autocomplete should have a border.                                                   | `boolean \| undefined`                        | `true`      |
-| `customClass`     | `custom-class`      | Custom CSS class to apply to host element.                                                              | `string \| undefined`                         | `''`        |
-| `debounceMs`      | `debounce-ms`       | The debounce timeout in milliseconds. Set to 0 to disable debouncing.                                   | `number \| undefined`                         | `300`       |
-| `disabled`        | `disabled`          | Whether the form control is disabled.                                                                   | `boolean \| undefined`                        | `false`     |
-| `inputDir`        | `input-dir`         | Specifies the text direction of the input content.                                                      | `"" \| "auto" \| "ltr" \| "rtl" \| undefined` | `undefined` |
-| `inputId`         | `input-id`          | The ID of the input element.                                                                            | `string \| undefined`                         | `undefined` |
-| `inputTabIndex`   | `input-tab-index`   | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`                         | `undefined` |
-| `items`           | --                  | The items to display in the menu.                                                                       | `IAutocompleteItem[]`                         | `[]`        |
-| `minChars`        | `min-chars`         | The minimum number of characters required to render the menu.                                           | `number`                                      | `0`         |
-| `name`            | `name`              | Name of the form control. Submitted with the form as part of a name/value pair.                         | `string \| undefined`                         | `undefined` |
-| `placeholder`     | `placeholder`       | Text that appears in the form control when it has no value set.                                         | `string \| undefined`                         | `''`        |
-| `readOnly`        | `read-only`         | Whether the value is editable.                                                                          | `boolean \| undefined`                        | `false`     |
-| `required`        | `required`          | A value is required for the form to be submittable.                                                     | `boolean \| undefined`                        | `false`     |
-| `size`            | `size`              | The size of the autocomplete (input and menu).                                                          | `"lg" \| "md" \| "sm" \| undefined`           | `'md'`      |
-| `value`           | `value`             | The value of the control.                                                                               | `string`                                      | `''`        |
+| Property        | Attribute         | Description                                                                                             | Type                                          | Default     |
+| --------------- | ----------------- | ------------------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `bordered`      | `bordered`        | Indicates that the autocomplete should have a border.                                                   | `boolean \| undefined`                        | `true`      |
+| `customClass`   | `custom-class`    | Custom CSS class to apply to host element.                                                              | `string \| undefined`                         | `''`        |
+| `debounceMs`    | `debounce-ms`     | The debounce timeout in milliseconds. Set to 0 to disable debouncing.                                   | `number \| undefined`                         | `300`       |
+| `disabled`      | `disabled`        | Whether the form control is disabled.                                                                   | `boolean \| undefined`                        | `false`     |
+| `inputDir`      | `input-dir`       | Specifies the text direction of the input content.                                                      | `"" \| "auto" \| "ltr" \| "rtl" \| undefined` | `undefined` |
+| `inputId`       | `input-id`        | The ID of the input element.                                                                            | `string \| undefined`                         | `undefined` |
+| `inputTabIndex` | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`                         | `undefined` |
+| `items`         | --                | The items to display in the menu.                                                                       | `IAutocompleteItem[]`                         | `[]`        |
+| `minChars`      | `min-chars`       | The minimum number of characters required to render the menu.                                           | `number`                                      | `0`         |
+| `name`          | `name`            | Name of the form control. Submitted with the form as part of a name/value pair.                         | `string \| undefined`                         | `undefined` |
+| `placeholder`   | `placeholder`     | Text that appears in the form control when it has no value set.                                         | `string \| undefined`                         | `''`        |
+| `readOnly`      | `read-only`       | Whether the value is editable.                                                                          | `boolean \| undefined`                        | `false`     |
+| `required`      | `required`        | A value is required for the form to be submittable.                                                     | `boolean \| undefined`                        | `false`     |
+| `size`          | `size`            | The size of the autocomplete (input and menu).                                                          | `"lg" \| "md" \| "sm" \| undefined`           | `'md'`      |
+| `value`         | `value`           | The value of the control.                                                                               | `string`                                      | `''`        |
 
 
 ## Events
 
 | Event         | Description                                                                                       | Type                             |
 | ------------- | ------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `chipRemove`  | Event emitted when a selected item chip is removed.                                               | `CustomEvent<IAutocompleteItem>` |
 | `inputBlur`   | Event emitted when the input loses focus.                                                         | `CustomEvent<FocusEvent>`        |
 | `inputChange` | Event emitted when the input value changes. This event is debounced based on the debounceMs prop. | `CustomEvent<Event>`             |
 | `inputFocus`  | Event emitted when the input gains focus.                                                         | `CustomEvent<FocusEvent>`        |
@@ -47,6 +47,8 @@ Adheres to WCAG 2.2 standards.
 
 ### Depends on
 
+- [modus-wc-button](../../atoms/modus-wc-button)
+- [modus-wc-icon](../../atoms/modus-wc-icon)
 - [modus-wc-menu-item](../../atoms/modus-wc-menu-item)
 - [modus-wc-text-input](../../atoms/modus-wc-text-input)
 - [modus-wc-menu](../../atoms/modus-wc-menu)
@@ -54,6 +56,8 @@ Adheres to WCAG 2.2 standards.
 ### Graph
 ```mermaid
 graph TD;
+  modus-wc-autocomplete --> modus-wc-button
+  modus-wc-autocomplete --> modus-wc-icon
   modus-wc-autocomplete --> modus-wc-menu-item
   modus-wc-autocomplete --> modus-wc-text-input
   modus-wc-autocomplete --> modus-wc-menu

--- a/src/components/molecules/modus-wc-autocomplete/readme.md
+++ b/src/components/molecules/modus-wc-autocomplete/readme.md
@@ -22,8 +22,9 @@ Adheres to WCAG 2.2 standards.
 | `inputDir`      | `input-dir`       | Specifies the text direction of the input content.                                                      | `"" \| "auto" \| "ltr" \| "rtl" \| undefined` | `undefined` |
 | `inputId`       | `input-id`        | The ID of the input element.                                                                            | `string \| undefined`                         | `undefined` |
 | `inputTabIndex` | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`                         | `undefined` |
-| `items`         | --                | The items to display in the menu.                                                                       | `IAutocompleteItem[]`                         | `[]`        |
+| `items`         | --                | The items to display in the menu. Creating a new array of items will ensure proper component re-render. | `IAutocompleteItem[]`                         | `[]`        |
 | `minChars`      | `min-chars`       | The minimum number of characters required to render the menu.                                           | `number`                                      | `0`         |
+| `multiSelect`   | `multi-select`    | Whether the input allows multiple items to be selected.                                                 | `boolean \| undefined`                        | `false`     |
 | `name`          | `name`            | Name of the form control. Submitted with the form as part of a name/value pair.                         | `string \| undefined`                         | `undefined` |
 | `placeholder`   | `placeholder`     | Text that appears in the form control when it has no value set.                                         | `string \| undefined`                         | `''`        |
 | `readOnly`      | `read-only`       | Whether the value is editable.                                                                          | `boolean \| undefined`                        | `false`     |
@@ -49,8 +50,8 @@ Adheres to WCAG 2.2 standards.
 
 - [modus-wc-button](../../atoms/modus-wc-button)
 - [modus-wc-icon](../../atoms/modus-wc-icon)
-- [modus-wc-menu-item](../../atoms/modus-wc-menu-item)
 - [modus-wc-text-input](../../atoms/modus-wc-text-input)
+- [modus-wc-menu-item](../../atoms/modus-wc-menu-item)
 - [modus-wc-menu](../../atoms/modus-wc-menu)
 
 ### Graph
@@ -58,8 +59,8 @@ Adheres to WCAG 2.2 standards.
 graph TD;
   modus-wc-autocomplete --> modus-wc-button
   modus-wc-autocomplete --> modus-wc-icon
-  modus-wc-autocomplete --> modus-wc-menu-item
   modus-wc-autocomplete --> modus-wc-text-input
+  modus-wc-autocomplete --> modus-wc-menu-item
   modus-wc-autocomplete --> modus-wc-menu
   modus-wc-menu-item --> modus-wc-icon
   style modus-wc-autocomplete fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -3346,7 +3346,7 @@
               "type": {
                 "text": "IAutocompleteItem[]"
               },
-              "description": "The items to display in the menu."
+              "description": "It's important to create a new array when updating 'items' to ensure proper component re-rendering."
             },
             {
               "name": "min-chars",
@@ -3355,6 +3355,14 @@
                 "text": "number"
               },
               "description": "The minimum number of characters required to render the menu."
+            },
+            {
+              "name": "multi-select",
+              "fieldName": "multiSelect",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Whether the input allows multiple items to be selected."
             },
             {
               "name": "name",

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -3346,7 +3346,7 @@
               "type": {
                 "text": "IAutocompleteItem[]"
               },
-              "description": "It's important to create a new array when updating 'items' to ensure proper component re-rendering."
+              "description": "The items to display in the menu.\r\nCreating a new array of items will ensure proper component re-render."
             },
             {
               "name": "min-chars",

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1148,6 +1148,14 @@
           ],
           "attributes": [
             {
+              "name": "bordered",
+              "fieldName": "bordered",
+              "type": {
+                "text": "boolean"
+              },
+              "description": "Indicates that the menu should have a border."
+            },
+            {
               "name": "custom-class",
               "fieldName": "customClass",
               "type": {
@@ -3277,14 +3285,6 @@
           ],
           "attributes": [
             {
-              "name": "active-item-value",
-              "fieldName": "activeItemValue",
-              "type": {
-                "text": "string"
-              },
-              "description": "The active menu item value, used to show an item as selected."
-            },
-            {
               "name": "bordered",
               "fieldName": "bordered",
               "type": {
@@ -3407,6 +3407,14 @@
           ],
           "tagName": "modus-wc-autocomplete",
           "events": [
+            {
+              "kind": "field",
+              "name": "chipRemove",
+              "type": {
+                "text": "EventEmitter<IAutocompleteItem>"
+              },
+              "description": "Event emitted when a selected item chip is removed."
+            },
             {
               "kind": "field",
               "name": "inputBlur",

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -54,9 +54,15 @@
   --modus-wc-in-field-black: #000;
 
   // Borders
+  --modus-wc-border-width-xs: 1px;
+  --modus-wc-border-width-sm: 2px;
+  --modus-wc-border-width-md: 3px;
+  --modus-wc-border-width-lg: 4px;
+
   --modus-wc-border-radius-sm: 2px;
   --modus-wc-border-radius-md: 4px;
   --modus-wc-border-radius-lg: 8px;
+  --modus-wc-border-radius-xl: 12px;
 
   // Line heights
   --modus-wc-line-height-xs: 0.5rem;


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR updates the autocomplete component to allow multi-select. It does so using temporary chip components. These will be replaced and coverage added once the official `Chip` component is complete.

There is still a lot of work to do to complete the autocomplete, this is not the final version.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Added and updated unit tests

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)
