### PR TITLE
fix: autocomplete menu location in firefox

### DIFF
--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -51,7 +51,7 @@
     position: absolute;
     left: 0;
     top: 100%;
-    margin-top: 10px; // Not exact but works for all 3 sizes
+    margin-top: 0.625rem; // 10px, not exact but works for all 3 sizes
     z-index: 99;
     border-radius: 0 0 var(--modus-wc-border-radius-md)
       var(--modus-wc-border-radius-md);

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -11,8 +11,7 @@
   }
 
   .modus-wc-input-bordered {
-    border-radius: var(--modus-wc-border-radius-md)
-      var(--modus-wc-border-radius-md) 0 0;
+    border-radius: var(--modus-wc-border-radius-md);
   }
 
   .modus-wc-autocomplete-multi-select {
@@ -50,6 +49,9 @@
 
   .modus-wc-menu {
     position: absolute;
+    left: 0;
+    top: 100%;
+    margin-top: 10px; // Not exact but works for all 3 sizes
     z-index: 99;
     border-radius: 0 0 var(--modus-wc-border-radius-md)
       var(--modus-wc-border-radius-md);


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR fixes the alignment of the menu within the autocomplete component within Firefox.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Manually tested in Chrome and Firefox

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

