### PR TITLE
feat: use single slot for button content and apply modus styling

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -224,6 +224,7 @@ export namespace Components {
     }
     /**
      * A customizable button component used to create buttons with different sizes, variants, and types.
+     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
      * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcButton {
@@ -243,10 +244,6 @@ export namespace Components {
           * If true, the button will take the full width of its container.
          */
         "fullWidth"?: boolean;
-        /**
-          * The text label displayed on the button.
-         */
-        "label"?: string;
         /**
           * If true, the button will be in a pressed state (for toggle buttons).
          */
@@ -1506,6 +1503,7 @@ declare global {
     }
     /**
      * A customizable button component used to create buttons with different sizes, variants, and types.
+     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
      * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcButtonElement extends Components.ModusWcButton, HTMLStencilElement {
@@ -2269,6 +2267,7 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable button component used to create buttons with different sizes, variants, and types.
+     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
      * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcButton {
@@ -2288,10 +2287,6 @@ declare namespace LocalJSX {
           * If true, the button will take the full width of its container.
          */
         "fullWidth"?: boolean;
-        /**
-          * The text label displayed on the button.
-         */
-        "label"?: string;
         /**
           * Event emitted when the button is clicked or activated via keyboard.
          */
@@ -3611,6 +3606,7 @@ declare module "@stencil/core" {
             "modus-wc-breadcrumbs": LocalJSX.ModusWcBreadcrumbs & JSXBase.HTMLAttributes<HTMLModusWcBreadcrumbsElement>;
             /**
              * A customizable button component used to create buttons with different sizes, variants, and types.
+             * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
              * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-button": LocalJSX.ModusWcButton & JSXBase.HTMLAttributes<HTMLModusWcButtonElement>;

--- a/src/components/atoms/modus-wc-button/__snapshots__/modus-wc-button.spec.ts.snap
+++ b/src/components/atoms/modus-wc-button/__snapshots__/modus-wc-button.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-button should render with custom props 1`] = `
-<modus-wc-button color="secondary" custom-class="test-class" full-width="true" label="Test" pressed="true" size="lg" type="submit" variant="outlined">
+<modus-wc-button color="secondary" custom-class="test-class" full-width="true" pressed="true" size="lg" type="submit" variant="outlined">
   <!---->
   <button aria-label="Custom Button" aria-pressed="true" class="modus-wc-btn modus-wc-btn-block modus-wc-btn-lg modus-wc-btn-outline modus-wc-btn-secondary test-class" tabindex="0" type="submit">
     Test
@@ -12,7 +12,8 @@ exports[`modus-wc-button should render with custom props 1`] = `
 exports[`modus-wc-button should render with default props 1`] = `
 <modus-wc-button>
   <!---->
-  <button aria-label="Default Button" class="modus-wc-btn modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
+  <button aria-label="Default Button" class="modus-wc-btn modus-wc-btn-filled modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
+    Test
   </button>
 </modus-wc-button>
 `;
@@ -20,7 +21,8 @@ exports[`modus-wc-button should render with default props 1`] = `
 exports[`modus-wc-button should render with disabled attribute 1`] = `
 <modus-wc-button disabled="true">
   <!---->
-  <button aria-label="Custom Button" class="modus-wc-btn modus-wc-btn-disabled modus-wc-btn-md modus-wc-btn-primary" disabled="" tabindex="-1" type="button">
+  <button aria-label="Custom Button" class="modus-wc-btn modus-wc-btn-disabled modus-wc-btn-filled modus-wc-btn-md modus-wc-btn-primary" disabled="" tabindex="-1" type="button">
+    Test
   </button>
 </modus-wc-button>
 `;

--- a/src/components/atoms/modus-wc-button/modus-wc-button.scss
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.scss
@@ -55,7 +55,8 @@
   }
 
   &.modus-wc-btn-outline {
-    border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-trimble-gray);
+    border: var(--modus-wc-border-width-xs) solid
+      var(--modus-wc-color-trimble-gray);
     background-color: transparent;
   }
 }

--- a/src/components/atoms/modus-wc-button/modus-wc-button.scss
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.scss
@@ -3,47 +3,417 @@
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
 
-.modus-wc-btn {
-  --rounded-btn: var(--modus-wc-border-radius-lg);
+[data-theme='modus-classic-light'] .modus-wc-btn,
+[data-theme='modus-classic-dark'] .modus-wc-btn {
+  --rounded-btn: var(--modus-wc-border-radius-md);
+  border: none;
+  outline: none;
 
+  // Allow Daisy to style circle and square shapes
+  &:not(.modus-wc-btn-circle):not(.modus-wc-btn-square) {
+    height: fit-content;
+    min-height: fit-content;
+  }
+
+  // Sizes
+  &.modus-wc-btn-xs {
+    font-size: var(--modus-wc-font-size-xs);
+
+    &:not(.modus-wc-btn-circle):not(.modus-wc-btn-square) {
+      padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-sm);
+    }
+  }
+
+  &.modus-wc-btn-sm {
+    font-size: var(--modus-wc-font-size-sm);
+
+    &:not(.modus-wc-btn-circle):not(.modus-wc-btn-square) {
+      padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-md);
+    }
+  }
+
+  &.modus-wc-btn-md {
+    font-size: var(--modus-wc-font-size-md);
+
+    &:not(.modus-wc-btn-circle):not(.modus-wc-btn-square) {
+      padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-lg);
+    }
+  }
+
+  &.modus-wc-btn-lg {
+    font-size: var(--modus-wc-font-size-lg);
+
+    &:not(.modus-wc-btn-circle):not(.modus-wc-btn-square) {
+      padding: var(--modus-wc-spacing-lg) var(--modus-wc-spacing-xl);
+    }
+  }
+
+  // Variants
   &.modus-wc-btn-borderless {
-    --tw-bg-opacity: 0;
-
-    border: none;
+    background-color: transparent;
     box-shadow: none;
+  }
 
+  &.modus-wc-btn-outline {
+    border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-trimble-gray);
+    background-color: transparent;
+  }
+}
+
+[data-theme='modus-classic-light'] .modus-wc-btn {
+  &.modus-wc-btn-disabled {
+    opacity: 0.3;
+  }
+
+  // Variants
+  &.modus-wc-btn-borderless {
+    // Colors
     &.modus-wc-btn-primary {
-      color: var(--modus-wc-color-primary);
+      color: var(--modus-wc-color-trimble-blue);
     }
 
     &.modus-wc-btn-secondary {
-      color: var(--modus-wc-color-accent);
+      color: var(--modus-wc-color-gray-6);
     }
 
+    // tertiary
     &.modus-wc-btn-neutral {
-      color: var(--modus-wc-color-neutral);
+      color: var(--modus-wc-color-gray-1);
     }
 
     &.modus-wc-btn-warning {
-      color: var(--modus-wc-color-warning);
+      color: var(--modus-wc-color-yellow);
     }
 
     &.modus-wc-btn-error {
-      color: var(--modus-wc-color-error);
+      color: var(--modus-wc-color-red);
+    }
+  }
+
+  &.modus-wc-btn-filled {
+    // Colors
+    &.modus-wc-btn-primary {
+      color: var(--modus-wc-color-white);
+      background-color: var(--modus-wc-color-trimble-blue);
+
+      &:hover {
+        background-color: var(--modus-wc-color-blue-light);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-blue-dark);
+      }
     }
 
-    &:hover {
-      --tw-bg-opacity: 0.05;
+    &.modus-wc-btn-secondary {
+      color: var(--modus-wc-color-white);
+      background-color: var(--modus-wc-color-gray-6);
 
-      border: none;
-      box-shadow: none;
+      &:hover {
+        background-color: var(--modus-wc-color-gray-5);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-gray-7);
+      }
     }
 
-    &:active {
-      --tw-bg-opacity: 0.1;
+    // tertiary
+    &.modus-wc-btn-neutral {
+      color: var(--modus-wc-color-trimble-gray);
+      background-color: var(--modus-wc-color-gray-1);
 
-      border: none;
-      box-shadow: none;
+      &:hover {
+        background-color: var(--modus-wc-color-gray-0);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-gray-2);
+      }
+    }
+
+    &.modus-wc-btn-warning {
+      color: var(--modus-wc-color-trimble-gray);
+      background-color: var(--modus-wc-color-yellow);
+
+      &:hover {
+        background-color: var(--modus-wc-color-yellow-light);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-yellow-dark);
+      }
+    }
+
+    &.modus-wc-btn-error {
+      color: var(--modus-wc-color-white);
+      background-color: var(--modus-wc-color-red);
+
+      &:hover {
+        background-color: var(--modus-wc-color-red-light);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-red-dark);
+      }
+    }
+  }
+
+  &.modus-wc-btn-outline {
+    // Colors
+    &.modus-wc-btn-primary {
+      color: var(--modus-wc-color-trimble-blue);
+      border-color: var(--modus-wc-color-trimble-blue);
+
+      &:hover {
+        color: var(--modus-wc-color-blue-light);
+        border-color: var(--modus-wc-color-blue-light);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-blue-dark);
+        border-color: var(--modus-wc-color-blue-dark);
+      }
+    }
+
+    &.modus-wc-btn-secondary {
+      color: var(--modus-wc-color-gray-6);
+      border-color: var(--modus-wc-color-gray-6);
+
+      &:hover {
+        color: var(--modus-wc-color-gray-5);
+        border-color: var(--modus-wc-color-gray-5);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-gray-7);
+        border-color: var(--modus-wc-color-gray-7);
+      }
+    }
+
+    // tertiary
+    &.modus-wc-btn-neutral {
+      color: var(--modus-wc-color-gray-1);
+      border-color: var(--modus-wc-color-gray-1);
+
+      &:hover {
+        color: var(--modus-wc-color-gray-0);
+        border-color: var(--modus-wc-color-gray-0);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-gray-2);
+        border-color: var(--modus-wc-color-gray-2);
+      }
+    }
+
+    &.modus-wc-btn-warning {
+      color: var(--modus-wc-color-yellow);
+      border-color: var(--modus-wc-color-yellow);
+
+      &:hover {
+        color: var(--modus-wc-color-yellow-light);
+        border-color: var(--modus-wc-color-yellow-light);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-yellow-dark);
+        border-color: var(--modus-wc-color-yellow-dark);
+      }
+    }
+
+    &.modus-wc-btn-error {
+      color: var(--modus-wc-color-red);
+      border-color: var(--modus-wc-color-red);
+
+      &:hover {
+        color: var(--modus-wc-color-red-light);
+        border-color: var(--modus-wc-color-red-light);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-red-dark);
+        border-color: var(--modus-wc-color-red-dark);
+      }
+    }
+  }
+}
+
+[data-theme='modus-classic-dark'] .modus-wc-btn {
+  &.modus-wc-btn-disabled {
+    opacity: 0.4;
+  }
+
+  // Variants
+  &.modus-wc-btn-borderless {
+    // Colors
+    &.modus-wc-btn-primary {
+      color: var(--modus-wc-color-highlight-blue);
+    }
+
+    &.modus-wc-btn-secondary {
+      color: var(--modus-wc-color-gray-6);
+    }
+
+    // tertiary
+    &.modus-wc-btn-neutral {
+      color: var(--modus-wc-color-gray-1);
+    }
+
+    &.modus-wc-btn-warning {
+      color: var(--modus-wc-color-yellow);
+    }
+
+    &.modus-wc-btn-error {
+      color: var(--modus-wc-color-red);
+    }
+  }
+
+  &.modus-wc-btn-filled {
+    // Colors
+    &.modus-wc-btn-primary {
+      color: var(--modus-wc-color-gray-10);
+      background-color: var(--modus-wc-color-highlight-blue);
+
+      &:hover {
+        background-color: var(--modus-wc-color-blue-light);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-blue-dark);
+      }
+    }
+
+    &.modus-wc-btn-secondary {
+      color: var(--modus-wc-color-white);
+      background-color: var(--modus-wc-color-gray-6);
+
+      &:hover {
+        background-color: var(--modus-wc-color-gray-5);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-gray-7);
+      }
+    }
+
+    // tertiary
+    &.modus-wc-btn-neutral {
+      color: var(--modus-wc-color-trimble-gray);
+      background-color: var(--modus-wc-color-gray-1);
+
+      &:hover {
+        background-color: var(--modus-wc-color-gray-0);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-gray-4);
+      }
+    }
+
+    &.modus-wc-btn-warning {
+      color: var(--modus-wc-color-trimble-gray);
+      background-color: var(--modus-wc-color-yellow);
+
+      &:hover {
+        background-color: var(--modus-wc-color-yellow-light);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-yellow-dark);
+      }
+    }
+
+    &.modus-wc-btn-error {
+      color: var(--modus-wc-color-white);
+      background-color: var(--modus-wc-color-red);
+
+      &:hover {
+        background-color: var(--modus-wc-color-red-light);
+      }
+
+      &:active {
+        background-color: var(--modus-wc-color-red-dark);
+      }
+    }
+  }
+
+  &.modus-wc-btn-outline {
+    // Colors
+    &.modus-wc-btn-primary {
+      color: var(--modus-wc-color-highlight-blue);
+      border-color: var(--modus-wc-color-highlight-blue);
+
+      &:hover {
+        color: var(--modus-wc-color-blue-light);
+        border-color: var(--modus-wc-color-blue-light);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-blue-dark);
+        border-color: var(--modus-wc-color-blue-dark);
+      }
+    }
+
+    &.modus-wc-btn-secondary {
+      color: var(--modus-wc-color-gray-6);
+      border-color: var(--modus-wc-color-gray-6);
+
+      &:hover {
+        color: var(--modus-wc-color-gray-5);
+        border-color: var(--modus-wc-color-gray-5);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-gray-7);
+        border-color: var(--modus-wc-color-gray-7);
+      }
+    }
+
+    // tertiary
+    &.modus-wc-btn-neutral {
+      color: var(--modus-wc-color-gray-1);
+      border-color: var(--modus-wc-color-gray-1);
+
+      &:hover {
+        color: var(--modus-wc-color-gray-0);
+        border-color: var(--modus-wc-color-gray-0);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-gray-2);
+        border-color: var(--modus-wc-color-gray-4);
+      }
+    }
+
+    &.modus-wc-btn-warning {
+      color: var(--modus-wc-color-yellow);
+      border-color: var(--modus-wc-color-yellow);
+
+      &:hover {
+        color: var(--modus-wc-color-yellow-light);
+        border-color: var(--modus-wc-color-yellow-light);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-yellow-dark);
+        border-color: var(--modus-wc-color-yellow-dark);
+      }
+    }
+
+    &.modus-wc-btn-error {
+      color: var(--modus-wc-color-red);
+      border-color: var(--modus-wc-color-red);
+
+      &:hover {
+        color: var(--modus-wc-color-red-light);
+        border-color: var(--modus-wc-color-red-light);
+      }
+
+      &:active {
+        color: var(--modus-wc-color-red-dark);
+        border-color: var(--modus-wc-color-red-dark);
+      }
     }
   }
 }

--- a/src/components/atoms/modus-wc-button/modus-wc-button.spec.ts
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.spec.ts
@@ -20,7 +20,7 @@ describe('modus-wc-button', () => {
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcButton],
-      html: '<modus-wc-button aria-label="Default Button"></modus-wc-button>',
+      html: '<modus-wc-button aria-label="Default Button">Test</modus-wc-button>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -28,7 +28,17 @@ describe('modus-wc-button', () => {
   it('should render with custom props', async () => {
     const page = await newSpecPage({
       components: [ModusWcButton],
-      html: '<modus-wc-button aria-label="Custom Button" color="secondary" custom-class="test-class" full-width="true" label="Test" pressed="true" size="lg" variant="outlined" type="submit"></modus-wc-button>',
+      html: `<modus-wc-button 
+              aria-label="Custom Button" 
+              color="secondary" 
+              custom-class="test-class" 
+              full-width="true" 
+              pressed="true" 
+              size="lg" 
+              variant="outlined" 
+              type="submit">
+              Test
+            </modus-wc-button>`,
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -36,7 +46,7 @@ describe('modus-wc-button', () => {
   it('should render with disabled attribute', async () => {
     const page = await newSpecPage({
       components: [ModusWcButton],
-      html: '<modus-wc-button aria-label="Custom Button" disabled="true"></modus-wc-button>',
+      html: '<modus-wc-button aria-label="Custom Button" disabled="true">Test</modus-wc-button>',
     });
     expect(page.root).toMatchSnapshot();
   });

--- a/src/components/atoms/modus-wc-button/modus-wc-button.stories.ts
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.stories.ts
@@ -5,12 +5,10 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { DaisySize } from '../../types';
 
 interface ButtonArgs {
-  'aria-label': string;
   color: 'primary' | 'secondary' | 'tertiary' | 'warning' | 'danger';
   'custom-class'?: string;
   disabled: boolean;
   'full-width': boolean;
-  label: string;
   pressed: boolean;
   shape: 'circle' | 'rectangle' | 'square';
   size: DaisySize;
@@ -22,11 +20,9 @@ const meta: Meta<ButtonArgs> = {
   title: 'Components/Button',
   component: 'modus-wc-button',
   args: {
-    'aria-label': 'Click me button',
     color: 'primary',
     disabled: false,
     'full-width': false,
-    label: 'Click me',
     pressed: false,
     shape: 'rectangle',
     size: 'md',
@@ -35,23 +31,23 @@ const meta: Meta<ButtonArgs> = {
   },
   argTypes: {
     color: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: ['primary', 'secondary', 'tertiary', 'warning', 'danger'],
     },
     shape: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: ['circle', 'rectangle', 'square'],
     },
     size: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: ['xs', 'sm', 'md', 'lg'],
     },
     type: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: ['button', 'submit', 'reset'],
     },
     variant: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: ['borderless', 'filled', 'outlined'],
     },
   },
@@ -69,20 +65,22 @@ type Story = StoryObj<ButtonArgs>;
 
 const Template: Story = {
   render: (args) => {
+    // prettier-ignore
     return html`
-      <modus-wc-button
-        aria-label="${args['aria-label']}"
-        color="${args.color}"
-        custom-class="${ifDefined(args['custom-class'])}"
-        ?disabled="${args.disabled}"
-        ?full-width="${args['full-width']}"
-        label="${args.label}"
-        ?pressed="${args.pressed}"
-        shape="${args.shape}"
-        size="${args.size}"
-        type="${args.type}"
-        variant="${args.variant}"
-      ></modus-wc-button>
+<modus-wc-button
+  aria-label="Click me button"
+  color="${args.color}"
+  custom-class="${ifDefined(args['custom-class'])}"
+  ?disabled="${args.disabled}"
+  ?full-width="${args['full-width']}"
+  ?pressed="${args.pressed}"
+  shape="${args.shape}"
+  size="${args.size}"
+  type="${args.type}"
+  variant="${args.variant}"
+>
+  Click me
+</modus-wc-button>
     `;
   },
 };
@@ -91,64 +89,69 @@ export const Default: Story = {
   ...Template,
 };
 
-// prettier-ignore
 export const ButtonShapes: Story = {
-  render: (args) => {
+  render: () => {
+    // prettier-ignore
     return html`
 <modus-wc-button
-  aria-label="${args['aria-label']}"
-  label="Click me"
+  aria-label="Circle button"
   shape="circle"
-></modus-wc-button>
+>
+  Circle
+</modus-wc-button>
 <modus-wc-button
-  aria-label="${args['aria-label']}"
-  label="Click me"
+  aria-label="Square button"
   shape="square"
-></modus-wc-button>
+>
+  Square
+</modus-wc-button>
     `;
   },
 };
 
-// prettier-ignore
 export const IconOnlyButton: Story = {
   render: () => {
+    // prettier-ignore
     return html`
-<modus-wc-button aria-label="notification button">
-  <modus-wc-icon aria-label="notify icon" decorative name="notifications"></modus-wc-icon>
+<modus-wc-button aria-label="Notification button">
+  <modus-wc-icon decorative name="notifications"></modus-wc-icon>
 </modus-wc-button>
     `;
   },
 };
 
-// prettier-ignore
 export const IconLeftButton: Story = {
   render: () => {
+    // prettier-ignore
     return html`
-<modus-wc-button aria-label="download button" label="Download">
-  <modus-wc-icon aria-label="download icon" decorative name="download" slot="left"></modus-wc-icon>
+<modus-wc-button aria-label="Download button">
+  <modus-wc-icon decorative name="download"></modus-wc-icon>
+  Download
 </modus-wc-button>
     `;
   },
 };
 
-// prettier-ignore
 export const IconRightButton: Story = {
   render: () => {
+    // prettier-ignore
     return html`
-<modus-wc-button aria-label="details button" label="Details">
-  <modus-wc-icon aria-label="launch icon" decorative name="launch" slot="right"></modus-wc-icon>
+<modus-wc-button aria-label="Details button">
+  Details
+  <modus-wc-icon decorative name="launch"></modus-wc-icon>
 </modus-wc-button>
     `;
   },
 };
 
-// prettier-ignore
 export const IconLeftAndRightButton: Story = {
   render: () => {
+    // prettier-ignore
     return html`
-<modus-wc-button aria-label="checkout button" label="Checkout">
-  <modus-wc-icon aria-label="shopping cart icon" decorative name="shopping_cart" slot="left"></modus-wc-icon>
-  <modus-wc-icon aria-label="shopping cart icon" decorative name="shopping_cart" slot="right"></modus-wc-icon>
+<modus-wc-button aria-label="Checkout button">
+  <modus-wc-icon decorative name="shopping_cart"></modus-wc-icon>
+  Checkout
+  <modus-wc-icon decorative name="shopping_cart"></modus-wc-icon>
 </modus-wc-button>
     `;
   },

--- a/src/components/atoms/modus-wc-button/modus-wc-button.tailwind.ts
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.tailwind.ts
@@ -61,11 +61,14 @@ export const convertPropsToClasses = (props: {
 
   if (Object.prototype.hasOwnProperty.call(props, 'variant') && props.variant) {
     switch (props.variant) {
-      case 'outlined':
-        classes = `${classes} modus-wc-btn-outline`;
-        break;
       case 'borderless':
         classes = `${classes} modus-wc-btn-borderless`;
+        break;
+      case 'filled':
+        classes = `${classes} modus-wc-btn-filled`;
+        break;
+      case 'outlined':
+        classes = `${classes} modus-wc-btn-outline`;
         break;
     }
   }

--- a/src/components/atoms/modus-wc-button/modus-wc-button.tsx
+++ b/src/components/atoms/modus-wc-button/modus-wc-button.tsx
@@ -15,6 +15,8 @@ import { Attributes, inheritAriaAttributes, KEY } from '../../utils';
 /**
  * A customizable button component used to create buttons with different sizes, variants, and types.
  *
+ * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
+ *
  * Adheres to WCAG 2.2 standards.
  */
 @Component({
@@ -41,9 +43,6 @@ export class ModusWcButton {
   /** If true, the button will take the full width of its container. */
   @Prop() fullWidth?: boolean = false;
 
-  /** The text label displayed on the button. */
-  @Prop() label?: string;
-
   /** If true, the button will be in a pressed state (for toggle buttons). */
   @Prop() pressed?: boolean = false;
 
@@ -67,7 +66,7 @@ export class ModusWcButton {
       console.warn(
         'ModusWcButton: aria-label is required for accessibility. Using fallback label.'
       );
-      this.el.ariaLabel = this.label || 'Button';
+      this.el.ariaLabel = 'Button';
     }
 
     this.inheritedAttributes = inheritAriaAttributes(this.el);
@@ -124,10 +123,7 @@ export class ModusWcButton {
           type={this.type}
           {...this.inheritedAttributes}
         >
-          <slot name="left" />
           <slot />
-          {this.label}
-          <slot name="right" />
         </button>
       </Host>
     );

--- a/src/components/atoms/modus-wc-button/readme.md
+++ b/src/components/atoms/modus-wc-button/readme.md
@@ -7,6 +7,8 @@
 
 A customizable button component used to create buttons with different sizes, variants, and types.
 
+The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
+
 Adheres to WCAG 2.2 standards.
 
 ## Properties
@@ -17,7 +19,6 @@ Adheres to WCAG 2.2 standards.
 | `customClass` | `custom-class` | Custom CSS class to apply to the button element.                     | `string \| undefined`                                             | `''`          |
 | `disabled`    | `disabled`     | If true, the button will be disabled.                                | `boolean \| undefined`                                            | `false`       |
 | `fullWidth`   | `full-width`   | If true, the button will take the full width of its container.       | `boolean \| undefined`                                            | `false`       |
-| `label`       | `label`        | The text label displayed on the button.                              | `string \| undefined`                                             | `undefined`   |
 | `pressed`     | `pressed`      | If true, the button will be in a pressed state (for toggle buttons). | `boolean \| undefined`                                            | `false`       |
 | `shape`       | `shape`        | The shape of the button.                                             | `"circle" \| "rectangle" \| "square"`                             | `'rectangle'` |
 | `size`        | `size`         | The size of the button.                                              | `"lg" \| "md" \| "sm" \| "xs"`                                    | `'md'`        |

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -234,14 +234,6 @@
               "description": "If true, the button will take the full width of its container."
             },
             {
-              "name": "label",
-              "fieldName": "label",
-              "type": {
-                "text": "string"
-              },
-              "description": "The text label displayed on the button."
-            },
-            {
               "name": "pressed",
               "fieldName": "pressed",
               "type": {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR does the following:
1. Removes specific named slots and `label` prop and replaces them with a single `<slot>`
2. Adds `modus-classic` button styling

I am aware that we are not providing styling for `modus-modern` borderless buttons, this is low priority at the moment.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Unit tests updated

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

