### PR TITLE
feat: replace badge prop with slot and update styling

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -174,6 +174,7 @@ export namespace Components {
     }
     /**
      * A customizable badge component used to create badges with different sizes, types, and colors.
+     * The component supports a `<slot>` for injecting content within the badge.
      * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcBadge {
@@ -187,10 +188,6 @@ export namespace Components {
     | 'success'
     | 'warning'
     | 'danger';
-        /**
-          * The content to display inside the badge. For 'counter' type, this should be a number.
-         */
-        "content": string;
         /**
           * Custom CSS class to apply to the span element.
          */
@@ -1480,6 +1477,7 @@ declare global {
     };
     /**
      * A customizable badge component used to create badges with different sizes, types, and colors.
+     * The component supports a `<slot>` for injecting content within the badge.
      * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcBadgeElement extends Components.ModusWcBadge, HTMLStencilElement {
@@ -2217,6 +2215,7 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable badge component used to create badges with different sizes, types, and colors.
+     * The component supports a `<slot>` for injecting content within the badge.
      * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcBadge {
@@ -2230,10 +2229,6 @@ declare namespace LocalJSX {
     | 'success'
     | 'warning'
     | 'danger';
-        /**
-          * The content to display inside the badge. For 'counter' type, this should be a number.
-         */
-        "content": string;
         /**
           * Custom CSS class to apply to the span element.
          */
