### PR TITLE
docs: add component interfaces to Storybook

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,28 +5,28 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { IAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
+import { IModusWcAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
 import { AutocompleteTypes, DaisySize, Density, ModusSize, Orientation, TextFieldTypes } from "./components/types";
 import { IModusWcBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 import { IModusWcCollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
 import { LoaderColor, LoaderVariant } from "./components/modus-wc-loader/modus-wc-loader";
 import { IModusWcAriaLabelValues, IModusWcPageChange } from "./components/modus-wc-pagination/modus-wc-pagination";
-import { ISelectOption } from "./components/modus-wc-select/modus-wc-select";
+import { IModusWcSelectOption } from "./components/modus-wc-select/modus-wc-select";
 import { IModusWcStepperItem } from "./components/modus-wc-stepper/modus-wc-stepper";
-import { ITableColumn } from "./components/modus-wc-table/modus-wc-table";
+import { IModusWcTableColumn } from "./components/modus-wc-table/modus-wc-table";
 import { IModusWcTab } from "./components/modus-wc-tabs/modus-wc-tabs";
 import { IThemeConfig } from "./providers/theme/theme.types";
 import { ToastPosition } from "./components/modus-wc-toast/modus-wc-toast";
 import { TypographyVariant, TypographyWeight } from "./components/modus-wc-typography/modus-wc-typography";
-export { IAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
+export { IModusWcAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
 export { AutocompleteTypes, DaisySize, Density, ModusSize, Orientation, TextFieldTypes } from "./components/types";
 export { IModusWcBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 export { IModusWcCollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
 export { LoaderColor, LoaderVariant } from "./components/modus-wc-loader/modus-wc-loader";
 export { IModusWcAriaLabelValues, IModusWcPageChange } from "./components/modus-wc-pagination/modus-wc-pagination";
-export { ISelectOption } from "./components/modus-wc-select/modus-wc-select";
+export { IModusWcSelectOption } from "./components/modus-wc-select/modus-wc-select";
 export { IModusWcStepperItem } from "./components/modus-wc-stepper/modus-wc-stepper";
-export { ITableColumn } from "./components/modus-wc-table/modus-wc-table";
+export { IModusWcTableColumn } from "./components/modus-wc-table/modus-wc-table";
 export { IModusWcTab } from "./components/modus-wc-tabs/modus-wc-tabs";
 export { IThemeConfig } from "./providers/theme/theme.types";
 export { ToastPosition } from "./components/modus-wc-toast/modus-wc-toast";
@@ -113,7 +113,7 @@ export namespace Components {
         /**
           * The items to display in the menu. Creating a new array of items will ensure proper component re-render.
          */
-        "items": IAutocompleteItem[];
+        "items": IModusWcAutocompleteItem[];
         /**
           * The text to display within the label.
          */
@@ -889,7 +889,7 @@ export namespace Components {
         /**
           * The options to display in the select dropdown.
          */
-        "options": ISelectOption[];
+        "options": IModusWcSelectOption[];
         /**
           * A value is required for the form to be submittable.
          */
@@ -1005,7 +1005,7 @@ export namespace Components {
         /**
           * An array of column definitions.
          */
-        "columns": ITableColumn[];
+        "columns": IModusWcTableColumn[];
         /**
           * Custom CSS class to apply to the inner div.
          */
@@ -1575,11 +1575,11 @@ declare global {
         new (): HTMLModusWcAlertElement;
     };
     interface HTMLModusWcAutocompleteElementEventMap {
-        "chipRemove": IAutocompleteItem;
+        "chipRemove": IModusWcAutocompleteItem;
         "inputBlur": FocusEvent;
         "inputChange": Event;
         "inputFocus": FocusEvent;
-        "itemSelect": IAutocompleteItem;
+        "itemSelect": IModusWcAutocompleteItem;
     }
     /**
      * A customizable autocomplete component used to create searchable text inputs.
@@ -2326,7 +2326,7 @@ declare namespace LocalJSX {
         /**
           * The items to display in the menu. Creating a new array of items will ensure proper component re-render.
          */
-        "items"?: IAutocompleteItem[];
+        "items"?: IModusWcAutocompleteItem[];
         /**
           * The text to display within the label.
          */
@@ -2346,7 +2346,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when a selected item chip is removed.
          */
-        "onChipRemove"?: (event: ModusWcAutocompleteCustomEvent<IAutocompleteItem>) => void;
+        "onChipRemove"?: (event: ModusWcAutocompleteCustomEvent<IModusWcAutocompleteItem>) => void;
         /**
           * Event emitted when the input loses focus.
          */
@@ -2362,7 +2362,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when a menu item is selected.
          */
-        "onItemSelect"?: (event: ModusWcAutocompleteCustomEvent<IAutocompleteItem>) => void;
+        "onItemSelect"?: (event: ModusWcAutocompleteCustomEvent<IModusWcAutocompleteItem>) => void;
         /**
           * Text that appears in the form control when it has no value set.
          */
@@ -3210,7 +3210,7 @@ declare namespace LocalJSX {
         /**
           * The options to display in the select dropdown.
          */
-        "options"?: ISelectOption[];
+        "options"?: IModusWcSelectOption[];
         /**
           * A value is required for the form to be submittable.
          */
@@ -3338,7 +3338,7 @@ declare namespace LocalJSX {
         /**
           * An array of column definitions.
          */
-        "columns": ITableColumn[];
+        "columns": IModusWcTableColumn[];
         /**
           * Custom CSS class to apply to the inner div.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { IModusWcAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
+import { IAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
 import { AutocompleteTypes, DaisySize, Density, ModusSize, Orientation, TextFieldTypes } from "./components/types";
 import { IModusWcBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 import { IModusWcCollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
@@ -18,7 +18,7 @@ import { IModusWcTab } from "./components/modus-wc-tabs/modus-wc-tabs";
 import { IThemeConfig } from "./providers/theme/theme.types";
 import { ToastPosition } from "./components/modus-wc-toast/modus-wc-toast";
 import { TypographyVariant, TypographyWeight } from "./components/modus-wc-typography/modus-wc-typography";
-export { IModusWcAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
+export { IAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
 export { AutocompleteTypes, DaisySize, Density, ModusSize, Orientation, TextFieldTypes } from "./components/types";
 export { IModusWcBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 export { IModusWcCollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
@@ -113,7 +113,7 @@ export namespace Components {
         /**
           * The items to display in the menu. Creating a new array of items will ensure proper component re-render.
          */
-        "items": IModusWcAutocompleteItem[];
+        "items": IAutocompleteItem[];
         /**
           * The text to display within the label.
          */
@@ -1575,11 +1575,11 @@ declare global {
         new (): HTMLModusWcAlertElement;
     };
     interface HTMLModusWcAutocompleteElementEventMap {
-        "chipRemove": IModusWcAutocompleteItem;
+        "chipRemove": IAutocompleteItem;
         "inputBlur": FocusEvent;
         "inputChange": Event;
         "inputFocus": FocusEvent;
-        "itemSelect": IModusWcAutocompleteItem;
+        "itemSelect": IAutocompleteItem;
     }
     /**
      * A customizable autocomplete component used to create searchable text inputs.
@@ -2326,7 +2326,7 @@ declare namespace LocalJSX {
         /**
           * The items to display in the menu. Creating a new array of items will ensure proper component re-render.
          */
-        "items"?: IModusWcAutocompleteItem[];
+        "items"?: IAutocompleteItem[];
         /**
           * The text to display within the label.
          */
@@ -2346,7 +2346,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when a selected item chip is removed.
          */
-        "onChipRemove"?: (event: ModusWcAutocompleteCustomEvent<IModusWcAutocompleteItem>) => void;
+        "onChipRemove"?: (event: ModusWcAutocompleteCustomEvent<IAutocompleteItem>) => void;
         /**
           * Event emitted when the input loses focus.
          */
@@ -2362,7 +2362,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when a menu item is selected.
          */
-        "onItemSelect"?: (event: ModusWcAutocompleteCustomEvent<IModusWcAutocompleteItem>) => void;
+        "onItemSelect"?: (event: ModusWcAutocompleteCustomEvent<IAutocompleteItem>) => void;
         /**
           * Text that appears in the form control when it has no value set.
          */

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -1,6 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import {
-  IAutocompleteItem,
+  IModusWcAutocompleteItem,
   ModusWcAutocomplete,
 } from './modus-wc-autocomplete';
 import { ModusWcMenu } from '../modus-wc-menu/modus-wc-menu';
@@ -8,7 +8,7 @@ import { ModusWcMenuItem } from '../modus-wc-menu-item/modus-wc-menu-item';
 import { ModusWcTextInput } from '../modus-wc-text-input/modus-wc-text-input';
 
 describe('modus-wc-autocomplete', () => {
-  const items: IAutocompleteItem[] = [
+  const items: IModusWcAutocompleteItem[] = [
     { label: 'Item 1', value: '1', visibleInMenu: true },
     { label: 'Item 2', value: '2', visibleInMenu: true },
     { label: 'Item 3', value: '3', visibleInMenu: true },

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -1,6 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
 import {
-  IModusWcAutocompleteItem,
+  IAutocompleteItem,
   ModusWcAutocomplete,
 } from './modus-wc-autocomplete';
 import { ModusWcMenu } from '../modus-wc-menu/modus-wc-menu';
@@ -8,7 +8,7 @@ import { ModusWcMenuItem } from '../modus-wc-menu-item/modus-wc-menu-item';
 import { ModusWcTextInput } from '../modus-wc-text-input/modus-wc-text-input';
 
 describe('modus-wc-autocomplete', () => {
-  const items: IModusWcAutocompleteItem[] = [
+  const items: IAutocompleteItem[] = [
     { label: 'Item 1', value: '1', visibleInMenu: true },
     { label: 'Item 2', value: '2', visibleInMenu: true },
     { label: 'Item 3', value: '3', visibleInMenu: true },

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -2,10 +2,10 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { IAutocompleteItem } from './modus-wc-autocomplete';
+import { IModusWcAutocompleteItem } from './modus-wc-autocomplete';
 import { ModusSize } from '../types';
 
-const items: IAutocompleteItem[] = [
+const items: IModusWcAutocompleteItem[] = [
   { label: 'Apple', value: 'apple', visibleInMenu: true },
   { label: 'Banana', value: 'banana', visibleInMenu: true },
   { label: 'Blueberry', value: 'blueberry', visibleInMenu: true },
@@ -25,7 +25,7 @@ interface AutocompleteArgs {
   disabled?: boolean;
   'input-id'?: string;
   'input-tab-index'?: number;
-  items: IAutocompleteItem[];
+  items: IModusWcAutocompleteItem[];
   label?: string;
   'min-chars': number;
   'multi-select'?: boolean;
@@ -52,6 +52,21 @@ const meta: Meta<AutocompleteArgs> = {
     value: '',
   },
   argTypes: {
+    items: {
+      description: 'Array of items for the autocomplete component',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcAutocompleteItem
+            Properties:
+            - label (string): The display text shown for the autocomplete item
+            - selected (boolean, optional): Whether the item is currently selected
+            - value (string): The unique value identifier for the item
+            - visibleInMenu (boolean): Whether the item should be shown in the dropdown menu
+          `,
+        },
+      },
+    },
     size: {
       control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
@@ -101,7 +116,7 @@ const Template: Story = {
       }
     };
 
-    const handleItemSelect = (e: CustomEvent<IAutocompleteItem>) => {
+    const handleItemSelect = (e: CustomEvent<IModusWcAutocompleteItem>) => {
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );
@@ -206,7 +221,7 @@ export const Default: Story = {
 
 export const MultiSelect: Story = {
   render: (args) => {
-    const handleChipRemove = (e: CustomEvent<IAutocompleteItem>) => {
+    const handleChipRemove = (e: CustomEvent<IModusWcAutocompleteItem>) => {
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );
@@ -244,7 +259,7 @@ export const MultiSelect: Story = {
       }
     };
 
-    const handleItemSelect = (e: CustomEvent<IAutocompleteItem>) => {
+    const handleItemSelect = (e: CustomEvent<IModusWcAutocompleteItem>) => {
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -2,10 +2,10 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { IModusWcAutocompleteItem } from './modus-wc-autocomplete';
+import { IAutocompleteItem } from './modus-wc-autocomplete';
 import { ModusSize } from '../types';
 
-const items: IModusWcAutocompleteItem[] = [
+const items: IAutocompleteItem[] = [
   { label: 'Apple', value: 'apple', visibleInMenu: true },
   { label: 'Banana', value: 'banana', visibleInMenu: true },
   { label: 'Blueberry', value: 'blueberry', visibleInMenu: true },
@@ -25,7 +25,7 @@ interface AutocompleteArgs {
   disabled?: boolean;
   'input-id'?: string;
   'input-tab-index'?: number;
-  items: IModusWcAutocompleteItem[];
+  items: IAutocompleteItem[];
   label?: string;
   'min-chars': number;
   'multi-select'?: boolean;
@@ -57,7 +57,7 @@ const meta: Meta<AutocompleteArgs> = {
       table: {
         type: {
           detail: `
-            Interface: IModusWcAutocompleteItem
+            Interface: IAutocompleteItem
             Properties:
             - label (string): The display text shown for the autocomplete item
             - selected (boolean, optional): Whether the item is currently selected
@@ -116,7 +116,7 @@ const Template: Story = {
       }
     };
 
-    const handleItemSelect = (e: CustomEvent<IModusWcAutocompleteItem>) => {
+    const handleItemSelect = (e: CustomEvent<IAutocompleteItem>) => {
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );
@@ -221,7 +221,7 @@ export const Default: Story = {
 
 export const MultiSelect: Story = {
   render: (args) => {
-    const handleChipRemove = (e: CustomEvent<IModusWcAutocompleteItem>) => {
+    const handleChipRemove = (e: CustomEvent<IAutocompleteItem>) => {
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );
@@ -259,7 +259,7 @@ export const MultiSelect: Story = {
       }
     };
 
-    const handleItemSelect = (e: CustomEvent<IModusWcAutocompleteItem>) => {
+    const handleItemSelect = (e: CustomEvent<IAutocompleteItem>) => {
       const autocomplete = (e.target as HTMLInputElement).closest(
         'modus-wc-autocomplete'
       );

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -12,16 +12,13 @@ import {
 import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
-export interface IAutocompleteItem {
+export interface IModusWcAutocompleteItem {
   /** The display text shown for the autocomplete item */
   label: string;
-
   /** Whether the item is currently selected */
   selected?: boolean;
-
   /** The unique value identifier for the item */
   value: string;
-
   /** Whether the item should be shown in the dropdown menu */
   visibleInMenu: boolean;
 }
@@ -70,7 +67,7 @@ export class ModusWcAutocomplete {
    * The items to display in the menu.
    * Creating a new array of items will ensure proper component re-render.
    **/
-  @Prop() items: IAutocompleteItem[] = [];
+  @Prop() items: IModusWcAutocompleteItem[] = [];
 
   /** The text to display within the label. */
   @Prop() label?: string;
@@ -100,7 +97,7 @@ export class ModusWcAutocomplete {
   @Prop({ mutable: true, reflect: true }) value: string = '';
 
   /** Event emitted when a selected item chip is removed. */
-  @StencilEvent() chipRemove!: EventEmitter<IAutocompleteItem>;
+  @StencilEvent() chipRemove!: EventEmitter<IModusWcAutocompleteItem>;
 
   /** Event emitted when the input loses focus. */
   @StencilEvent() inputBlur!: EventEmitter<FocusEvent>;
@@ -115,7 +112,7 @@ export class ModusWcAutocomplete {
   @StencilEvent() inputFocus!: EventEmitter<FocusEvent>;
 
   /** Event emitted when a menu item is selected. */
-  @StencilEvent() itemSelect!: EventEmitter<IAutocompleteItem>;
+  @StencilEvent() itemSelect!: EventEmitter<IModusWcAutocompleteItem>;
 
   // istanbul ignore next - TODO
   disconnectedCallback() {
@@ -189,14 +186,14 @@ export class ModusWcAutocomplete {
 
   // TODO - add code coverage once autocomplete is updated
   // istanbul ignore next
-  private handleItemSelect = (item: IAutocompleteItem) => {
+  private handleItemSelect = (item: IModusWcAutocompleteItem) => {
     this.menuVisible = false;
     this.itemSelect.emit(item);
   };
 
   // TODO - add code coverage once chip component is implemented
   // istanbul ignore next
-  private handleChipRemove = (item: IAutocompleteItem) => {
+  private handleChipRemove = (item: IModusWcAutocompleteItem) => {
     this.chipRemove.emit(item);
   };
 

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -12,7 +12,7 @@ import {
 import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
-export interface IModusWcAutocompleteItem {
+export interface IAutocompleteItem {
   /** The display text shown for the autocomplete item */
   label: string;
   /** Whether the item is currently selected */
@@ -67,7 +67,7 @@ export class ModusWcAutocomplete {
    * The items to display in the menu.
    * Creating a new array of items will ensure proper component re-render.
    **/
-  @Prop() items: IModusWcAutocompleteItem[] = [];
+  @Prop() items: IAutocompleteItem[] = [];
 
   /** The text to display within the label. */
   @Prop() label?: string;
@@ -97,7 +97,7 @@ export class ModusWcAutocomplete {
   @Prop({ mutable: true, reflect: true }) value: string = '';
 
   /** Event emitted when a selected item chip is removed. */
-  @StencilEvent() chipRemove!: EventEmitter<IModusWcAutocompleteItem>;
+  @StencilEvent() chipRemove!: EventEmitter<IAutocompleteItem>;
 
   /** Event emitted when the input loses focus. */
   @StencilEvent() inputBlur!: EventEmitter<FocusEvent>;
@@ -112,7 +112,7 @@ export class ModusWcAutocomplete {
   @StencilEvent() inputFocus!: EventEmitter<FocusEvent>;
 
   /** Event emitted when a menu item is selected. */
-  @StencilEvent() itemSelect!: EventEmitter<IModusWcAutocompleteItem>;
+  @StencilEvent() itemSelect!: EventEmitter<IAutocompleteItem>;
 
   // istanbul ignore next - TODO
   disconnectedCallback() {
@@ -186,14 +186,14 @@ export class ModusWcAutocomplete {
 
   // TODO - add code coverage once autocomplete is updated
   // istanbul ignore next
-  private handleItemSelect = (item: IModusWcAutocompleteItem) => {
+  private handleItemSelect = (item: IAutocompleteItem) => {
     this.menuVisible = false;
     this.itemSelect.emit(item);
   };
 
   // TODO - add code coverage once chip component is implemented
   // istanbul ignore next
-  private handleChipRemove = (item: IModusWcAutocompleteItem) => {
+  private handleChipRemove = (item: IAutocompleteItem) => {
     this.chipRemove.emit(item);
   };
 

--- a/src/components/modus-wc-autocomplete/readme.md
+++ b/src/components/modus-wc-autocomplete/readme.md
@@ -21,7 +21,7 @@ Adheres to WCAG 2.2 standards.
 | `disabled`      | `disabled`        | Whether the form control is disabled.                                                                   | `boolean \| undefined`              | `false`     |
 | `inputId`       | `input-id`        | The ID of the input element.                                                                            | `string \| undefined`               | `undefined` |
 | `inputTabIndex` | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`               | `undefined` |
-| `items`         | --                | The items to display in the menu. Creating a new array of items will ensure proper component re-render. | `IModusWcAutocompleteItem[]`        | `[]`        |
+| `items`         | --                | The items to display in the menu. Creating a new array of items will ensure proper component re-render. | `IAutocompleteItem[]`               | `[]`        |
 | `label`         | `label`           | The text to display within the label.                                                                   | `string \| undefined`               | `undefined` |
 | `minChars`      | `min-chars`       | The minimum number of characters required to render the menu.                                           | `number`                            | `0`         |
 | `multiSelect`   | `multi-select`    | Whether the input allows multiple items to be selected.                                                 | `boolean \| undefined`              | `false`     |
@@ -35,13 +35,13 @@ Adheres to WCAG 2.2 standards.
 
 ## Events
 
-| Event         | Description                                                                                       | Type                                    |
-| ------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| `chipRemove`  | Event emitted when a selected item chip is removed.                                               | `CustomEvent<IModusWcAutocompleteItem>` |
-| `inputBlur`   | Event emitted when the input loses focus.                                                         | `CustomEvent<FocusEvent>`               |
-| `inputChange` | Event emitted when the input value changes. This event is debounced based on the debounceMs prop. | `CustomEvent<Event>`                    |
-| `inputFocus`  | Event emitted when the input gains focus.                                                         | `CustomEvent<FocusEvent>`               |
-| `itemSelect`  | Event emitted when a menu item is selected.                                                       | `CustomEvent<IModusWcAutocompleteItem>` |
+| Event         | Description                                                                                       | Type                             |
+| ------------- | ------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `chipRemove`  | Event emitted when a selected item chip is removed.                                               | `CustomEvent<IAutocompleteItem>` |
+| `inputBlur`   | Event emitted when the input loses focus.                                                         | `CustomEvent<FocusEvent>`        |
+| `inputChange` | Event emitted when the input value changes. This event is debounced based on the debounceMs prop. | `CustomEvent<Event>`             |
+| `inputFocus`  | Event emitted when the input gains focus.                                                         | `CustomEvent<FocusEvent>`        |
+| `itemSelect`  | Event emitted when a menu item is selected.                                                       | `CustomEvent<IAutocompleteItem>` |
 
 
 ## Dependencies

--- a/src/components/modus-wc-autocomplete/readme.md
+++ b/src/components/modus-wc-autocomplete/readme.md
@@ -21,7 +21,7 @@ Adheres to WCAG 2.2 standards.
 | `disabled`      | `disabled`        | Whether the form control is disabled.                                                                   | `boolean \| undefined`              | `false`     |
 | `inputId`       | `input-id`        | The ID of the input element.                                                                            | `string \| undefined`               | `undefined` |
 | `inputTabIndex` | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`               | `undefined` |
-| `items`         | --                | The items to display in the menu. Creating a new array of items will ensure proper component re-render. | `IAutocompleteItem[]`               | `[]`        |
+| `items`         | --                | The items to display in the menu. Creating a new array of items will ensure proper component re-render. | `IModusWcAutocompleteItem[]`        | `[]`        |
 | `label`         | `label`           | The text to display within the label.                                                                   | `string \| undefined`               | `undefined` |
 | `minChars`      | `min-chars`       | The minimum number of characters required to render the menu.                                           | `number`                            | `0`         |
 | `multiSelect`   | `multi-select`    | Whether the input allows multiple items to be selected.                                                 | `boolean \| undefined`              | `false`     |
@@ -35,13 +35,13 @@ Adheres to WCAG 2.2 standards.
 
 ## Events
 
-| Event         | Description                                                                                       | Type                             |
-| ------------- | ------------------------------------------------------------------------------------------------- | -------------------------------- |
-| `chipRemove`  | Event emitted when a selected item chip is removed.                                               | `CustomEvent<IAutocompleteItem>` |
-| `inputBlur`   | Event emitted when the input loses focus.                                                         | `CustomEvent<FocusEvent>`        |
-| `inputChange` | Event emitted when the input value changes. This event is debounced based on the debounceMs prop. | `CustomEvent<Event>`             |
-| `inputFocus`  | Event emitted when the input gains focus.                                                         | `CustomEvent<FocusEvent>`        |
-| `itemSelect`  | Event emitted when a menu item is selected.                                                       | `CustomEvent<IAutocompleteItem>` |
+| Event         | Description                                                                                       | Type                                    |
+| ------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `chipRemove`  | Event emitted when a selected item chip is removed.                                               | `CustomEvent<IModusWcAutocompleteItem>` |
+| `inputBlur`   | Event emitted when the input loses focus.                                                         | `CustomEvent<FocusEvent>`               |
+| `inputChange` | Event emitted when the input value changes. This event is debounced based on the debounceMs prop. | `CustomEvent<Event>`                    |
+| `inputFocus`  | Event emitted when the input gains focus.                                                         | `CustomEvent<FocusEvent>`               |
+| `itemSelect`  | Event emitted when a menu item is selected.                                                       | `CustomEvent<IModusWcAutocompleteItem>` |
 
 
 ## Dependencies

--- a/src/components/modus-wc-breadcrumbs/modus-wc-breadcrumbs.stories.ts
+++ b/src/components/modus-wc-breadcrumbs/modus-wc-breadcrumbs.stories.ts
@@ -34,6 +34,19 @@ const meta: Meta<BreadcrumbArgs> = {
     size: 'md',
   },
   argTypes: {
+    items: {
+      description: 'Array of items for the breadcrumbs component',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcBreadcrumb
+            Properties:
+            - label (string): The text to render in the breadcrumb
+            - url (string, optional): The URL emitted when the breadcrumb is clicked
+          `,
+        },
+      },
+    },
     size: {
       control: {
         type: 'select',

--- a/src/components/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
+++ b/src/components/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
@@ -14,7 +14,6 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 export interface IModusWcBreadcrumb {
   /** The text to render in the breadcrumb. */
   label: string;
-
   /** The URL emitted when the breadcrumb is clicked. */
   url?: string;
 }

--- a/src/components/modus-wc-collapse/modus-wc-collapse.stories.ts
+++ b/src/components/modus-wc-collapse/modus-wc-collapse.stories.ts
@@ -27,6 +27,24 @@ const meta: Meta<CollapseArgs> = {
     expanded: false,
     options,
   },
+  argTypes: {
+    options: {
+      description: 'Configuration options for the collapse component',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcCollapseOptions
+            Properties:
+            - description (string, optional): The description to render in the collapse header
+            - icon (string, optional): The Modus icon name to render in the collapse header
+            - iconAriaLabel (string, optional): The icon's aria-label
+            - size (DaisySize, optional): The size of the collapse header
+            - title (string): The title to render in the collapse header
+          `,
+        },
+      },
+    },
+  },
   decorators: [withActions],
   parameters: {
     actions: {

--- a/src/components/modus-wc-collapse/modus-wc-collapse.tsx
+++ b/src/components/modus-wc-collapse/modus-wc-collapse.tsx
@@ -25,16 +25,12 @@ import {
 export interface IModusWcCollapseOptions {
   /** The description to render in the collapse header. */
   description?: string;
-
   /** The Modus icon name to render in the collapse header. */
   icon?: string;
-
   /** The icon's aria-label. */
   iconAriaLabel?: string;
-
   /** The size of the collapse header. */
   size?: DaisySize;
-
   /** The title to render in the collapse header. */
   title: string;
 }

--- a/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
@@ -13,7 +13,7 @@ const defaultLabelValues: IModusWcAriaLabelValues = {
 };
 
 interface PaginationArgs {
-  'arial-label-values'?: IModusWcAriaLabelValues;
+  'aria-label-values'?: IModusWcAriaLabelValues;
   count: number;
   'custom-class'?: string;
   page: number;
@@ -24,13 +24,29 @@ const meta: Meta<PaginationArgs> = {
   title: 'Components/Pagination',
   component: 'modus-wc-pagination',
   args: {
-    'arial-label-values': defaultLabelValues,
+    'aria-label-values': defaultLabelValues,
     count: 5,
     'custom-class': '',
     page: 1,
     size: 'md',
   },
   argTypes: {
+    'aria-label-values': {
+      description: 'Custom aria label values for pagination buttons',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcAriaLabelValues
+            Properties:
+            - firstPage (string, optional): Aria label for the first page button
+            - lastPage (string, optional): Aria label for the last page button
+            - nextPage (string, optional): Aria label for the next page button
+            - page (string, optional): Aria label for the page number button. Use {0} as placeholder for the page number
+            - previousPage (string, optional): Aria label for the previous page button
+          `,
+        },
+      },
+    },
     size: {
       control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
@@ -40,6 +56,24 @@ const meta: Meta<PaginationArgs> = {
   parameters: {
     actions: {
       handles: ['pageChange'],
+    },
+    docs: {
+      description: {
+        component: `
+## Event Interface Documentation
+
+The pageChange event emits an object with the following interface:
+
+\`\`\`typescript
+interface IModusWcPageChange {
+  /** The number of the newly selected page */
+  newPage: number;
+  /** The number of the previously selected page */
+  prevPage: number;
+}
+\`\`\`
+        `,
+      },
     },
   },
 };
@@ -51,7 +85,7 @@ type Story = StoryObj<PaginationArgs>;
 export const Default: Story = {
   render: (args) => html`
     <modus-wc-pagination
-      .ariaLabelValues=${args['arial-label-values']}
+      .ariaLabelValues=${args['aria-label-values']}
       count=${args.count}
       custom-class=${ifDefined(args['custom-class'])}
       page=${args.page}

--- a/src/components/modus-wc-pagination/modus-wc-pagination.tsx
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.tsx
@@ -28,7 +28,9 @@ export interface IModusWcAriaLabelValues {
 }
 
 export interface IModusWcPageChange {
+  /** The number of the newly selected page */
   newPage: number;
+  /** The number of the previously selected page */
   prevPage: number;
 }
 

--- a/src/components/modus-wc-select/modus-wc-select.stories.ts
+++ b/src/components/modus-wc-select/modus-wc-select.stories.ts
@@ -2,10 +2,10 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { ISelectOption } from './modus-wc-select';
+import { IModusWcSelectOption } from './modus-wc-select';
 import { ModusSize } from '../types';
 
-const options: ISelectOption[] = [
+const options: IModusWcSelectOption[] = [
   { label: 'Option 1', value: '1' },
   { label: 'Option 2', value: '2' },
   { label: 'Option 3', value: '3' },
@@ -20,7 +20,7 @@ interface SelectArgs {
   'input-tab-index'?: number;
   label?: string;
   name?: string;
-  options: ISelectOption[];
+  options: IModusWcSelectOption[];
   required?: boolean;
   size?: ModusSize;
   value: string;
@@ -41,6 +41,20 @@ const meta: Meta<SelectArgs> = {
     'input-aria-invalid': {
       control: { type: 'select' },
       options: ['true', 'false'],
+    },
+    options: {
+      description: 'Array of option objects for the select dropdown',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcSelectOption
+            Properties:
+            - disabled (boolean, optional): Whether the option is disabled and cannot be selected
+            - label (string): Display text for the option
+            - value (string): The value of the option
+          `,
+        },
+      },
     },
     size: {
       control: { type: 'select' },

--- a/src/components/modus-wc-select/modus-wc-select.tsx
+++ b/src/components/modus-wc-select/modus-wc-select.tsx
@@ -11,9 +11,12 @@ import { convertPropsToClasses } from './modus-wc-select.tailwind';
 import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
-export interface ISelectOption {
+export interface IModusWcSelectOption {
+  /** Whether the option is disabled and cannot be selected */
   disabled?: boolean;
+  /** Display text for the option */
   label: string;
+  /** The value of the option */
   value: string;
 }
 
@@ -55,7 +58,7 @@ export class ModusWcSelect {
   @Prop() name?: string;
 
   /** The options to display in the select dropdown. */
-  @Prop({ mutable: true, reflect: true }) options: ISelectOption[] = [];
+  @Prop({ mutable: true, reflect: true }) options: IModusWcSelectOption[] = [];
 
   /** A value is required for the form to be submittable. */
   @Prop() required?: boolean = false;

--- a/src/components/modus-wc-select/readme.md
+++ b/src/components/modus-wc-select/readme.md
@@ -22,7 +22,7 @@ Adheres to WCAG 2.2 standards.
 | `inputTabIndex` | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`               | `undefined` |
 | `label`         | `label`           | The text to display within the label.                                                                   | `string \| undefined`               | `undefined` |
 | `name`          | `name`            | Name of the form control. Submitted with the form as part of a name/value pair.                         | `string \| undefined`               | `undefined` |
-| `options`       | --                | The options to display in the select dropdown.                                                          | `ISelectOption[]`                   | `[]`        |
+| `options`       | --                | The options to display in the select dropdown.                                                          | `IModusWcSelectOption[]`            | `[]`        |
 | `required`      | `required`        | A value is required for the form to be submittable.                                                     | `boolean \| undefined`              | `false`     |
 | `size`          | `size`            | The size of the input.                                                                                  | `"lg" \| "md" \| "sm" \| undefined` | `'md'`      |
 | `value`         | `value`           | The value of the control.                                                                               | `string`                            | `''`        |

--- a/src/components/modus-wc-stepper/modus-wc-stepper.stories.ts
+++ b/src/components/modus-wc-stepper/modus-wc-stepper.stories.ts
@@ -43,6 +43,21 @@ const meta: Meta<StepperArgs> = {
       control: { type: 'select' },
       options: ['horizontal', 'vertical'],
     },
+    steps: {
+      description: 'Array of step objects defining the steps to display',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcStepperItem
+            Properties:
+            - color ('primary' | 'secondary' | 'accent' | 'info' | 'success' | 'warning' | 'error' | 'neutral', optional): The color theme of the step
+            - content (string, optional): Custom content to display in the step indicator
+            - customClass (string, optional): Custom CSS class to apply to the step
+            - label (string, optional): Text label for the step
+          `,
+        },
+      },
+    },
   },
   parameters: {
     layout: 'padded',

--- a/src/components/modus-wc-stepper/modus-wc-stepper.tsx
+++ b/src/components/modus-wc-stepper/modus-wc-stepper.tsx
@@ -4,6 +4,7 @@ import { Orientation } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 export interface IModusWcStepperItem {
+  /** The color theme of the step */
   color?:
     | 'primary'
     | 'secondary'
@@ -13,8 +14,11 @@ export interface IModusWcStepperItem {
     | 'warning'
     | 'error'
     | 'neutral';
+  /** Custom content to display in the step indicator */
   content?: string;
+  /** Custom CSS class to apply to the step */
   customClass?: string;
+  /** Text label for the step */
   label?: string;
 }
 

--- a/src/components/modus-wc-table/modus-wc-table.spec.tsx
+++ b/src/components/modus-wc-table/modus-wc-table.spec.tsx
@@ -1,8 +1,8 @@
 import { newSpecPage } from '@stencil/core/testing';
-import { ITableColumn, ModusWcTable } from './modus-wc-table';
+import { IModusWcTableColumn, ModusWcTable } from './modus-wc-table';
 
 describe('modus-wc-table', () => {
-  const defaultColumns: ITableColumn[] = [
+  const defaultColumns: IModusWcTableColumn[] = [
     {
       id: 'name',
       header: 'Name',

--- a/src/components/modus-wc-table/modus-wc-table.stories.ts
+++ b/src/components/modus-wc-table/modus-wc-table.stories.ts
@@ -4,10 +4,10 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { ITableColumn } from './modus-wc-table';
+import { IModusWcTableColumn } from './modus-wc-table';
 import { Density } from '../types';
 
-const defaultColumns: ITableColumn[] = [
+const defaultColumns: IModusWcTableColumn[] = [
   {
     id: 'name',
     header: 'Name',
@@ -42,7 +42,7 @@ const defaultData = [
 ];
 
 interface TableArgs {
-  columns: ITableColumn[];
+  columns: IModusWcTableColumn[];
   'custom-class'?: string;
   data: Record<string, any>[];
   density?: Density;
@@ -59,6 +59,23 @@ const meta: Meta<TableArgs> = {
     zebra: false,
   },
   argTypes: {
+    columns: {
+      description: 'Array of column definitions for the table',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcTableColumn
+            Properties:
+            - accessor (string): Key to access data from row object
+            - cellRenderer ((value: any, row: any) => string | HTMLElement, optional): Custom cell renderer
+            - className (string, optional): Class names for the column
+            - header (string | HTMLElement): Header content - can be string or HTML
+            - id (string): Unique identifier for the column
+            - width (string, optional): Width style (e.g., '200px', '50%')
+        `,
+        },
+      },
+    },
     density: {
       control: { type: 'select' },
       options: ['comfortable', 'compact'],

--- a/src/components/modus-wc-table/modus-wc-table.tsx
+++ b/src/components/modus-wc-table/modus-wc-table.tsx
@@ -13,18 +13,18 @@ import { convertTablePropsToClasses } from './modus-wc-table.tailwind';
 import { Density } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
-export interface ITableColumn {
+export interface IModusWcTableColumn {
   /** Key to access data from row object */
   accessor: string;
-  /** Optional custom cell renderer */
+  /** Custom cell renderer */
   cellRenderer?: (value: any, row: any) => string | HTMLElement;
-  /** Optional class names for the column */
+  /** Class names for the column */
   className?: string;
   /** Header content - can be string or HTML */
   header: string | HTMLElement;
   /** Unique identifier for the column */
   id: string;
-  /** Optional width style (e.g., '200px', '50%') */
+  /** Width style (e.g., '200px', '50%') */
   width?: string;
 }
 
@@ -45,7 +45,7 @@ export class ModusWcTable {
   @Element() el!: HTMLElement;
 
   /** An array of column definitions. */
-  @Prop() columns!: ITableColumn[];
+  @Prop() columns!: IModusWcTableColumn[];
 
   /** Custom CSS class to apply to the inner div. */
   @Prop() customClass?: string = '';
@@ -100,7 +100,7 @@ export class ModusWcTable {
   };
 
   private renderCell(
-    column: ITableColumn,
+    column: IModusWcTableColumn,
     row: Record<string, any>
   ): string | HTMLElement {
     const value = row[column.accessor];

--- a/src/components/modus-wc-table/readme.md
+++ b/src/components/modus-wc-table/readme.md
@@ -15,7 +15,7 @@ Adheres to WCAG 2.2 standards.
 
 | Property               | Attribute      | Description                                                                        | Type                                      | Default         |
 | ---------------------- | -------------- | ---------------------------------------------------------------------------------- | ----------------------------------------- | --------------- |
-| `columns` _(required)_ | --             | An array of column definitions.                                                    | `ITableColumn[]`                          | `undefined`     |
+| `columns` _(required)_ | --             | An array of column definitions.                                                    | `IModusWcTableColumn[]`                   | `undefined`     |
 | `customClass`          | `custom-class` | Custom CSS class to apply to the inner div.                                        | `string \| undefined`                     | `''`            |
 | `data` _(required)_    | --             | An array of data objects.                                                          | `Record<string, any>[]`                   | `undefined`     |
 | `density`              | `density`      | The density of the table, used to save space or increase readability.              | `"comfortable" \| "compact" \| undefined` | `'comfortable'` |

--- a/src/components/modus-wc-tabs/modus-wc-tabs.stories.ts
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.stories.ts
@@ -27,6 +27,22 @@ const meta: Meta<TabsArgs> = {
     tabStyle: 'bordered',
   },
   argTypes: {
+    tabs: {
+      description: 'Array of tab objects defining the tabs to display',
+      table: {
+        type: {
+          detail: `
+            Interface: IModusWcTab
+            Properties:
+            - customClass (string, optional): Custom CSS class for the inner button
+            - disabled (boolean, optional): Whether the tab is disabled
+            - icon (string, optional): A Modus Icon name to display
+            - iconPosition ('left' | 'right', optional): The position of the icon
+            - label (string, optional): The content to display in the tab
+          `,
+        },
+      },
+    },
     tabStyle: {
       control: { type: 'select' },
       options: ['boxed', 'bordered', 'lifted', 'none'],

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1755,7 +1755,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input label component.\n\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input label component.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcInputLabel",
           "members": [
             {
@@ -3025,7 +3025,7 @@
               "default": "[]",
               "description": "The options to display in the select dropdown.",
               "type": {
-                "text": "ISelectOption[]"
+                "text": "IModusWcSelectOption[]"
               }
             },
             {
@@ -3472,7 +3472,7 @@
               "fieldName": "columns",
               "description": "An array of column definitions.",
               "type": {
-                "text": "ITableColumn[]"
+                "text": "IModusWcTableColumn[]"
               }
             },
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds interface documentation to each component that exports an interface. It also aligns naming `IModusWc...`

I will create a story to replace these by a tool to auto update these docs.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)
