### PR TITLE
fix: input label host styles

### DIFF
--- a/src/components/modus-wc-input-label/__snapshots__/modus-wc-input-label.spec.ts.snap
+++ b/src/components/modus-wc-input-label/__snapshots__/modus-wc-input-label.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-input-label should render with content in the primary slot 1`] = `
-<modus-wc-input-label>
+<modus-wc-input-label class="modus-wc-input-label-host">
   <!---->
   <label class="modus-wc-input-label modus-wc-input-label-size-md">
     <span>
@@ -12,7 +12,7 @@ exports[`modus-wc-input-label should render with content in the primary slot 1`]
 `;
 
 exports[`modus-wc-input-label should render with custom props 1`] = `
-<modus-wc-input-label custom-class="test-class" for-id="input-id" label-text="Custom label" required="true" size="lg" sub-label-text="Sublabel text">
+<modus-wc-input-label class="modus-wc-input-label-host" custom-class="test-class" for-id="input-id" label-text="Custom label" required="true" size="lg" sub-label-text="Sublabel text">
   <!---->
   <label class="modus-wc-input-label modus-wc-input-label-size-lg test-class" htmlfor="input-id">
     Custom label
@@ -27,7 +27,7 @@ exports[`modus-wc-input-label should render with custom props 1`] = `
 `;
 
 exports[`modus-wc-input-label should render with default props 1`] = `
-<modus-wc-input-label>
+<modus-wc-input-label class="modus-wc-input-label-host">
   <!---->
   <label class="modus-wc-input-label modus-wc-input-label-size-md"></label>
 </modus-wc-input-label>

--- a/src/components/modus-wc-input-label/modus-wc-input-label.scss
+++ b/src/components/modus-wc-input-label/modus-wc-input-label.scss
@@ -1,3 +1,8 @@
+.modus-wc-input-label-host {
+  display: flex;
+  align-items: center;
+}
+
 .modus-wc-input-label {
   // Sizes
   &.modus-wc-input-label-size-sm {

--- a/src/components/modus-wc-input-label/modus-wc-input-label.tsx
+++ b/src/components/modus-wc-input-label/modus-wc-input-label.tsx
@@ -54,7 +54,7 @@ export class ModusWcInputLabel {
 
   render() {
     return (
-      <Host>
+      <Host class="modus-wc-input-label-host">
         <label
           class={this.getClasses()}
           htmlFor={this.forId}

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1679,7 +1679,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input label component.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input label component.\n\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcInputLabel",
           "members": [
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds flex and align items CSS attributes to the `modus-wc-input-label` host element to fix alignment issues.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Updated snapshot tests. Tested manually on storybook.

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

[AB#596441](https://dev.azure.com/ViewpointVSO/Prism/_boards/board/t/Web/Stories?workitem=596441)
