### PR TITLE
feat: add input-feedback to input components

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -427,6 +427,10 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
+        /**
           * The ID of the input element.
          */
         "inputId"?: string;
@@ -729,6 +733,10 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
+        /**
           * The ID of the input element.
          */
         "inputId"?: string;
@@ -939,6 +947,10 @@ export namespace Components {
           * Whether the form control is disabled.
          */
         "disabled"?: boolean;
+        /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
         /**
           * The ID of the input element.
          */
@@ -1262,6 +1274,10 @@ export namespace Components {
     | 'search'
     | 'send';
         /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
+        /**
           * The ID of the input element.
          */
         "inputId"?: string;
@@ -1349,6 +1365,10 @@ export namespace Components {
           * Whether the form control is disabled.
          */
         "disabled"?: boolean;
+        /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
         /**
           * The ID of the input element.
          */
@@ -2799,6 +2819,10 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
+        /**
           * The ID of the input element.
          */
         "inputId"?: string;
@@ -3117,6 +3141,10 @@ declare namespace LocalJSX {
          */
         "disabled"?: boolean;
         /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
+        /**
           * The ID of the input element.
          */
         "inputId"?: string;
@@ -3359,6 +3387,10 @@ declare namespace LocalJSX {
           * Whether the form control is disabled.
          */
         "disabled"?: boolean;
+        /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
         /**
           * The ID of the input element.
          */
@@ -3732,6 +3764,10 @@ declare namespace LocalJSX {
     | 'search'
     | 'send';
         /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
+        /**
           * The ID of the input element.
          */
         "inputId"?: string;
@@ -3835,6 +3871,10 @@ declare namespace LocalJSX {
           * Whether the form control is disabled.
          */
         "disabled"?: boolean;
+        /**
+          * Feedback to render below the input.
+         */
+        "feedback"?: IInputFeedbackProp;
         /**
           * The ID of the input element.
          */

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.scss
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.scss
@@ -65,7 +65,7 @@
 
     &:focus-within {
       border-color: var(--modus-wc-color-highlight-blue);
-      border-width: 2px;
+      border-width: var(--modus-wc-border-width-sm);
     }
   }
 

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.scss
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.scss
@@ -19,7 +19,7 @@
   --chkfg: var(--modus-wc-color-white);
 
   border-radius: var(--modus-wc-border-radius-sm);
-  border-width: 2px;
+  border-width: var(--modus-wc-border-width-sm);
 
   &.modus-wc-checkbox-xl {
     height: 4rem;

--- a/src/components/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
+++ b/src/components/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
@@ -12,3 +12,19 @@ exports[`modus-wc-date should render with custom props 1`] = `
   <input aria-describedby="description" aria-disabled="" aria-label="Test date" aria-labelledby="Another element" class="modus-wc-date modus-wc-input modus-wc-input-lg modus-wc-w-full test-class" disabled="" id="custom-id" max="11/25/2024" min="11/20/2024" name="test-name" required="" tabindex="1" type="date" value="Test value">
 </modus-wc-date>
 `;
+
+exports[`modus-wc-date should render with error feedback 1`] = `
+<modus-wc-date value="">
+  <input aria-label="Error input" class="modus-wc-date modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" type="date" value="">
+  <modus-wc-input-feedback>
+    <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
+      <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
+      </svg>
+      <span>
+        Test error message
+      </span>
+    </div>
+  </modus-wc-input-feedback>
+</modus-wc-date>
+`;

--- a/src/components/modus-wc-date/modus-wc-date.scss
+++ b/src/components/modus-wc-date/modus-wc-date.scss
@@ -1,3 +1,7 @@
+.modus-wc-input {
+  @include feedback-levels();
+}
+
 [data-theme='modus-classic-light'] .modus-wc-input,
 [data-theme='modus-classic-dark'] .modus-wc-input {
   border-radius: var(--modus-wc-border-radius-md);
@@ -28,7 +32,7 @@
 
   &:focus {
     border-color: var(--modus-wc-color-blue-light);
-    border-width: 2px;
+    border-width: var(--modus-wc-border-width-sm);
     box-shadow: none; // Removes the Tailwind ring effect
     outline: none; // Ensures there's no outline on focus
   }

--- a/src/components/modus-wc-date/modus-wc-date.spec.ts
+++ b/src/components/modus-wc-date/modus-wc-date.spec.ts
@@ -1,5 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ModusWcDate } from './modus-wc-date';
+import { ModusWcInputFeedback } from '../modus-wc-input-feedback/modus-wc-input-feedback';
+import { IInputFeedbackProp } from '../types';
 
 describe('modus-wc-date', () => {
   it('renders with default props', async () => {
@@ -33,6 +35,25 @@ describe('modus-wc-date', () => {
         value="Test value"
       ></modus-wc-date>`,
     });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with error feedback', async () => {
+    const feedback: IInputFeedbackProp = {
+      level: 'error',
+      message: 'Test error message',
+    };
+    const page = await newSpecPage({
+      components: [ModusWcDate, ModusWcInputFeedback],
+      html: '<modus-wc-date aria-label="Error input"></modus-wc-date>',
+    });
+
+    // Set feedback attribute
+    const component = page.rootInstance as ModusWcDate;
+    component.feedback = feedback;
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 

--- a/src/components/modus-wc-date/modus-wc-date.stories.ts
+++ b/src/components/modus-wc-date/modus-wc-date.stories.ts
@@ -2,12 +2,13 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 interface DateArgs {
   bordered?: boolean;
   'custom-class'?: string;
   disabled?: boolean;
+  feedback?: IInputFeedbackProp;
   'input-id'?: string;
   'input-tab-index'?: number;
   label?: string;
@@ -35,6 +36,19 @@ const meta: Meta<DateArgs> = {
     value: '',
   },
   argTypes: {
+    feedback: {
+      description: 'Feedback prop for input components',
+      table: {
+        type: {
+          detail: `
+            Interface: IInputFeedbackProp
+            Properties:
+            - level ('error' | 'info' | 'success' | 'warning'): The feedback level
+            - message (string, optional): The feedback message
+          `,
+        },
+      },
+    },
     size: {
       control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
@@ -60,6 +74,7 @@ export const Default: Story = {
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
         ?disabled=${args.disabled}
+        .feedback=${ifDefined(args.feedback)}
         input-id=${ifDefined(args['input-id'])}
         input-tab-index=${ifDefined(args['input-tab-index'])}
         label=${ifDefined(args.label)}
@@ -74,4 +89,21 @@ export const Default: Story = {
       ></modus-wc-date>
     `;
   },
+};
+
+const errorFeedback: IInputFeedbackProp = {
+  level: 'error',
+  message: 'Value is required.',
+};
+
+export const WithErrorFeedback: Story = {
+  render: (args) => html`
+    <modus-wc-date
+      aria-label="Date input"
+      .feedback=${errorFeedback}
+      label=${ifDefined(args.label)}
+      ?required=${true}
+      .value=${args.value}
+    ></modus-wc-date>
+  `,
 };

--- a/src/components/modus-wc-date/modus-wc-date.tailwind.ts
+++ b/src/components/modus-wc-date/modus-wc-date.tailwind.ts
@@ -1,14 +1,22 @@
+import { IInputFeedbackProp } from '../types';
+
 export const convertPropsToClasses = ({
   bordered,
+  feedback,
   size,
 }: {
   bordered?: boolean;
+  feedback?: IInputFeedbackProp;
   size?: 'sm' | 'md' | 'lg';
 }): string => {
   let classes = '';
 
   if (bordered) {
     classes = `${classes} modus-wc-input-bordered`;
+  }
+
+  if (feedback) {
+    classes = `${classes} modus-wc-input--${feedback.level}`;
   }
 
   if (size) {

--- a/src/components/modus-wc-date/modus-wc-date.tsx
+++ b/src/components/modus-wc-date/modus-wc-date.tsx
@@ -8,7 +8,7 @@ import {
   Event as StencilEvent,
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-date.tailwind';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
@@ -35,6 +35,9 @@ export class ModusWcDate {
 
   /** Whether the form control is disabled. */
   @Prop() disabled?: boolean = false;
+
+  /** Feedback to render below the input. */
+  @Prop() feedback?: IInputFeedbackProp;
 
   /** The ID of the input element. */
   @Prop() inputId?: string;
@@ -86,6 +89,7 @@ export class ModusWcDate {
     const classList = ['modus-wc-date', 'modus-wc-input', 'modus-wc-w-full'];
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
+      feedback: this.feedback,
       size: this.size,
     });
 
@@ -137,6 +141,13 @@ export class ModusWcDate {
           value={this.value}
           {...this.inheritedAttributes}
         />
+        {this.feedback && (
+          <modus-wc-input-feedback
+            level={this.feedback.level}
+            message={this.feedback.message}
+            size={this.size}
+          />
+        )}
       </Host>
     );
   }

--- a/src/components/modus-wc-date/readme.md
+++ b/src/components/modus-wc-date/readme.md
@@ -18,6 +18,7 @@ Adheres to WCAG 2.2 standards.
 | `bordered`      | `bordered`        | Indicates that the input should have a border.                                                          | `boolean \| undefined`              | `true`      |
 | `customClass`   | `custom-class`    | Custom CSS class to apply to the input.                                                                 | `string \| undefined`               | `''`        |
 | `disabled`      | `disabled`        | Whether the form control is disabled.                                                                   | `boolean \| undefined`              | `false`     |
+| `feedback`      | --                | Feedback to render below the input.                                                                     | `IInputFeedbackProp \| undefined`   | `undefined` |
 | `inputId`       | `input-id`        | The ID of the input element.                                                                            | `string \| undefined`               | `undefined` |
 | `inputTabIndex` | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`               | `undefined` |
 | `label`         | `label`           | The text to display within the label.                                                                   | `string \| undefined`               | `undefined` |
@@ -44,11 +45,14 @@ Adheres to WCAG 2.2 standards.
 ### Depends on
 
 - [modus-wc-input-label](../modus-wc-input-label)
+- [modus-wc-input-feedback](../modus-wc-input-feedback)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-date --> modus-wc-input-label
+  modus-wc-date --> modus-wc-input-feedback
+  modus-wc-input-feedback --> modus-wc-icon
   style modus-wc-date fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
@@ -10,7 +10,8 @@
 
   border-radius: 0 0 var(--modus-wc-border-radius-sm)
     var(--modus-wc-border-radius-sm);
-  padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-sm);
+  padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-sm)
+    var(--modus-wc-spacing-xs) 0;
 
   // Sizes
   &.modus-wc-input-feedback--sm {

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.scss
@@ -10,8 +10,7 @@
 
   border-radius: 0 0 var(--modus-wc-border-radius-sm)
     var(--modus-wc-border-radius-sm);
-  padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-sm)
-    var(--modus-wc-spacing-xs) 0;
+  padding: var(--modus-wc-spacing-xs) 0;
 
   // Sizes
   &.modus-wc-input-feedback--sm {

--- a/src/components/modus-wc-input-feedback/readme.md
+++ b/src/components/modus-wc-input-feedback/readme.md
@@ -28,7 +28,12 @@ Adheres to WCAG 2.2 standards.
 
 ### Used by
 
+ - [modus-wc-date](../modus-wc-date)
+ - [modus-wc-number-input](../modus-wc-number-input)
+ - [modus-wc-select](../modus-wc-select)
  - [modus-wc-text-input](../modus-wc-text-input)
+ - [modus-wc-textarea](../modus-wc-textarea)
+ - [modus-wc-time-input](../modus-wc-time-input)
 
 ### Depends on
 
@@ -38,7 +43,12 @@ Adheres to WCAG 2.2 standards.
 ```mermaid
 graph TD;
   modus-wc-input-feedback --> modus-wc-icon
+  modus-wc-date --> modus-wc-input-feedback
+  modus-wc-number-input --> modus-wc-input-feedback
+  modus-wc-select --> modus-wc-input-feedback
   modus-wc-text-input --> modus-wc-input-feedback
+  modus-wc-textarea --> modus-wc-input-feedback
+  modus-wc-time-input --> modus-wc-input-feedback
   style modus-wc-input-feedback fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
+++ b/src/components/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
@@ -19,3 +19,21 @@ exports[`modus-wc-number-input should render with default props 1`] = `
   </div>
 </modus-wc-number-input>
 `;
+
+exports[`modus-wc-number-input should render with error feedback 1`] = `
+<modus-wc-number-input value="">
+  <div class="modus-wc-input-container">
+    <input aria-label="Error input" aria-placeholder="" class="modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="numeric" placeholder="" type="number" value="">
+  </div>
+  <modus-wc-input-feedback>
+    <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
+      <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
+      </svg>
+      <span>
+        Test error message
+      </span>
+    </div>
+  </modus-wc-input-feedback>
+</modus-wc-number-input>
+`;

--- a/src/components/modus-wc-number-input/modus-wc-number-input.scss
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.scss
@@ -3,6 +3,10 @@
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
 
+.modus-wc-input {
+  @include feedback-levels();
+}
+
 // TODO - see if we can simplify this styling by overriding tailwind classes (see modus-wc-checkbox.scss)
 [data-theme='modus-classic-light'] .modus-wc-input-container,
 [data-theme='modus-classic-dark'] .modus-wc-input-container {
@@ -59,10 +63,6 @@
 
   .modus-wc-input,
   .modus-wc-input-currency {
-    &.modus-wc-input-bordered {
-      border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-6);
-    }
-
     // TODO - add support for xs and xl once added to Modus Figma
     &.modus-wc-input-sm {
       font-size: var(--modus-wc-font-size-sm);

--- a/src/components/modus-wc-number-input/modus-wc-number-input.spec.ts
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.spec.ts
@@ -1,5 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ModusWcNumberInput } from './modus-wc-number-input';
+import { ModusWcInputFeedback } from '../modus-wc-input-feedback/modus-wc-input-feedback';
+import { IInputFeedbackProp } from '../types';
 
 describe('modus-wc-number-input', () => {
   it('should render with default props', async () => {
@@ -38,6 +40,25 @@ describe('modus-wc-number-input', () => {
         value="test@example.com"
       ></modus-wc-number-input>`,
     });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with error feedback', async () => {
+    const feedback: IInputFeedbackProp = {
+      level: 'error',
+      message: 'Test error message',
+    };
+    const page = await newSpecPage({
+      components: [ModusWcNumberInput, ModusWcInputFeedback],
+      html: '<modus-wc-number-input aria-label="Error input"></modus-wc-number-input>',
+    });
+
+    // Set feedback attribute
+    const component = page.rootInstance as ModusWcNumberInput;
+    component.feedback = feedback;
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 

--- a/src/components/modus-wc-number-input/modus-wc-number-input.stories.ts
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.stories.ts
@@ -2,7 +2,7 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 interface NumberInputArgs {
   'auto-complete'?: 'on' | 'off';
@@ -10,6 +10,7 @@ interface NumberInputArgs {
   'currency-symbol'?: string;
   'custom-class'?: string;
   disabled?: boolean;
+  feedback?: IInputFeedbackProp;
   'input-aria-invalid'?: 'true' | 'false';
   'input-id'?: string;
   'input-mode': 'decimal' | 'none' | 'numeric';
@@ -43,6 +44,19 @@ const meta: Meta<NumberInputArgs> = {
     'auto-complete': {
       control: { type: 'select' },
       options: ['on', 'off'],
+    },
+    feedback: {
+      description: 'Feedback prop for input components',
+      table: {
+        type: {
+          detail: `
+            Interface: IInputFeedbackProp
+            Properties:
+            - level ('error' | 'info' | 'success' | 'warning'): The feedback level
+            - message (string, optional): The feedback message
+          `,
+        },
+      },
     },
     'input-aria-invalid': {
       control: { type: 'select' },
@@ -82,6 +96,7 @@ const Template: Story = {
       currency-symbol=${ifDefined(args['currency-symbol'])}
       custom-class=${ifDefined(args['custom-class'])}
       ?disabled=${args.disabled}
+      .feedback=${ifDefined(args.feedback)}
       input-aria-invalid=${ifDefined(args['input-aria-invalid'])}
       input-id=${ifDefined(args['input-id'])}
       input-mode=${args['input-mode']}
@@ -103,7 +118,17 @@ const Template: Story = {
 
 export const Default: Story = { ...Template };
 
+const errorFeedback: IInputFeedbackProp = {
+  level: 'error',
+  message: 'Value is required.',
+};
+
 export const Currency: Story = {
   ...Template,
   args: { 'currency-symbol': '$' },
+};
+
+export const WithErrorFeedback: Story = {
+  ...Template,
+  args: { feedback: errorFeedback, required: true },
 };

--- a/src/components/modus-wc-number-input/modus-wc-number-input.tailwind.ts
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.tailwind.ts
@@ -1,14 +1,22 @@
+import { IInputFeedbackProp } from '../types';
+
 export const convertPropsToClasses = ({
   bordered,
+  feedback,
   size,
 }: {
   bordered?: boolean;
+  feedback?: IInputFeedbackProp;
   size?: string;
 }): string => {
   let classes = '';
 
   if (bordered) {
     classes = `${classes} modus-wc-input-bordered`;
+  }
+
+  if (feedback) {
+    classes = `${classes} modus-wc-input--${feedback.level}`;
   }
 
   if (size) {

--- a/src/components/modus-wc-number-input/modus-wc-number-input.tsx
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.tsx
@@ -8,7 +8,7 @@ import {
   Event as StencilEvent,
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-number-input.tailwind';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
@@ -41,6 +41,9 @@ export class ModusWcNumberInput {
 
   /** Whether the form control is disabled. */
   @Prop() disabled?: boolean = false;
+
+  /** Feedback to render below the input. */
+  @Prop() feedback?: IInputFeedbackProp;
 
   /** The ID of the input element. */
   @Prop() inputId?: string;
@@ -108,6 +111,7 @@ export class ModusWcNumberInput {
     const classList = [...styleList];
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
+      feedback: this.feedback,
       size: this.size,
     });
 
@@ -200,6 +204,13 @@ export class ModusWcNumberInput {
             {...this.inheritedAttributes}
           />
         </div>
+        {this.feedback && (
+          <modus-wc-input-feedback
+            level={this.feedback.level}
+            message={this.feedback.message}
+            size={this.size}
+          />
+        )}
       </Host>
     );
   }

--- a/src/components/modus-wc-number-input/readme.md
+++ b/src/components/modus-wc-number-input/readme.md
@@ -20,6 +20,7 @@ Adheres to WCAG 2.2 standards.
 | `currencySymbol` | `currency-symbol` | The currency symbol to display.                                                                                                                                          | `string \| undefined`               | `''`        |
 | `customClass`    | `custom-class`    | Custom CSS class to apply to the input.                                                                                                                                  | `string \| undefined`               | `''`        |
 | `disabled`       | `disabled`        | Whether the form control is disabled.                                                                                                                                    | `boolean \| undefined`              | `false`     |
+| `feedback`       | --                | Feedback to render below the input.                                                                                                                                      | `IInputFeedbackProp \| undefined`   | `undefined` |
 | `inputId`        | `input-id`        | The ID of the input element.                                                                                                                                             | `string \| undefined`               | `undefined` |
 | `inputMode`      | `input-mode`      | Hints at the type of data that might be entered by the user while editing the element or its contents. This allows a browser to display an appropriate virtual keyboard. | `"decimal" \| "none" \| "numeric"`  | `'numeric'` |
 | `inputTabIndex`  | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key).                                                                  | `number \| undefined`               | `undefined` |
@@ -50,11 +51,14 @@ Adheres to WCAG 2.2 standards.
 ### Depends on
 
 - [modus-wc-input-label](../modus-wc-input-label)
+- [modus-wc-input-feedback](../modus-wc-input-feedback)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-number-input --> modus-wc-input-label
+  modus-wc-number-input --> modus-wc-input-feedback
+  modus-wc-input-feedback --> modus-wc-icon
   style modus-wc-number-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/modus-wc-radio/modus-wc-radio.scss
+++ b/src/components/modus-wc-radio/modus-wc-radio.scss
@@ -16,7 +16,7 @@
 [data-theme='modus-classic-dark'] .modus-wc-radio {
   --fallback-bc: var(--modus-wc-color-gray-4);
 
-  border-width: 2px;
+  border-width: var(--modus-wc-border-width-sm);
 
   &.modus-wc-radio-xl {
     height: 4rem;

--- a/src/components/modus-wc-select/__snapshots__/modus-wc-select.spec.ts.snap
+++ b/src/components/modus-wc-select/__snapshots__/modus-wc-select.spec.ts.snap
@@ -12,3 +12,19 @@ exports[`modus-wc-select should render with custom props 1`] = `
   <select aria-describedby="description" aria-label="Test select" class="modus-wc-select modus-wc-select-lg modus-wc-w-full test-class" disabled="" id="custom-id" name="test-name" required="" tabindex="1"></select>
 </modus-wc-select>
 `;
+
+exports[`modus-wc-select should render with error feedback 1`] = `
+<modus-wc-select value="">
+  <select aria-label="Error input" class="modus-wc-input--error modus-wc-select modus-wc-select-bordered modus-wc-select-md modus-wc-w-full"></select>
+  <modus-wc-input-feedback>
+    <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
+      <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
+      </svg>
+      <span>
+        Test error message
+      </span>
+    </div>
+  </modus-wc-input-feedback>
+</modus-wc-select>
+`;

--- a/src/components/modus-wc-select/modus-wc-select.scss
+++ b/src/components/modus-wc-select/modus-wc-select.scss
@@ -3,6 +3,10 @@
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
 
+.modus-wc-input {
+  @include feedback-levels();
+}
+
 [data-theme='modus-classic-light'] .modus-wc-select,
 [data-theme='modus-classic-dark'] .modus-wc-select {
   border-radius: var(--modus-wc-border-radius-md);
@@ -36,7 +40,7 @@
 
   &:focus {
     border-color: var(--modus-wc-color-blue-light);
-    border-width: 2px;
+    border-width: var(--modus-wc-border-width-sm);
     box-shadow: none; // Removes the Tailwind ring effect
     outline: none; // Ensures there's no outline on focus
   }

--- a/src/components/modus-wc-select/modus-wc-select.spec.ts
+++ b/src/components/modus-wc-select/modus-wc-select.spec.ts
@@ -1,5 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ModusWcSelect } from './modus-wc-select';
+import { ModusWcInputFeedback } from '../modus-wc-input-feedback/modus-wc-input-feedback';
+import { IInputFeedbackProp } from '../types';
 
 describe('modus-wc-select', () => {
   it('renders with default props', async () => {
@@ -31,6 +33,25 @@ describe('modus-wc-select', () => {
         value="1"
       ></modus-wc-select>`,
     });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with error feedback', async () => {
+    const feedback: IInputFeedbackProp = {
+      level: 'error',
+      message: 'Test error message',
+    };
+    const page = await newSpecPage({
+      components: [ModusWcSelect, ModusWcInputFeedback],
+      html: '<modus-wc-select aria-label="Error input"></modus-wc-select>',
+    });
+
+    // Set feedback attribute
+    const component = page.rootInstance as ModusWcSelect;
+    component.feedback = feedback;
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 

--- a/src/components/modus-wc-select/modus-wc-select.stories.ts
+++ b/src/components/modus-wc-select/modus-wc-select.stories.ts
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { ISelectOption } from './modus-wc-select';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 const options: ISelectOption[] = [
   { label: 'Option 1', value: '1' },
@@ -15,6 +15,7 @@ interface SelectArgs {
   bordered?: boolean;
   'custom-class'?: string;
   disabled?: boolean;
+  feedback?: IInputFeedbackProp;
   'input-aria-invalid'?: 'true' | 'false';
   'input-id'?: string;
   'input-tab-index'?: number;
@@ -38,6 +39,19 @@ const meta: Meta<SelectArgs> = {
     value: '',
   },
   argTypes: {
+    feedback: {
+      description: 'Feedback prop for input components',
+      table: {
+        type: {
+          detail: `
+            Interface: IInputFeedbackProp
+            Properties:
+            - level ('error' | 'info' | 'success' | 'warning'): The feedback level
+            - message (string, optional): The feedback message
+          `,
+        },
+      },
+    },
     'input-aria-invalid': {
       control: { type: 'select' },
       options: ['true', 'false'],
@@ -80,6 +94,7 @@ export const Default: Story = {
       ?bordered=${args.bordered}
       custom-class=${ifDefined(args['custom-class'])}
       ?disabled=${args.disabled}
+      .feedback=${ifDefined(args.feedback)}
       input-aria-invalid=${ifDefined(args['input-aria-invalid'])}
       input-id=${ifDefined(args['input-id'])}
       input-tab-index=${ifDefined(args['input-tab-index'])}
@@ -93,33 +108,20 @@ export const Default: Story = {
   `,
 };
 
-export const SelectWithLabel: Story = {
-  render: () => {
-    // prettier-ignore
-    return html`
-<style>
-  .form-control {
-    display: flex;
-    align-items: center;
-  }
-  .modus-wc-input-label {
-    padding-inline-end: 8px;
-  }
-</style>
-<form action="" method="get">
-  <div class="form-control">
-    <modus-wc-input-label
-      for-id="select-input"
-      label-text="Example select"
-    ></modus-wc-input-label>
+const errorFeedback: IInputFeedbackProp = {
+  level: 'error',
+  message: 'Value is required.',
+};
+
+export const WithErrorFeedback: Story = {
+  render: (args) => html`
     <modus-wc-select
-      aria-label="Example select"
-      input-id="select-input"
-      name="example-select-input"
-      .options=${options}
+      aria-label="Select input"
+      .feedback=${errorFeedback}
+      label=${ifDefined(args.label)}
+      .options=${[]}
+      ?required=${true}
+      .value=${args.value}
     ></modus-wc-select>
-  </div>
-</form>
-    `;
-  },
+  `,
 };

--- a/src/components/modus-wc-select/modus-wc-select.tailwind.ts
+++ b/src/components/modus-wc-select/modus-wc-select.tailwind.ts
@@ -1,16 +1,22 @@
-import { DaisySize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 export const convertPropsToClasses = ({
   bordered,
+  feedback,
   size,
 }: {
   bordered?: boolean;
-  size?: DaisySize;
+  feedback?: IInputFeedbackProp;
+  size?: ModusSize;
 }): string => {
   let classes = '';
 
   if (bordered) {
     classes = `${classes} modus-wc-select-bordered`;
+  }
+
+  if (feedback) {
+    classes = `${classes} modus-wc-input--${feedback.level}`;
   }
 
   if (size) {

--- a/src/components/modus-wc-select/modus-wc-select.tsx
+++ b/src/components/modus-wc-select/modus-wc-select.tsx
@@ -8,7 +8,7 @@ import {
   Event as StencilEvent,
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-select.tailwind';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 export interface ISelectOption {
@@ -44,6 +44,9 @@ export class ModusWcSelect {
 
   /** Whether the form control is disabled. */
   @Prop() disabled?: boolean = false;
+
+  /** Feedback to render below the input. */
+  @Prop() feedback?: IInputFeedbackProp;
 
   /** The ID of the input element. */
   @Prop() inputId?: string;
@@ -91,6 +94,7 @@ export class ModusWcSelect {
 
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
+      feedback: this.feedback,
       size: this.size,
     });
 
@@ -146,6 +150,13 @@ export class ModusWcSelect {
             </option>
           ))}
         </select>
+        {this.feedback && (
+          <modus-wc-input-feedback
+            level={this.feedback.level}
+            message={this.feedback.message}
+            size={this.size}
+          />
+        )}
       </Host>
     );
   }

--- a/src/components/modus-wc-select/readme.md
+++ b/src/components/modus-wc-select/readme.md
@@ -18,6 +18,7 @@ Adheres to WCAG 2.2 standards.
 | `bordered`      | `bordered`        | Indicates that the input should have a border.                                                          | `boolean \| undefined`              | `true`      |
 | `customClass`   | `custom-class`    | Custom CSS class to apply to the inner div.                                                             | `string \| undefined`               | `''`        |
 | `disabled`      | `disabled`        | Whether the form control is disabled.                                                                   | `boolean \| undefined`              | `false`     |
+| `feedback`      | --                | Feedback to render below the input.                                                                     | `IInputFeedbackProp \| undefined`   | `undefined` |
 | `inputId`       | `input-id`        | The ID of the input element.                                                                            | `string \| undefined`               | `undefined` |
 | `inputTabIndex` | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key). | `number \| undefined`               | `undefined` |
 | `label`         | `label`           | The text to display within the label.                                                                   | `string \| undefined`               | `undefined` |
@@ -42,11 +43,14 @@ Adheres to WCAG 2.2 standards.
 ### Depends on
 
 - [modus-wc-input-label](../modus-wc-input-label)
+- [modus-wc-input-feedback](../modus-wc-input-feedback)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-select --> modus-wc-input-label
+  modus-wc-select --> modus-wc-input-feedback
+  modus-wc-input-feedback --> modus-wc-icon
   style modus-wc-select fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/modus-wc-text-input/modus-wc-text-input.scss
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.scss
@@ -3,6 +3,10 @@
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
 
+.modus-wc-input {
+  @include feedback-levels();
+}
+
 label.modus-wc-input-label {
   padding-bottom: var(--modus-wc-spacing-xs);
 }
@@ -37,27 +41,13 @@ label.modus-wc-input-label {
   }
 
   &:focus {
-    border-width: 2px;
+    border-width: var(--modus-wc-border-width-sm);
     box-shadow: none; // Removes the Tailwind ring effect
     outline: none; // Ensures there's no outline on focus
   }
 
   &:read-only {
     background-color: var(--modus-wc-color-base-100);
-  }
-
-  // Feedback levels
-  &.modus-wc-input--error {
-    border-color: var(--modus-wc-color-red) !important;
-  }
-  &.modus-wc-input--info {
-    border-color: var(--modus-wc-color-trimble-blue) !important;
-  }
-  &.modus-wc-input--success {
-    border-color: var(--modus-wc-color-green-dark) !important;
-  }
-  &.modus-wc-input--warning {
-    border-color: var(--modus-wc-color-yellow-dark) !important;
   }
 }
 

--- a/src/components/modus-wc-textarea/__snapshots__/modus-wc-textarea.spec.ts.snap
+++ b/src/components/modus-wc-textarea/__snapshots__/modus-wc-textarea.spec.ts.snap
@@ -10,3 +10,18 @@ exports[`modus-wc-textarea should render with custom props 1`] = `
   <modus-wc-input-label forid="custom-id" labeltext="Test label" required="" size="lg"></modus-wc-input-label><textarea aria-describedby="description" aria-label="Test textarea" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-textarea modus-wc-textarea-lg modus-wc-w-full test-class" disabled="" id="custom-id" maxlength="100" name="test-name" placeholder="Test placeholder" readonly="" required="" rows="5" tabindex="1" value="Test value"></textarea>
 </modus-wc-textarea>
 `;
+
+exports[`modus-wc-textarea should render with error feedback 1`] = `
+<modus-wc-textarea value=""><textarea aria-label="Error input" aria-placeholder="" class="modus-wc-input--error modus-wc-textarea modus-wc-textarea-bordered modus-wc-textarea-md modus-wc-w-full" placeholder="" value=""></textarea>
+  <modus-wc-input-feedback>
+    <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
+      <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
+      </svg>
+      <span>
+        Test error message
+      </span>
+    </div>
+  </modus-wc-input-feedback>
+</modus-wc-textarea>
+`;

--- a/src/components/modus-wc-textarea/modus-wc-textarea.scss
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.scss
@@ -3,6 +3,10 @@
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
 
+.modus-wc-input {
+  @include feedback-levels();
+}
+
 // TODO - see if we can simplify this styling by overriding tailwind classes (see modus-wc-checkbox.scss)
 [data-theme='modus-classic-light'] .modus-wc-textarea,
 [data-theme='modus-classic-dark'] .modus-wc-textarea {
@@ -32,7 +36,7 @@
 
   &:focus {
     border-color: var(--modus-wc-color-blue-light);
-    border-width: 2px;
+    border-width: var(--modus-wc-border-width-sm);
     box-shadow: none; // Removes the Tailwind ring effect
     outline: none; // Ensures there's no outline on focus
   }

--- a/src/components/modus-wc-textarea/modus-wc-textarea.spec.ts
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.spec.ts
@@ -1,5 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ModusWcTextarea } from './modus-wc-textarea';
+import { ModusWcInputFeedback } from '../modus-wc-input-feedback/modus-wc-input-feedback';
+import { IInputFeedbackProp } from '../types';
 
 describe('modus-wc-textarea', () => {
   it('renders with default props', async () => {
@@ -34,6 +36,25 @@ describe('modus-wc-textarea', () => {
         value="Test value"
       ></modus-wc-textarea>`,
     });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with error feedback', async () => {
+    const feedback: IInputFeedbackProp = {
+      level: 'error',
+      message: 'Test error message',
+    };
+    const page = await newSpecPage({
+      components: [ModusWcTextarea, ModusWcInputFeedback],
+      html: '<modus-wc-textarea aria-label="Error input"></modus-wc-textarea>',
+    });
+
+    // Set feedback attribute
+    const component = page.rootInstance as ModusWcTextarea;
+    component.feedback = feedback;
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 

--- a/src/components/modus-wc-textarea/modus-wc-textarea.stories.ts
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.stories.ts
@@ -2,7 +2,7 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { DaisySize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 interface TextAreaArgs {
   'auto-correct': 'on' | 'off';
@@ -17,6 +17,7 @@ interface TextAreaArgs {
     | 'previous'
     | 'search'
     | 'send';
+  feedback?: IInputFeedbackProp;
   'input-aria-invalid'?: 'grammar' | 'spelling' | 'true' | 'false';
   'input-id'?: string;
   'input-tab-index'?: number;
@@ -27,7 +28,7 @@ interface TextAreaArgs {
   readonly?: boolean;
   required?: boolean;
   rows?: number;
-  size?: DaisySize;
+  size?: ModusSize;
   spellcheck?: boolean;
   value: string;
 }
@@ -52,6 +53,19 @@ const meta: Meta<TextAreaArgs> = {
     },
     enterkeyhint: {
       options: ['enter', 'done', 'go', 'next', 'previous', 'search', 'send'],
+    },
+    feedback: {
+      description: 'Feedback prop for input components',
+      table: {
+        type: {
+          detail: `
+            Interface: IInputFeedbackProp
+            Properties:
+            - level ('error' | 'info' | 'success' | 'warning'): The feedback level
+            - message (string, optional): The feedback message
+          `,
+        },
+      },
     },
     'input-aria-invalid': {
       control: {
@@ -94,6 +108,7 @@ export const Default: Story = {
         custom-class=${ifDefined(args['custom-class'])}
         enterkeyhint=${ifDefined(args.enterkeyhint)}
         ?disabled=${args.disabled}
+        .feedback=${ifDefined(args.feedback)}
         input-aria-invalid=${ifDefined(args['input-aria-invalid'])}
         input-id=${ifDefined(args['input-id'])}
         input-tab-index=${ifDefined(args['input-tab-index'])}
@@ -110,4 +125,21 @@ export const Default: Story = {
       ></modus-wc-textarea>
     `;
   },
+};
+
+const errorFeedback: IInputFeedbackProp = {
+  level: 'error',
+  message: 'Value is required.',
+};
+
+export const WithErrorFeedback: Story = {
+  render: (args) => html`
+    <modus-wc-textarea
+      aria-label="Textarea input"
+      .feedback=${errorFeedback}
+      label=${ifDefined(args.label)}
+      ?required=${true}
+      .value=${args.value}
+    ></modus-wc-textarea>
+  `,
 };

--- a/src/components/modus-wc-textarea/modus-wc-textarea.tailwind.ts
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.tailwind.ts
@@ -1,16 +1,22 @@
-import { DaisySize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 export const convertPropsToClasses = ({
   bordered,
+  feedback,
   size,
 }: {
   bordered?: boolean;
-  size?: DaisySize;
+  feedback?: IInputFeedbackProp;
+  size?: ModusSize;
 }): string => {
   let classes = '';
 
   if (bordered) {
     classes = `${classes} modus-wc-textarea-bordered`;
+  }
+
+  if (feedback) {
+    classes = `${classes} modus-wc-input--${feedback.level}`;
   }
 
   if (size) {

--- a/src/components/modus-wc-textarea/modus-wc-textarea.tsx
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.tsx
@@ -8,7 +8,7 @@ import {
   Event as StencilEvent,
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-textarea.tailwind';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes, inheritAttributes } from '../utils';
 
 /**
@@ -48,6 +48,9 @@ export class ModusWcTextarea {
     | 'previous'
     | 'search'
     | 'send';
+
+  /** Feedback to render below the input. */
+  @Prop() feedback?: IInputFeedbackProp;
 
   /** The ID of the input element. */
   @Prop() inputId?: string;
@@ -106,6 +109,7 @@ export class ModusWcTextarea {
     const classList = ['modus-wc-textarea', 'modus-wc-w-full'];
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
+      feedback: this.feedback,
       size: this.size,
     });
 
@@ -160,6 +164,13 @@ export class ModusWcTextarea {
           value={this.value}
           {...this.inheritedAttributes}
         />
+        {this.feedback && (
+          <modus-wc-input-feedback
+            level={this.feedback.level}
+            message={this.feedback.message}
+            size={this.size}
+          />
+        )}
       </Host>
     );
   }

--- a/src/components/modus-wc-textarea/readme.md
+++ b/src/components/modus-wc-textarea/readme.md
@@ -20,6 +20,7 @@ Adheres to WCAG 2.2 standards.
 | `customClass`   | `custom-class`    | Custom CSS class to apply to the textarea (supports DaisyUI).                   | `string \| undefined`                                                                  | `''`        |
 | `disabled`      | `disabled`        | The disabled state of the textarea.                                             | `boolean \| undefined`                                                                 | `false`     |
 | `enterkeyhint`  | `enterkeyhint`    | A hint to the browser for which enter key to display.                           | `"done" \| "enter" \| "go" \| "next" \| "previous" \| "search" \| "send" \| undefined` | `undefined` |
+| `feedback`      | --                | Feedback to render below the input.                                             | `IInputFeedbackProp \| undefined`                                                      | `undefined` |
 | `inputId`       | `input-id`        | The ID of the input element.                                                    | `string \| undefined`                                                                  | `undefined` |
 | `inputTabIndex` | `input-tab-index` | The tabindex of the input.                                                      | `number \| undefined`                                                                  | `undefined` |
 | `label`         | `label`           | The text to display within the label.                                           | `string \| undefined`                                                                  | `undefined` |
@@ -47,11 +48,14 @@ Adheres to WCAG 2.2 standards.
 ### Depends on
 
 - [modus-wc-input-label](../modus-wc-input-label)
+- [modus-wc-input-feedback](../modus-wc-input-feedback)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-textarea --> modus-wc-input-label
+  modus-wc-textarea --> modus-wc-input-feedback
+  modus-wc-input-feedback --> modus-wc-icon
   style modus-wc-textarea fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
+++ b/src/components/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
@@ -12,3 +12,19 @@ exports[`modus-wc-time-input should render with default props 1`] = `
   <input aria-label="Default input" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" list="test-list" step="60" type="time" value="">
 </modus-wc-time-input>
 `;
+
+exports[`modus-wc-time-input should render with error feedback 1`] = `
+<modus-wc-time-input value="">
+  <input aria-label="Error input" class="modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" list="modus-wc-datalist-test-random-id" step="60" type="time" value="">
+  <modus-wc-input-feedback>
+    <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
+      <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 15.12c-.67 0-1.21.54-1.21 1.19s.54 1.21 1.21 1.21 1.21-.54 1.21-1.21-.54-1.19-1.21-1.19m0-1.61c.36 0 .62-.26.66-.7l.39-5.04s.01-.1.01-.14c0-.63-.45-1.15-1.06-1.15s-1.06.51-1.06 1.15v.14l.4 5.04c.04.44.28.7.66.7M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8"></path>
+      </svg>
+      <span>
+        Test error message
+      </span>
+    </div>
+  </modus-wc-input-feedback>
+</modus-wc-time-input>
+`;

--- a/src/components/modus-wc-time-input/modus-wc-time-input.scss
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.scss
@@ -3,6 +3,10 @@
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
 
+.modus-wc-input {
+  @include feedback-levels();
+}
+
 [data-theme='modus-classic-light'] .modus-wc-input,
 [data-theme='modus-classic-dark'] .modus-wc-input {
   border-radius: var(--modus-wc-border-radius-md);
@@ -32,7 +36,7 @@
   &:focus,
   &:focus-within {
     border-color: var(--modus-wc-color-blue-light);
-    border-width: 2px;
+    border-width: var(--modus-wc-border-width-sm);
     box-shadow: none; // Removes the Tailwind ring effect
     outline: none; // Ensures there's no outline on focus
   }

--- a/src/components/modus-wc-time-input/modus-wc-time-input.spec.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.spec.ts
@@ -1,5 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { ModusWcTimeInput } from './modus-wc-time-input';
+import { ModusWcInputFeedback } from '../modus-wc-input-feedback/modus-wc-input-feedback';
+import { IInputFeedbackProp } from '../types';
 
 describe('modus-wc-time-input', () => {
   it('should render with default props', async () => {
@@ -35,6 +37,25 @@ describe('modus-wc-time-input', () => {
                 value="12:00">
               </modus-wc-time-input>`,
     });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with error feedback', async () => {
+    const feedback: IInputFeedbackProp = {
+      level: 'error',
+      message: 'Test error message',
+    };
+    const page = await newSpecPage({
+      components: [ModusWcTimeInput, ModusWcInputFeedback],
+      html: '<modus-wc-time-input aria-label="Error input"></modus-wc-time-input>',
+    });
+
+    // Set feedback attribute
+    const component = page.rootInstance as ModusWcTimeInput;
+    component.feedback = feedback;
+
+    await page.waitForChanges();
+
     expect(page.root).toMatchSnapshot();
   });
 

--- a/src/components/modus-wc-time-input/modus-wc-time-input.stories.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.stories.ts
@@ -2,7 +2,7 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 // const timeOptions = ['08:00', '12:00', '17:00'];
 
@@ -13,6 +13,7 @@ interface TimeInputArgs {
   'datalist-id'?: string;
   'datalist-options'?: string[];
   disabled?: boolean;
+  feedback?: IInputFeedbackProp;
   'input-id'?: string;
   'input-tab-index'?: number;
   label?: string;
@@ -40,6 +41,19 @@ const meta: Meta<TimeInputArgs> = {
       control: { type: 'select' },
       options: ['on', 'off'],
     },
+    feedback: {
+      description: 'Feedback prop for input components',
+      table: {
+        type: {
+          detail: `
+            Interface: IInputFeedbackProp
+            Properties:
+            - level ('error' | 'info' | 'success' | 'warning'): The feedback level
+            - message (string, optional): The feedback message
+          `,
+        },
+      },
+    },
     size: {
       control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
@@ -66,6 +80,7 @@ export const Template: Story = {
       custom-class=${ifDefined(args['custom-class'])}
       datalist-id=${ifDefined(args['datalist-id'])}
       ?disabled=${args.disabled}
+      .feedback=${ifDefined(args.feedback)}
       input-id=${ifDefined(args['input-id'])}
       input-tab-index=${ifDefined(args['input-tab-index'])}
       label=${ifDefined(args.label)}
@@ -83,7 +98,7 @@ export const Template: Story = {
   `,
 };
 
-export const TimeInputWithSeconds: Story = {
+export const WithSeconds: Story = {
   render: () => {
     return html`
       <modus-wc-time-input
@@ -94,7 +109,7 @@ export const TimeInputWithSeconds: Story = {
   },
 };
 
-export const TimeInputWithDatalist: Story = {
+export const WithDatalist: Story = {
   render: () => {
     // prettier-ignore
     return html`
@@ -111,7 +126,7 @@ export const TimeInputWithDatalist: Story = {
   },
 };
 
-export const TimeInputWithDatalistOptions: Story = {
+export const WithDatalistOptions: Story = {
   render: () => {
     // prettier-ignore
     return html`
@@ -128,4 +143,21 @@ export const TimeInputWithDatalistOptions: Story = {
 ></modus-wc-time-input>
     `;
   },
+};
+
+const errorFeedback: IInputFeedbackProp = {
+  level: 'error',
+  message: 'Value is required.',
+};
+
+export const WithErrorFeedback: Story = {
+  render: (args) => html`
+    <modus-wc-time-input
+      aria-label="Time input"
+      .feedback=${errorFeedback}
+      label=${ifDefined(args.label)}
+      ?required=${true}
+      .value=${args.value}
+    ></modus-wc-time-input>
+  `,
 };

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tailwind.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tailwind.ts
@@ -1,16 +1,22 @@
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 
 export const convertPropsToClasses = ({
   bordered,
+  feedback,
   size,
 }: {
   bordered?: boolean;
+  feedback?: IInputFeedbackProp;
   size?: ModusSize;
 }): string => {
   let classes = '';
 
   if (bordered) {
     classes = `${classes} modus-wc-input-bordered`;
+  }
+
+  if (feedback) {
+    classes = `${classes} modus-wc-input--${feedback.level}`;
   }
 
   if (size) {

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tsx
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tsx
@@ -8,7 +8,7 @@ import {
   Event as StencilEvent,
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-time-input.tailwind';
-import { ModusSize } from '../types';
+import { IInputFeedbackProp, ModusSize } from '../types';
 import { generateRandomId } from '../utils';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
@@ -42,6 +42,9 @@ export class ModusWcTimeInput {
 
   /** Whether the form control is disabled. */
   @Prop() disabled?: boolean = false;
+
+  /** Feedback to render below the input. */
+  @Prop() feedback?: IInputFeedbackProp;
 
   /** The ID of the input element. */
   @Prop() inputId?: string;
@@ -126,6 +129,7 @@ export class ModusWcTimeInput {
 
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
+      feedback: this.feedback,
       size: this.size,
     });
 
@@ -209,6 +213,13 @@ export class ModusWcTimeInput {
           {...this.inheritedAttributes}
         />
         {this.renderDatalist()}
+        {this.feedback && (
+          <modus-wc-input-feedback
+            level={this.feedback.level}
+            message={this.feedback.message}
+            size={this.size}
+          />
+        )}
       </Host>
     );
   }

--- a/src/components/modus-wc-time-input/readme.md
+++ b/src/components/modus-wc-time-input/readme.md
@@ -21,6 +21,7 @@ Adheres to WCAG 2.2 standards.
 | `datalistId`      | `datalist-id`     | ID of a `<datalist>` element that contains pre-defined time options. The value must be the ID of a `<datalist>` element in the same document.                                                                                                                                | `string \| undefined`               | `undefined` |
 | `datalistOptions` | --                | The options to display in the time input dropdown. Options must be in `HH:mm` or `HH:mm:ss` format.                                                                                                                                                                          | `string[]`                          | `[]`        |
 | `disabled`        | `disabled`        | Whether the form control is disabled.                                                                                                                                                                                                                                        | `boolean \| undefined`              | `false`     |
+| `feedback`        | --                | Feedback to render below the input.                                                                                                                                                                                                                                          | `IInputFeedbackProp \| undefined`   | `undefined` |
 | `inputId`         | `input-id`        | The ID of the input element.                                                                                                                                                                                                                                                 | `string \| undefined`               | `undefined` |
 | `inputTabIndex`   | `input-tab-index` | Determine the control's relative ordering for sequential focus navigation (typically with the Tab key).                                                                                                                                                                      | `number \| undefined`               | `undefined` |
 | `label`           | `label`           | The text to display within the label.                                                                                                                                                                                                                                        | `string \| undefined`               | `undefined` |
@@ -49,11 +50,14 @@ Adheres to WCAG 2.2 standards.
 ### Depends on
 
 - [modus-wc-input-label](../modus-wc-input-label)
+- [modus-wc-input-feedback](../modus-wc-input-feedback)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-time-input --> modus-wc-input-label
+  modus-wc-time-input --> modus-wc-input-feedback
+  modus-wc-input-feedback --> modus-wc-icon
   style modus-wc-time-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1431,6 +1431,14 @@
               }
             },
             {
+              "name": "feedback",
+              "fieldName": "feedback",
+              "description": "Feedback to render below the input.",
+              "type": {
+                "text": "IInputFeedbackProp"
+              }
+            },
+            {
               "name": "input-id",
               "fieldName": "inputId",
               "description": "The ID of the input element.",
@@ -2493,6 +2501,14 @@
               }
             },
             {
+              "name": "feedback",
+              "fieldName": "feedback",
+              "description": "Feedback to render below the input.",
+              "type": {
+                "text": "IInputFeedbackProp"
+              }
+            },
+            {
               "name": "input-id",
               "fieldName": "inputId",
               "description": "The ID of the input element.",
@@ -3248,6 +3264,14 @@
               "description": "Whether the form control is disabled.",
               "type": {
                 "text": "boolean"
+              }
+            },
+            {
+              "name": "feedback",
+              "fieldName": "feedback",
+              "description": "Feedback to render below the input.",
+              "type": {
+                "text": "IInputFeedbackProp"
               }
             },
             {
@@ -4232,6 +4256,14 @@
               }
             },
             {
+              "name": "feedback",
+              "fieldName": "feedback",
+              "description": "Feedback to render below the input.",
+              "type": {
+                "text": "IInputFeedbackProp"
+              }
+            },
+            {
               "name": "input-id",
               "fieldName": "inputId",
               "description": "The ID of the input element.",
@@ -4516,6 +4548,14 @@
               "description": "Whether the form control is disabled.",
               "type": {
                 "text": "boolean"
+              }
+            },
+            {
+              "name": "feedback",
+              "fieldName": "feedback",
+              "description": "Feedback to render below the input.",
+              "type": {
+                "text": "IInputFeedbackProp"
               }
             },
             {

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,0 +1,17 @@
+@mixin feedback-levels {
+  &--error {
+    border-color: var(--modus-wc-color-red) !important;
+  }
+
+  &--info {
+    border-color: var(--modus-wc-color-trimble-blue) !important;
+  }
+
+  &--success {
+    border-color: var(--modus-wc-color-green-dark) !important;
+  }
+
+  &--warning {
+    border-color: var(--modus-wc-color-yellow-dark) !important;
+  }
+}


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds the `modus-wc-input-feedback` component to the remaining (appropriate) inputs based on the Figma mocks.

Added to:
- Date
- Number
- Select
- Textarea
- Time Input

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tests added and snapshots updated

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