@@ -3596,6 +3591,7 @@ declare module "@stencil/core" {
             "modus-wc-avatar": LocalJSX.ModusWcAvatar & JSXBase.HTMLAttributes<HTMLModusWcAvatarElement>;
             /**
              * A customizable badge component used to create badges with different sizes, types, and colors.
+             * The component supports a `<slot>` for injecting content within the badge.
              * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-badge": LocalJSX.ModusWcBadge & JSXBase.HTMLAttributes<HTMLModusWcBadgeElement>;

--- a/src/components/atoms/modus-wc-badge/__snapshots__/modus-wc-badge.spec.ts.snap
+++ b/src/components/atoms/modus-wc-badge/__snapshots__/modus-wc-badge.spec.ts.snap
@@ -2,12 +2,14 @@
 
 exports[`modus-wc-badge should render with alert role 1`] = `
 <modus-wc-badge color="warning">
+  <!---->
   <span class="modus-wc-badge modus-wc-badge-md modus-wc-badge-warning" role="alert" tabindex="-1"></span>
 </modus-wc-badge>
 `;
 
 exports[`modus-wc-badge should render with custom props 1`] = `
-<modus-wc-badge color="secondary" content="Test" custom-class="test-class" size="lg" variant="text">
+<modus-wc-badge color="secondary" custom-class="test-class" size="lg" variant="text">
+  <!---->
   <span class="modus-wc-badge modus-wc-badge-lg modus-wc-badge-secondary modus-wc-badge-text test-class" role="status" tabindex="-1">
     Test
   </span>
@@ -16,6 +18,7 @@ exports[`modus-wc-badge should render with custom props 1`] = `
 
 exports[`modus-wc-badge should render with default props 1`] = `
 <modus-wc-badge>
+  <!---->
   <span class="modus-wc-badge modus-wc-badge-md modus-wc-badge-primary" role="status" tabindex="-1"></span>
 </modus-wc-badge>
 `;

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.scss
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.scss
@@ -21,6 +21,7 @@
     background-color: transparent;
     border: none;
 
+    // Colors
     &.modus-wc-badge-primary {
       color: var(--modus-wc-color-trimble-blue);
     }
@@ -55,10 +56,17 @@
 [data-theme='modus-classic-dark'] .modus-wc-badge {
   &.modus-wc-badge-sm {
     font-size: var(--modus-wc-font-size-xs);
+    padding: var(--modus-wc-spacing-2xs) var(--modus-wc-spacing-xs);
   }
 
   &.modus-wc-badge-md {
     font-size: var(--modus-wc-font-size-sm);
+    padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-sm);
+  }
+
+  &.modus-wc-badge-lg {
+    font-size: var(--modus-wc-font-size-md);
+    padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-md);
   }
 }
 

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.spec.ts
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.spec.ts
@@ -13,7 +13,7 @@ describe('modus-wc-badge', () => {
   it('should render with custom props', async () => {
     const page = await newSpecPage({
       components: [ModusWcBadge],
-      html: '<modus-wc-badge color="secondary" content="Test" custom-class="test-class" size="lg" variant="text"></modus-wc-badge>',
+      html: '<modus-wc-badge color="secondary" custom-class="test-class" size="lg" variant="text">Test</modus-wc-badge>',
     });
     expect(page.root).toMatchSnapshot();
   });

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.stories.ts
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.stories.ts
@@ -12,7 +12,6 @@ interface BadgeArgs {
     | 'success'
     | 'warning'
     | 'danger';
-  content: string;
   'custom-class'?: string;
   size: ModusSize;
   variant: 'counter' | 'filled' | 'text';
@@ -23,7 +22,6 @@ const meta: Meta<BadgeArgs> = {
   component: 'modus-wc-badge',
   args: {
     color: 'primary',
-    content: 'Badge',
     size: 'md',
     variant: 'filled',
   },
@@ -41,11 +39,11 @@ const meta: Meta<BadgeArgs> = {
       ],
     },
     size: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
     },
     variant: {
-      control: { type: 'inline-radio' },
+      control: { type: 'select' },
       options: ['counter', 'filled', 'text'],
     },
   },
@@ -57,18 +55,37 @@ type Story = StoryObj<BadgeArgs>;
 
 const Template: Story = {
   render: (args) => {
+    // prettier-ignore
     return html`
-      <modus-wc-badge
-        color="${args.color}"
-        content="${args.content}"
-        custom-class="${ifDefined(args['custom-class'])}"
-        size="${args.size}"
-        variant="${args.variant}"
-      ></modus-wc-badge>
+<modus-wc-badge
+  color="${args.color}"
+  custom-class="${ifDefined(args['custom-class'])}"
+  size="${args.size}"
+  variant="${args.variant}"
+>
+  Badge
+</modus-wc-badge>
     `;
   },
 };
 
 export const Default: Story = {
   ...Template,
+};
+
+export const WithIcon: Story = {
+  render: () => {
+    // prettier-ignore
+    return html`
+<style>
+  i {
+    padding-inline-end: 4px;
+  }
+</style>
+<modus-wc-badge>
+  <modus-wc-icon decorative name="check" size="xs"></modus-wc-icon>
+  Item
+</modus-wc-badge>
+    `;
+  },
 };

--- a/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
+++ b/src/components/atoms/modus-wc-badge/modus-wc-badge.tsx
@@ -8,6 +8,8 @@ const ALERT_COLORS = ['success', 'warning', 'danger'];
 /**
  * A customizable badge component used to create badges with different sizes, types, and colors.
  *
+ * The component supports a `<slot>` for injecting content within the badge.
+ *
  * Adheres to WCAG 2.2 standards.
  */
 @Component({
@@ -30,9 +32,6 @@ export class ModusWcBadge {
     | 'success'
     | 'warning'
     | 'danger' = 'primary';
-
-  /** The content to display inside the badge. For 'counter' type, this should be a number. */
-  @Prop() content!: string;
 
   /** Custom CSS class to apply to the span element. */
   @Prop() customClass: string = '';
@@ -73,7 +72,7 @@ export class ModusWcBadge {
           tabindex={-1}
           {...this.inheritedAttributes}
         >
-          {this.content}
+          <slot />
         </span>
       </Host>
     );

--- a/src/components/atoms/modus-wc-badge/readme.md
+++ b/src/components/atoms/modus-wc-badge/readme.md
@@ -9,17 +9,18 @@
 
 A customizable badge component used to create badges with different sizes, types, and colors.
 
+The component supports a `<slot>` for injecting content within the badge.
+
 Adheres to WCAG 2.2 standards.
 
 ## Properties
 
-| Property               | Attribute      | Description                                                                           | Type                                                                                              | Default     |
-| ---------------------- | -------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------- |
-| `color`                | `color`        | The color variant of the badge.                                                       | `"danger" \| "high-contrast" \| "primary" \| "secondary" \| "success" \| "tertiary" \| "warning"` | `'primary'` |
-| `content` _(required)_ | `content`      | The content to display inside the badge. For 'counter' type, this should be a number. | `string`                                                                                          | `undefined` |
-| `customClass`          | `custom-class` | Custom CSS class to apply to the span element.                                        | `string`                                                                                          | `''`        |
-| `size`                 | `size`         | The size of the badge.                                                                | `"lg" \| "md" \| "sm"`                                                                            | `'md'`      |
-| `variant`              | `variant`      | The variant of the badge.                                                             | `"counter" \| "filled" \| "text"`                                                                 | `'filled'`  |
+| Property      | Attribute      | Description                                    | Type                                                                                              | Default     |
+| ------------- | -------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------- | ----------- |
+| `color`       | `color`        | The color variant of the badge.                | `"danger" \| "high-contrast" \| "primary" \| "secondary" \| "success" \| "tertiary" \| "warning"` | `'primary'` |
+| `customClass` | `custom-class` | Custom CSS class to apply to the span element. | `string`                                                                                          | `''`        |
+| `size`        | `size`         | The size of the badge.                         | `"lg" \| "md" \| "sm"`                                                                            | `'md'`      |
+| `variant`     | `variant`      | The variant of the badge.                      | `"counter" \| "filled" \| "text"`                                                                 | `'filled'`  |
 
 
 ----------------------------------------------

--- a/src/components/atoms/modus-wc-tooltip/modus-wc-tooltip.stories.ts
+++ b/src/components/atoms/modus-wc-tooltip/modus-wc-tooltip.stories.ts
@@ -40,7 +40,7 @@ const Template: Story = {
         tooltip-id="${ifDefined(args['tooltip-id'])}"
         position=${ifDefined(args.position)}
       >
-        <modus-wc-badge content="Hover"></modus-wc-badge>
+        <modus-wc-badge>Hover</modus-wc-badge>
       </modus-wc-tooltip>
     `;
   },

--- a/src/components/organisms/modus-wc-table/modus-wc-table.stories.ts
+++ b/src/components/organisms/modus-wc-table/modus-wc-table.stories.ts
@@ -27,7 +27,9 @@ const defaultColumns: ITableColumn[] = [
       const isActive = value.toLowerCase() === 'active';
       const badge = document.createElement('modus-wc-badge');
       badge.color = isActive ? 'success' : 'danger';
-      badge.content = value;
+      const div = document.createElement('div');
+      div.textContent = value;
+      badge.appendChild(div);
       return badge;
     },
   },

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -184,7 +184,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\r\n\r\nThe component supports a `<slot>` for injecting content within the button, similar to a native HTML button.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcButton",
           "members": [
             {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -93,6 +93,7 @@
   --modus-wc-font-weight-bold: 700;
 
   // Spacing
+  --modus-wc-spacing-2xs: 0.125rem; // 2px
   --modus-wc-spacing-xs: 0.25rem; // 4px
   --modus-wc-spacing-sm: 0.5rem; // 8px
   --modus-wc-spacing-md: 0.75rem; // 12px


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR replaces the badge `content` prop with a `<slot>` so the user can render any content. It also updates the padding of the badge to match Figma.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tests updated

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)
