### PR TITLE
feat: add input feedback component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,6 +9,7 @@ import { IAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-a
 import { AutocompleteTypes, DaisySize, Density, ModusSize, Orientation, TextFieldTypes } from "./components/types";
 import { IBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 import { ICollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
+import { IInputFeedbackLevel } from "./components/modus-wc-input-feedback/modus-wc-input-feedback";
 import { LoaderColor, LoaderVariant } from "./components/modus-wc-loader/modus-wc-loader";
 import { IAriaLabelValues, IPageChange } from "./components/modus-wc-pagination/modus-wc-pagination";
 import { IRatingChange, ModusWcRatingVariant } from "./components/modus-wc-rating/modus-wc-rating";
@@ -23,6 +24,7 @@ export { IAutocompleteItem } from "./components/modus-wc-autocomplete/modus-wc-a
 export { AutocompleteTypes, DaisySize, Density, ModusSize, Orientation, TextFieldTypes } from "./components/types";
 export { IBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 export { ICollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
+export { IInputFeedbackLevel } from "./components/modus-wc-input-feedback/modus-wc-input-feedback";
 export { LoaderColor, LoaderVariant } from "./components/modus-wc-loader/modus-wc-loader";
 export { IAriaLabelValues, IPageChange } from "./components/modus-wc-pagination/modus-wc-pagination";
 export { IRatingChange, ModusWcRatingVariant } from "./components/modus-wc-rating/modus-wc-rating";
@@ -523,6 +525,33 @@ export namespace Components {
           * The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon.
          */
         "size"?: DaisySize;
+    }
+    /**
+     * A customizable feedback component used to provide additional context related to form input interactions.
+     * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface ModusWcInputFeedback {
+        /**
+          * Custom CSS class to apply to the outer div element.
+         */
+        "customClass"?: string;
+        /**
+          * The Modus icon to use instead of the pre-defined icons.
+         */
+        "icon"?: string;
+        /**
+          * The level informs which icon and color that will be rendered.
+         */
+        "level": IInputFeedbackLevel;
+        /**
+          * The message.
+         */
+        "message"?: string;
+        /**
+          * The size of the feedback component.
+         */
+        "size"?: ModusSize;
     }
     /**
      * A customizable input label component.
@@ -1830,6 +1859,17 @@ declare global {
         new (): HTMLModusWcIconElement;
     };
     /**
+     * A customizable feedback component used to provide additional context related to form input interactions.
+     * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface HTMLModusWcInputFeedbackElement extends Components.ModusWcInputFeedback, HTMLStencilElement {
+    }
+    var HTMLModusWcInputFeedbackElement: {
+        prototype: HTMLModusWcInputFeedbackElement;
+        new (): HTMLModusWcInputFeedbackElement;
+    };
+    /**
      * A customizable input label component.
      * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
      * Adheres to WCAG 2.2 standards.
@@ -2272,6 +2312,7 @@ declare global {
         "modus-wc-date": HTMLModusWcDateElement;
         "modus-wc-divider": HTMLModusWcDividerElement;
         "modus-wc-icon": HTMLModusWcIconElement;
+        "modus-wc-input-feedback": HTMLModusWcInputFeedbackElement;
         "modus-wc-input-label": HTMLModusWcInputLabelElement;
         "modus-wc-loader": HTMLModusWcLoaderElement;
         "modus-wc-menu": HTMLModusWcMenuElement;
@@ -2864,6 +2905,33 @@ declare namespace LocalJSX {
           * The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon.
          */
         "size"?: DaisySize;
+    }
+    /**
+     * A customizable feedback component used to provide additional context related to form input interactions.
+     * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
+     * Adheres to WCAG 2.2 standards.
+     */
+    interface ModusWcInputFeedback {
+        /**
+          * Custom CSS class to apply to the outer div element.
+         */
+        "customClass"?: string;
+        /**
+          * The Modus icon to use instead of the pre-defined icons.
+         */
+        "icon"?: string;
+        /**
+          * The level informs which icon and color that will be rendered.
+         */
+        "level": IInputFeedbackLevel;
+        /**
+          * The message.
+         */
+        "message"?: string;
+        /**
+          * The size of the feedback component.
+         */
+        "size"?: ModusSize;
     }
     /**
      * A customizable input label component.
@@ -3960,6 +4028,7 @@ declare namespace LocalJSX {
         "modus-wc-date": ModusWcDate;
         "modus-wc-divider": ModusWcDivider;
         "modus-wc-icon": ModusWcIcon;
+        "modus-wc-input-feedback": ModusWcInputFeedback;
         "modus-wc-input-label": ModusWcInputLabel;
         "modus-wc-loader": ModusWcLoader;
         "modus-wc-menu": ModusWcMenu;
@@ -4067,6 +4136,12 @@ declare module "@stencil/core" {
              * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-icon": LocalJSX.ModusWcIcon & JSXBase.HTMLAttributes<HTMLModusWcIconElement>;
+            /**
+             * A customizable feedback component used to provide additional context related to form input interactions.
+             * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
+             * Adheres to WCAG 2.2 standards.
+             */
+            "modus-wc-input-feedback": LocalJSX.ModusWcInputFeedback & JSXBase.HTMLAttributes<HTMLModusWcInputFeedbackElement>;
             /**
              * A customizable input label component.
              * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.

--- a/src/components/modus-wc-icon/readme.md
+++ b/src/components/modus-wc-icon/readme.md
@@ -30,6 +30,7 @@ Adheres to WCAG 2.2 standards.
  - [modus-wc-alert](../modus-wc-alert)
  - [modus-wc-autocomplete](../modus-wc-autocomplete)
  - [modus-wc-collapse](../modus-wc-collapse)
+ - [modus-wc-input-feedback](../modus-wc-input-feedback)
  - [modus-wc-menu-item](../modus-wc-menu-item)
  - [modus-wc-tabs](../modus-wc-tabs)
 
@@ -39,6 +40,7 @@ graph TD;
   modus-wc-alert --> modus-wc-icon
   modus-wc-autocomplete --> modus-wc-icon
   modus-wc-collapse --> modus-wc-icon
+  modus-wc-input-feedback --> modus-wc-icon
   modus-wc-menu-item --> modus-wc-icon
   modus-wc-tabs --> modus-wc-icon
   style modus-wc-icon fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/components/modus-wc-input-feedback/__snapshots__/modus-wc-input-feedback.spec.ts.snap
+++ b/src/components/modus-wc-input-feedback/__snapshots__/modus-wc-input-feedback.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`modus-wc-input-feedback should render with a custom modus icon 1`] = `
 exports[`modus-wc-input-feedback should render with custom class 1`] = `
 <modus-wc-input-feedback custom-class="test-class" level="info">
   <div class="modus-wc-input-feedback modus-wc-input-feedback--info modus-wc-input-feedback--md test-class">
-    <svg class="mi-info mi-outline" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <svg class="mi-info mi-outline modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path d="M12 9.03c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1M12 22c5.52 0 10-4.48 10-10S17.52 2 12 2 2 6.48 2 12s4.48 10 10 10m0-18c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0 13c.55 0 1-.45 1-1v-4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1"></path>
     </svg>
     <span></span>
@@ -27,7 +27,7 @@ exports[`modus-wc-input-feedback should render with custom class 1`] = `
 exports[`modus-wc-input-feedback should render with default props 1`] = `
 <modus-wc-input-feedback level="info">
   <div class="modus-wc-input-feedback modus-wc-input-feedback--info modus-wc-input-feedback--md">
-    <svg class="mi-info mi-outline" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <svg class="mi-info mi-outline modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path d="M12 9.03c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1M12 22c5.52 0 10-4.48 10-10S17.52 2 12 2 2 6.48 2 12s4.48 10 10 10m0-18c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0 13c.55 0 1-.45 1-1v-4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1"></path>
     </svg>
     <span></span>
@@ -38,7 +38,7 @@ exports[`modus-wc-input-feedback should render with default props 1`] = `
 exports[`modus-wc-input-feedback should render with error level 1`] = `
 <modus-wc-input-feedback level="error" message="An error has occurred.">
   <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
-    <svg class="mi-outline mi-warning" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
     </svg>
     <span>
@@ -51,7 +51,7 @@ exports[`modus-wc-input-feedback should render with error level 1`] = `
 exports[`modus-wc-input-feedback should render with success level 1`] = `
 <modus-wc-input-feedback level="success" message="Success has occurred.">
   <div class="modus-wc-input-feedback modus-wc-input-feedback--md modus-wc-input-feedback--success">
-    <svg class="mi-check-circle mi-outline" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <svg class="mi-check-circle mi-outline modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m5.04-11.28V8.7c-.4-.39-1.03-.39-1.42 0L10.33 14l-2.6-2.62a.996.996 0 0 0-1.41 0 .984.984 0 0 0-.01 1.4l.01.01 3.3 3.34a1 1 0 0 0 1.42.01l6-6.01a.996.996 0 0 0 0-1.41"></path>
     </svg>
     <span>
@@ -64,7 +64,7 @@ exports[`modus-wc-input-feedback should render with success level 1`] = `
 exports[`modus-wc-input-feedback should render with warning level 1`] = `
 <modus-wc-input-feedback level="warning" message="A warning has occurred.">
   <div class="modus-wc-input-feedback modus-wc-input-feedback--md modus-wc-input-feedback--warning">
-    <svg class="mi-outline mi-warning" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
     </svg>
     <span>

--- a/src/components/modus-wc-input-feedback/__snapshots__/modus-wc-input-feedback.spec.ts.snap
+++ b/src/components/modus-wc-input-feedback/__snapshots__/modus-wc-input-feedback.spec.ts.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modus-wc-input-feedback should render with a custom modus icon 1`] = `
+<modus-wc-input-feedback icon="alert">
+  <div class="modus-wc-input-feedback modus-wc-input-feedback--md">
+    <modus-wc-icon class="modus-wc-flex modus-wc-items-center">
+      <i aria-hidden="true" class="modus-icons modus-wc-icon modus-wc-icon--md" tabindex="-1">
+        alert
+      </i>
+    </modus-wc-icon>
+    <span></span>
+  </div>
+</modus-wc-input-feedback>
+`;
+
+exports[`modus-wc-input-feedback should render with custom class 1`] = `
+<modus-wc-input-feedback custom-class="test-class" level="info">
+  <div class="modus-wc-input-feedback modus-wc-input-feedback--info modus-wc-input-feedback--md test-class">
+    <svg class="mi-info mi-outline" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 9.03c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1M12 22c5.52 0 10-4.48 10-10S17.52 2 12 2 2 6.48 2 12s4.48 10 10 10m0-18c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0 13c.55 0 1-.45 1-1v-4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1"></path>
+    </svg>
+    <span></span>
+  </div>
+</modus-wc-input-feedback>
+`;
+
+exports[`modus-wc-input-feedback should render with default props 1`] = `
+<modus-wc-input-feedback level="info">
+  <div class="modus-wc-input-feedback modus-wc-input-feedback--info modus-wc-input-feedback--md">
+    <svg class="mi-info mi-outline" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 9.03c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1M12 22c5.52 0 10-4.48 10-10S17.52 2 12 2 2 6.48 2 12s4.48 10 10 10m0-18c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0 13c.55 0 1-.45 1-1v-4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1"></path>
+    </svg>
+    <span></span>
+  </div>
+</modus-wc-input-feedback>
+`;
+
+exports[`modus-wc-input-feedback should render with error level 1`] = `
+<modus-wc-input-feedback level="error" message="An error has occurred.">
+  <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
+    <svg class="mi-outline mi-warning" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
+    </svg>
+    <span>
+      An error has occurred.
+    </span>
+  </div>
+</modus-wc-input-feedback>
+`;
+
+exports[`modus-wc-input-feedback should render with success level 1`] = `
+<modus-wc-input-feedback level="success" message="Success has occurred.">
+  <div class="modus-wc-input-feedback modus-wc-input-feedback--md modus-wc-input-feedback--success">
+    <svg class="mi-check-circle mi-outline" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m5.04-11.28V8.7c-.4-.39-1.03-.39-1.42 0L10.33 14l-2.6-2.62a.996.996 0 0 0-1.41 0 .984.984 0 0 0-.01 1.4l.01.01 3.3 3.34a1 1 0 0 0 1.42.01l6-6.01a.996.996 0 0 0 0-1.41"></path>
+    </svg>
+    <span>
+      Success has occurred.
+    </span>
+  </div>
+</modus-wc-input-feedback>
+`;
+
+exports[`modus-wc-input-feedback should render with warning level 1`] = `
+<modus-wc-input-feedback level="warning" message="A warning has occurred.">
+  <div class="modus-wc-input-feedback modus-wc-input-feedback--md modus-wc-input-feedback--warning">
+    <svg class="mi-outline mi-warning" fill="currentColor" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
+    </svg>
+    <span>
+      A warning has occurred.
+    </span>
+  </div>
+</modus-wc-input-feedback>
+`;

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx
@@ -4,10 +4,8 @@ export const CheckIcon: FunctionalComponent = () => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
       fill="currentColor"
-      class="mi-outline mi-check-circle"
+      class="modus-wc-input-feedback-icon mi-outline mi-check-circle"
       viewBox="0 0 24 24"
     >
       <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m5.04-11.28V8.7c-.4-.39-1.03-.39-1.42 0L10.33 14l-2.6-2.62a.996.996 0 0 0-1.41 0 .984.984 0 0 0-.01 1.4l.01.01 3.3 3.34a1 1 0 0 0 1.42.01l6-6.01a.996.996 0 0 0 0-1.41" />
@@ -19,10 +17,8 @@ export const InfoIcon: FunctionalComponent = () => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
       fill="currentColor"
-      class="mi-outline mi-info"
+      class="modus-wc-input-feedback-icon mi-outline mi-info"
       viewBox="0 0 24 24"
     >
       <path d="M12 9.03c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1M12 22c5.52 0 10-4.48 10-10S17.52 2 12 2 2 6.48 2 12s4.48 10 10 10m0-18c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0 13c.55 0 1-.45 1-1v-4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1" />
@@ -34,10 +30,8 @@ export const WarningIcon: FunctionalComponent = () => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
       fill="currentColor"
-      class="mi-outline mi-warning"
+      class="modus-wc-input-feedback-icon mi-outline mi-warning"
       viewBox="0 0 24 24"
     >
       <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8" />

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx
@@ -1,0 +1,46 @@
+import { FunctionalComponent, h } from '@stencil/core';
+
+export const CheckIcon: FunctionalComponent = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="currentColor"
+      class="mi-outline mi-check-circle"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8m5.04-11.28V8.7c-.4-.39-1.03-.39-1.42 0L10.33 14l-2.6-2.62a.996.996 0 0 0-1.41 0 .984.984 0 0 0-.01 1.4l.01.01 3.3 3.34a1 1 0 0 0 1.42.01l6-6.01a.996.996 0 0 0 0-1.41" />
+    </svg>
+  );
+};
+
+export const InfoIcon: FunctionalComponent = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="currentColor"
+      class="mi-outline mi-info"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 9.03c.55 0 1-.45 1-1s-.45-1-1-1-1 .45-1 1 .45 1 1 1M12 22c5.52 0 10-4.48 10-10S17.52 2 12 2 2 6.48 2 12s4.48 10 10 10m0-18c4.41 0 8 3.59 8 8s-3.59 8-8 8-8-3.59-8-8 3.59-8 8-8m0 13c.55 0 1-.45 1-1v-4c0-.55-.45-1-1-1s-1 .45-1 1v4c0 .55.45 1 1 1" />
+    </svg>
+  );
+};
+
+export const WarningIcon: FunctionalComponent = () => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="currentColor"
+      class="mi-outline mi-warning"
+      viewBox="0 0 24 24"
+    >
+      <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8" />
+    </svg>
+  );
+};

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
@@ -15,12 +15,27 @@
   // Sizes
   &.modus-wc-input-feedback--sm {
     font-size: var(--modus-wc-font-size-xs);
+
+    .modus-wc-input-feedback-icon {
+      height: var(--modus-wc-font-size-lg);
+      width: var(--modus-wc-font-size-lg);
+    }
   }
   &.modus-wc-input-feedback--md {
     font-size: var(--modus-wc-font-size-sm);
+
+    .modus-wc-input-feedback-icon {
+      height: var(--modus-wc-font-size-xl);
+      width: var(--modus-wc-font-size-xl);
+    }
   }
   &.modus-wc-input-feedback--lg {
     font-size: var(--modus-wc-font-size-md);
+
+    .modus-wc-input-feedback-icon {
+      height: var(--modus-wc-font-size-2xl);
+      width: var(--modus-wc-font-size-2xl);
+    }
   }
 }
 

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
@@ -1,0 +1,61 @@
+/**
+* This component uses Tailwind CSS and DaisyUI.
+* Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
+*/
+
+.modus-wc-input-feedback {
+  display: flex;
+  align-items: center;
+  gap: var(--modus-wc-spacing-sm);
+
+  border-radius: 0 0 var(--modus-wc-border-radius-sm)
+    var(--modus-wc-border-radius-sm);
+  padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-sm);
+
+  // Sizes
+  &.modus-wc-input-feedback--sm {
+    font-size: var(--modus-wc-font-size-xs);
+  }
+  &.modus-wc-input-feedback--md {
+    font-size: var(--modus-wc-font-size-sm);
+  }
+  &.modus-wc-input-feedback--lg {
+    font-size: var(--modus-wc-font-size-md);
+  }
+}
+
+[data-theme='modus-classic-light'] .modus-wc-input-feedback,
+[data-theme='modus-modern-light'] .modus-wc-input-feedback {
+  // Levels
+  &.modus-wc-input-feedback--error {
+    color: var(--modus-wc-color-red);
+  }
+  &.modus-wc-input-feedback--info {
+    color: inherit;
+  }
+  &.modus-wc-input-feedback--success {
+    color: var(--modus-wc-color-green-dark);
+  }
+  &.modus-wc-input-feedback--warning {
+    color: var(--modus-wc-color-yellow-dark);
+  }
+}
+
+[data-theme='modus-classic-dark'] .modus-wc-input-feedback,
+[data-theme='modus-modern-dark'] .modus-wc-input-feedback {
+  color: var(--modus-wc-color-white);
+
+  // Levels
+  &.modus-wc-input-feedback--error {
+    background-color: var(--modus-wc-color-red);
+  }
+  &.modus-wc-input-feedback--info {
+    background-color: inherit;
+  }
+  &.modus-wc-input-feedback--success {
+    background-color: var(--modus-wc-color-green-dark);
+  }
+  &.modus-wc-input-feedback--warning {
+    background-color: var(--modus-wc-color-yellow-dark);
+  }
+}

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
@@ -31,7 +31,7 @@
     color: var(--modus-wc-color-red);
   }
   &.modus-wc-input-feedback--info {
-    color: inherit;
+    color: var(--modus-wc-color-trimble-blue);
   }
   &.modus-wc-input-feedback--success {
     color: var(--modus-wc-color-green-dark);
@@ -50,7 +50,7 @@
     background-color: var(--modus-wc-color-red);
   }
   &.modus-wc-input-feedback--info {
-    background-color: inherit;
+    background-color: var(--modus-wc-color-trimble-blue);
   }
   &.modus-wc-input-feedback--success {
     background-color: var(--modus-wc-color-green-dark);

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.spec.ts
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.spec.ts
@@ -1,0 +1,53 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ModusWcInputFeedback } from './modus-wc-input-feedback';
+import { ModusWcIcon } from '../modus-wc-icon/modus-wc-icon';
+
+describe('modus-wc-input-feedback', () => {
+  it('should render with default props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputFeedback],
+      html: '<modus-wc-input-feedback level="info"></modus-wc-input-feedback>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with custom class', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputFeedback],
+      html: '<modus-wc-input-feedback custom-class="test-class" level="info"></modus-wc-input-feedback>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with error level', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputFeedback],
+      html: '<modus-wc-input-feedback level="error" message="An error has occurred."></modus-wc-input-feedback>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with success level', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputFeedback],
+      html: '<modus-wc-input-feedback level="success" message="Success has occurred."></modus-wc-input-feedback>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with warning level', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputFeedback],
+      html: '<modus-wc-input-feedback level="warning" message="A warning has occurred."></modus-wc-input-feedback>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with a custom modus icon', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputFeedback, ModusWcIcon],
+      html: '<modus-wc-input-feedback icon="alert"></modus-wc-input-feedback>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+});

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.stories.ts
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.stories.ts
@@ -1,0 +1,71 @@
+import { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { IInputFeedbackLevel } from './modus-wc-input-feedback';
+import { ModusSize } from '../types';
+
+interface InputFeedbackArgs {
+  'custom-class'?: string;
+  icon?: string;
+  level: IInputFeedbackLevel;
+  message?: string;
+  size?: ModusSize;
+}
+
+const meta: Meta<InputFeedbackArgs> = {
+  title: 'Components/Forms/Input Feedback',
+  component: 'modus-wc-input-feedback',
+  args: {
+    level: 'error',
+    message: 'Uh oh. You done messed up.',
+    size: 'md',
+  },
+  argTypes: {
+    level: {
+      control: { type: 'select' },
+      options: ['error', 'info', 'success', 'warning'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<InputFeedbackArgs>;
+
+const Template: Story = {
+  render: (args) => {
+    // prettier-ignore
+    return html`
+<modus-wc-input-feedback
+  custom-class=${ifDefined(args['custom-class'])}
+  icon=${ifDefined(args.icon)}
+  level=${args.level}
+  message=${ifDefined(args.message)}
+  size=${ifDefined(args.size)}
+>
+</modus-wc-input-feedback>
+    `;
+  },
+};
+
+export const Default: Story = { ...Template };
+
+export const WithCustomModusIcon: Story = {
+  render: (args) => {
+    // prettier-ignore
+    return html`
+<modus-wc-input-feedback
+  custom-class=${ifDefined(args['custom-class'])}
+  icon='calendar_check'
+  level='success'
+  message='Event added to calendar!'
+  size=${ifDefined(args.size)}
+>
+</modus-wc-input-feedback>
+    `;
+  },
+};

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.tailwind.ts
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.tailwind.ts
@@ -1,0 +1,22 @@
+import { ModusSize } from '../types';
+import { IInputFeedbackLevel } from './modus-wc-input-feedback';
+
+export const convertPropsToClasses = ({
+  level,
+  size,
+}: {
+  level?: IInputFeedbackLevel;
+  size?: ModusSize;
+}): string => {
+  let classes = '';
+
+  if (level) {
+    classes = `${classes} modus-wc-input-feedback--${level}`;
+  }
+
+  if (size) {
+    classes = `${classes} modus-wc-input-feedback--${size}`;
+  }
+
+  return classes.trim();
+};

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.tsx
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.tsx
@@ -1,0 +1,91 @@
+import { Component, Element, h, Host, Prop } from '@stencil/core';
+import { Attributes, inheritAriaAttributes } from '../utils';
+import {
+  CheckIcon,
+  InfoIcon,
+  WarningIcon,
+} from './modus-wc-input-feedback.icons';
+import { ModusSize } from '../types';
+import { convertPropsToClasses } from './modus-wc-input-feedback.tailwind';
+
+export type IInputFeedbackLevel = 'error' | 'info' | 'success' | 'warning';
+
+/**
+ * A customizable feedback component used to provide additional context related to form input interactions.
+ *
+ * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
+ *
+ * Adheres to WCAG 2.2 standards.
+ */
+@Component({
+  tag: 'modus-wc-input-feedback',
+  styleUrl: 'modus-wc-input-feedback.scss',
+  shadow: false,
+})
+export class ModusWcInputFeedback {
+  private inheritedAttributes: Attributes = {};
+
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
+  /** Custom CSS class to apply to the outer div element. */
+  @Prop() customClass?: string = '';
+
+  /** The Modus icon to use instead of the pre-defined icons. */
+  @Prop() icon?: string = '';
+
+  /** The level informs which icon and color that will be rendered. */
+  @Prop() level!: IInputFeedbackLevel;
+
+  /** The message. */
+  @Prop() message?: string = '';
+
+  /** The size of the feedback component. */
+  @Prop() size?: ModusSize = 'md';
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
+
+  private getClasses(): string {
+    const classList = ['modus-wc-input-feedback'];
+    const propClasses = convertPropsToClasses({
+      level: this.level,
+      size: this.size,
+    });
+
+    // The order CSS classes are added matters to CSS specificity
+    if (propClasses) classList.push(propClasses);
+    if (this.customClass) classList.push(this.customClass);
+
+    return classList.join(' ');
+  }
+
+  private getPresetIcon() {
+    switch (this.level) {
+      case 'error':
+        return <WarningIcon />;
+      case 'info':
+        return <InfoIcon />;
+      case 'success':
+        return <CheckIcon />;
+      case 'warning':
+        return <WarningIcon />;
+    }
+  }
+
+  render() {
+    return (
+      <Host>
+        <div class={this.getClasses()} {...this.inheritedAttributes}>
+          {this.icon ? (
+            <modus-wc-icon decorative name={this.icon} />
+          ) : (
+            this.getPresetIcon()
+          )}
+          <span>{this.message}</span>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/modus-wc-input-feedback/readme.md
+++ b/src/components/modus-wc-input-feedback/readme.md
@@ -1,0 +1,42 @@
+# modus-wc-input-feedback
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+A customizable feedback component used to provide additional context related to form input interactions.
+
+<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
+
+Adheres to WCAG 2.2 standards.
+
+## Properties
+
+| Property             | Attribute      | Description                                                   | Type                                          | Default     |
+| -------------------- | -------------- | ------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `customClass`        | `custom-class` | Custom CSS class to apply to the outer div element.           | `string \| undefined`                         | `''`        |
+| `icon`               | `icon`         | The Modus icon to use instead of the pre-defined icons.       | `string \| undefined`                         | `''`        |
+| `level` _(required)_ | `level`        | The level informs which icon and color that will be rendered. | `"error" \| "info" \| "success" \| "warning"` | `undefined` |
+| `message`            | `message`      | The message.                                                  | `string \| undefined`                         | `''`        |
+| `size`               | `size`         | The size of the feedback component.                           | `"lg" \| "md" \| "sm" \| undefined`           | `'md'`      |
+
+
+## Dependencies
+
+### Depends on
+
+- [modus-wc-icon](../modus-wc-icon)
+
+### Graph
+```mermaid
+graph TD;
+  modus-wc-input-feedback --> modus-wc-icon
+  style modus-wc-input-feedback fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1799,7 +1799,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable feedback component used to provide additional context related to form input interactions.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable feedback component used to provide additional context related to form input interactions.\r\n\r\n<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcInputFeedback",
           "members": [
             {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1751,6 +1751,142 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx",
+      "declarations": [
+        {
+          "kind": "function",
+          "name": "CheckIcon"
+        },
+        {
+          "kind": "function",
+          "name": "InfoIcon"
+        },
+        {
+          "kind": "function",
+          "name": "WarningIcon"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "CheckIcon",
+          "declaration": {
+            "name": "CheckIcon",
+            "module": "src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "InfoIcon",
+          "declaration": {
+            "name": "InfoIcon",
+            "module": "src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "WarningIcon",
+          "declaration": {
+            "name": "WarningIcon",
+            "module": "src/components/modus-wc-input-feedback/modus-wc-input-feedback.icons.tsx"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/modus-wc-input-feedback/modus-wc-input-feedback.tsx",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A customizable feedback component used to provide additional context related to form input interactions.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "name": "ModusWcInputFeedback",
+          "members": [
+            {
+              "kind": "field",
+              "name": "el",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "description": "Reference to the host element"
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "custom-class",
+              "fieldName": "customClass",
+              "default": "''",
+              "description": "Custom CSS class to apply to the outer div element.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "icon",
+              "fieldName": "icon",
+              "default": "''",
+              "description": "The Modus icon to use instead of the pre-defined icons.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "level",
+              "fieldName": "level",
+              "description": "The level informs which icon and color that will be rendered.",
+              "type": {
+                "text": "IInputFeedbackLevel"
+              }
+            },
+            {
+              "name": "message",
+              "fieldName": "message",
+              "default": "''",
+              "description": "The message.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "size",
+              "fieldName": "size",
+              "default": "'md'",
+              "description": "The size of the feedback component.",
+              "type": {
+                "text": "ModusSize"
+              }
+            }
+          ],
+          "tagName": "modus-wc-input-feedback",
+          "events": [],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ModusWcInputFeedback",
+          "declaration": {
+            "name": "ModusWcInputFeedback",
+            "module": "src/components/modus-wc-input-feedback/modus-wc-input-feedback.tsx"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "modus-wc-input-feedback",
+          "declaration": {
+            "name": "ModusWcInputFeedback",
+            "module": "src/components/modus-wc-input-feedback/modus-wc-input-feedback.tsx"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/modus-wc-input-label/modus-wc-input-label.tsx",
       "declarations": [
         {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds a new component used by inputs to display various feedback states and messages. In an upcoming PR I will start adding this component to each of the input components.

I have included the SVG icons to match the Figma mocks but am also allowing the user to provide a custom Modus icon name.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tests added

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

