### PR TITLE
docs: add form inputs and text input migration docs

### DIFF
--- a/src/components/modus-wc-accordion/modus-wc-accordion.stories.ts
+++ b/src/components/modus-wc-accordion/modus-wc-accordion.stories.ts
@@ -77,10 +77,9 @@ export const Migration: Story = {
         story: `
 #### Breaking Changes
 
-- In 1.0 the accordion was composed of child accordion-item components. In 2.0
-accordion children are collapse components.
-- The new accordion supports "header" and "content" slots to provide maximum
-flexibility.
+  - In 1.0 the accordion was composed of child accordion-item components. In 2.0 accordion children are collapse
+  components.
+  - The new accordion supports "header" and "content" slots to provide maximum flexibility.
 
 #### Prop Mapping
 

--- a/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
@@ -145,3 +145,61 @@ export const Default: Story = {
     ></modus-wc-text-input>
   `,
 };
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 input state was maintained by the component. 2.0 components encourage users to follow a controlled
+  input model. See the Form Inputs [documentation]([Angular](?path=/docs/documentation-form-inputs--docs) for
+  additional info and examples.
+
+#### Prop Mapping
+
+| 1.0 Prop                     | 2.0 Prop            | Notes                |
+|------------------------------|---------------------|----------------------|
+| aria-label                   | aria-label          |                      |
+| autocapitalize               | auto-capitalize     |                      |
+| autocorrect                  | auto-correct        |                      |
+| autocomplete                 | autocomplete        |                      |
+| auto-focus-input             | autofocus           |                      |
+| clearable                    |                     | Use Search component |
+| disabled                     | disabled            |                      |
+| enter-key-hint               | enterkeyhint        |                      |
+| error-text                   |                     | Not carried over     |
+| helper-text                  |                     | Not carried over     |
+| include-error-icon           |                     | Not carried over     |
+| include-search-icon          |                     | Use Search component |
+| include-password-text-toggle |                     | Not carried over     |
+| inputmode                    | input-mode          |                      |
+| label                        | label               |                      |
+| max-length                   | max-length          |                      |
+| pattern                      | pattern             |                      |
+| placeholder                  | placeholder         |                      |
+| read-only                    | read-only           |                      |
+| required                     | required            |                      |
+| size                         | size                |                      |
+| spellcheck                   | spellcheck          |                      |
+| text-align                   |                     | Not carried over     |
+| type                         | type                |                      |
+| valid-text                   |                     | Not carried over     |
+| value                        | value               |                      |
+
+#### Event Mapping
+
+| 1.0 Event   | 2.0 Event   | Notes            |
+|-------------|-------------|------------------|
+| valueChange | inputChange |                  |
+        `,
+      },
+    },
+    // To hide the actual story rendering and only show docs:
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  // Simple render function or leave it empty
+  render: () => html`<div></div>`,
+};

--- a/src/stories/form-inputs.mdx
+++ b/src/stories/form-inputs.mdx
@@ -1,0 +1,86 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Documentation/Form Inputs" />
+
+# Form Inputs
+
+## Controlled Input Pattern
+
+The controlled input pattern is a design pattern where the form element's value is controlled by the application state rather than the DOM element itself. This pattern offers several benefits:
+
+- Single source of truth for input values
+- Ability to validate and transform input data in real-time
+- Simplified form state management
+- Improved testability and debugging
+
+### Angular
+
+Angular uses two-way data binding with ngModel to implement the controlled input pattern efficiently.
+
+```typescript
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'controlled-text-input',
+  template: `
+    <modus-wc-text-input
+      (inputChange)="onInputChange($event)"
+      [value]="inputValue"
+    >
+    </modus-wc-text-input>
+  `,
+})
+export class ControlledTextInput {
+  inputValue: string = '';
+
+  onInputChange(event: CustomEvent) {
+    this.inputValue = event.detail.target.value;
+
+    // You can add validation or transformation logic here
+  }
+}
+```
+
+### React
+
+React's controlled input pattern binds form elements to state values and handlers, making React a natural fit for controlled inputs.
+
+```typescript jsx
+import { useState } from 'react';
+
+function ControlledTextInput() {
+  const [value, setValue] = useState('');
+
+  // Handle input changes
+  const handleChange = (event: CustomEvent) => {
+    setValue(event.detail.target.value);
+  };
+
+  return <ModusWcTextInput onInputChange={handleChange} value={value} />;
+}
+```
+
+### Web Components
+
+Web Components can implement the controlled input pattern by exposing properties and events that allow parent applications to manage state externally.
+
+```javascript
+// Example of using the Modus Text Input as a controlled component
+const textInput = document.getElementById('first-name');
+let inputValue = ''; // State lives in the parent application
+
+// Set initial value
+textInput.value = inputValue;
+
+// Listen for changes
+textInput.addEventListener('inputChange', (event) => {
+  // Update our state
+  inputValue = event.detail.target.value;
+
+  // You can perform validation or transformations here
+
+  // Update the input to reflect the new state
+  // This step is only needed if you transform the value
+  textInput.value = inputValue;
+});
+```

--- a/src/stories/modus-icon-usage.mdx
+++ b/src/stories/modus-icon-usage.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/blocks';
-import { Canvas, Story } from '@storybook/blocks';
 
 <Meta title="Documentation/Modus Icon Usage" />
 

--- a/src/stories/styling.mdx
+++ b/src/stories/styling.mdx
@@ -1,5 +1,4 @@
 import { Meta } from '@storybook/blocks';
-import { Canvas, Story } from '@storybook/blocks';
 
 <Meta title="Documentation/Styling" />
 


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds a `Form Inputs` document that describes the controlled input pattern and provides example usage for supported frameworks.

It also adds a migration section to the text input Storybook.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)