### PR TITLE
feat: add migration docs to alert and autocomplete

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -71,7 +71,7 @@ export namespace Components {
         /**
           * Whether the alert has a dismiss button
          */
-        "dismissable"?: boolean;
+        "dismissible"?: boolean;
         /**
           * The Modus icon to render. *
          */
@@ -2419,7 +2419,7 @@ declare namespace LocalJSX {
         /**
           * Whether the alert has a dismiss button
          */
-        "dismissable"?: boolean;
+        "dismissible"?: boolean;
         /**
           * The Modus icon to render. *
          */

--- a/src/components/modus-wc-alert/modus-wc-alert.spec.ts
+++ b/src/components/modus-wc-alert/modus-wc-alert.spec.ts
@@ -118,7 +118,7 @@ describe('modus-wc-alert', () => {
   it('should render dismissible button and handle click event', async () => {
     const page = await newSpecPage({
       components: [ModusWcAlert, ModusWcIcon, ModusWCTypography, ModusWcButton],
-      html: '<modus-wc-alert dismissable></modus-wc-alert>',
+      html: '<modus-wc-alert dismissible></modus-wc-alert>',
     });
 
     const component = page.rootInstance as ModusWcAlert;
@@ -131,7 +131,7 @@ describe('modus-wc-alert', () => {
     expect(dismissElementSpy).toHaveBeenCalled();
   });
 
-  it('should call dismissElement on Escape keyup when dismissable is true', async () => {
+  it('should call dismissElement on Escape keyup when dismissible is true', async () => {
     const page = await newSpecPage({
       components: [ModusWcAlert, ModusWcIcon, ModusWCTypography, ModusWcButton],
       html: '<modus-wc-alert></modus-wc-alert>',
@@ -144,7 +144,7 @@ describe('modus-wc-alert', () => {
     page.root?.dispatchEvent(event);
     expect(dismissElementSpy).not.toHaveBeenCalled();
 
-    component.dismissable = true;
+    component.dismissible = true;
     await page.waitForChanges();
 
     page.root?.dispatchEvent(event);

--- a/src/components/modus-wc-alert/modus-wc-alert.stories.ts
+++ b/src/components/modus-wc-alert/modus-wc-alert.stories.ts
@@ -7,7 +7,7 @@ interface AlertArgs {
   'alert-title': string;
   'custom-class'?: string;
   delay: number;
-  dismissable?: boolean;
+  dismissible?: boolean;
   dismissClick?: () => void;
   icon?: string;
   variant: 'error' | 'info' | 'success' | 'warning';
@@ -20,7 +20,7 @@ const meta: Meta<AlertArgs> = {
   args: {
     'alert-description': 'You have 3 new messages.',
     'alert-title': 'New message!',
-    dismissable: false,
+    dismissible: false,
     delay: 15000,
     role: 'status',
     variant: 'info',
@@ -52,7 +52,7 @@ const Template: Story = {
   alert-description=${ifDefined(args['alert-description'])}
   alert-title=${args['alert-title']}
   custom-class=${ifDefined(args['custom-class'])}
-  dismissable=${args.dismissable}
+  dismissible=${args.dismissible}
   icon=${ifDefined(args.icon)}
   role=${args.role}
   variant=${ifDefined(args.variant)}
@@ -72,7 +72,7 @@ export const CustomButton: Story = {
   alert-description=${ifDefined(args['alert-description'])}
   alert-title=${args['alert-title']}
   custom-class=${ifDefined(args['custom-class'])}
-  dismissable=${args.dismissable}
+  dismissible=${args.dismissible}
   icon=${ifDefined(args.icon)}
   role=${args.role}
   variant=${ifDefined(args.variant)}
@@ -94,7 +94,7 @@ export const WithCustomContent: Story = {
 <modus-wc-alert
   id="alert-123"
   custom-class=${ifDefined(args['custom-class'])}
-  dismissable=${args.dismissable}
+  dismissible=${args.dismissible}
   icon=${ifDefined(args.icon)}
   role=${args.role}
   variant=${ifDefined(args.variant)}
@@ -103,4 +103,42 @@ export const WithCustomContent: Story = {
 </modus-wc-alert>
     `;
   },
+};
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - The 2.0 component can render a custom HTML title in the "content" slot.
+  - The 1.0 component rendered a button, while the 2.0 component can render a custom HTML button in the "button" slot.
+
+#### Prop Mapping
+
+| 1.0 Prop          | 2.0 Prop    | Notes                             |
+|-------------------|-------------|-----------------------------------|
+| aria-label        | aria-label  |                                   |
+| button-aria-label |             | Not carried over, use button slot |
+| button-text       |             | Not carried over, use button slot |
+| dismissible       | dismissible |                                   |
+| message           | alert-title |                                   |
+| type              | variant     |                                   |
+
+#### Event Mapping
+
+| 1.0 Event    | 2.0 Event    | Notes                             |
+|--------------|--------------|-----------------------------------|
+| actionClick  |              | Not carried over, use button slot |
+| dismissClick | dismissClick |                                   |
+        `,
+      },
+    },
+    // To hide the actual story rendering and only show docs:
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  // Simple render function or leave it empty
+  render: () => html`<div></div>`,
 };

--- a/src/components/modus-wc-alert/modus-wc-alert.tsx
+++ b/src/components/modus-wc-alert/modus-wc-alert.tsx
@@ -41,7 +41,7 @@ export class ModusWcAlert {
   @Prop() delay?: number = 15000;
 
   /** Whether the alert has a dismiss button */
-  @Prop() dismissable?: boolean = false;
+  @Prop() dismissible?: boolean = false;
 
   /** The Modus icon to render. **/
   @Prop() icon?: string;
@@ -120,7 +120,7 @@ export class ModusWcAlert {
   elementKeyupHandler(event: KeyboardEvent): void {
     switch (event.code) {
       case 'Escape':
-        if (!this.dismissable) {
+        if (!this.dismissible) {
           return;
         }
 
@@ -150,7 +150,7 @@ export class ModusWcAlert {
             )}
           </div>
           <slot name="button" />
-          {this.dismissable && (
+          {this.dismissible && (
             <modus-wc-button
               aria-label="notification button"
               color="secondary"

--- a/src/components/modus-wc-alert/readme.md
+++ b/src/components/modus-wc-alert/readme.md
@@ -19,7 +19,7 @@ Adheres to WCAG 2.2 standards.
 | `alertTitle` _(required)_ | `alert-title`       | The title of the alert. *                           | `string`                                                   | `undefined` |
 | `customClass`             | `custom-class`      | Custom CSS class to apply to the outer div element. | `string \| undefined`                                      | `''`        |
 | `delay`                   | `delay`             | Time taken to dismiss the toast in milliseconds     | `number \| undefined`                                      | `15000`     |
-| `dismissable`             | `dismissable`       | Whether the alert has a dismiss button              | `boolean \| undefined`                                     | `false`     |
+| `dismissible`             | `dismissible`       | Whether the alert has a dismiss button              | `boolean \| undefined`                                     | `false`     |
 | `icon`                    | `icon`              | The Modus icon to render. *                         | `string \| undefined`                                      | `undefined` |
 | `role`                    | `role`              | Role taken by the alert. Defaults to 'status'       | `"alert" \| "log" \| "marquee" \| "status" \| "timer"`     | `'status'`  |
 | `variant`                 | `variant`           | The variant of the alert.                           | `"error" \| "info" \| "success" \| "warning" \| undefined` | `undefined` |

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -378,3 +378,83 @@ export const MultiSelect: Story = {
     `;
   },
 };
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 input state was maintained by the component. 2.0 components encourage users to follow a controlled
+  input model. See the Form Inputs [documentation]([Angular](?path=/docs/documentation-form-inputs--docs) for
+  additional info and examples.
+  - To handle updating items in 2.0, simply create a new array of items and bind it to the "items" prop. The 1.0 prop
+  "filter-options" is no longer necessary.
+
+#### Prop Mapping
+
+| 1.0 Prop                      | 2.0 Prop              | Notes              |
+|-------------------------------|-----------------------|--------------------|
+| aria-label                    | aria-label           |                     |
+| clearable                     |                      | Upcoming feature    |
+| disabled                      | disabled             |                     |
+| disable-close-on-select       | leave-menu-open      |                     |
+| dropdown-max-height           |                      | Use CSS to override |
+| dropdown-z-index              |                      | Use CSS to override |
+| error-text                    | feedback.message     | Use feedback level  |
+| filter-options                |                      | Rebind options      |
+| include-search-icon           |                      | Coming soon         |
+| label                         | label                |                     |
+| loading                       |                      | Upcoming feature    |
+| multiple                      | multi-select         |                     |
+| no-results-found-text         | no-results.label     |                     |
+| no-results-found-subtext      | no-results.subLabel  |                     |
+| options                       | items                |                     |
+| placeholder                   | placeholder          |                     |
+| read-only                     | read-only            |                     |
+| required                      | required             |                     |
+| show-no-results-found-message |                      | Use no-results prop |
+| show-options-on-focus         |                      | Not carried over    |
+| size                          | size                 |                     |
+| value                         | value                |                     |
+
+#### Event Mapping
+
+| 1.0 Event   | 2.0 Event   | Notes            |
+|-------------|-------------|------------------|
+| optionSelected ||
+| selectionsChanged ||
+| valueChange | inputChange |                  |
+
+#### Interfaces
+
+##### 1.0
+
+\`\`\`typescript
+interface ModusAutocompleteOption {
+  id: string;
+  value: string;
+}
+\`\`\`
+
+##### 2.0
+
+\`\`\`typescript
+interface IAutocompleteItem {
+  label: string;
+  selected?: boolean;
+  value: string;
+  visibleInMenu: boolean;
+}
+\`\`\`
+        `,
+      },
+    },
+    // To hide the actual story rendering and only show docs:
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  // Simple render function or leave it empty
+  render: () => html`<div></div>`,
+};

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -164,8 +164,8 @@
               }
             },
             {
-              "name": "dismissable",
-              "fieldName": "dismissable",
+              "name": "dismissible",
+              "fieldName": "dismissible",
               "default": "false",
               "description": "Whether the alert has a dismiss button",
               "type": {
@@ -3973,7 +3973,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create text inputs with types.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create text inputs with types.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcTextInput",
           "members": [
             {
@@ -3995,7 +3995,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
+                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
               }
             },
             {
@@ -4055,7 +4055,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
+                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
               }
             },
             {
@@ -4096,9 +4096,9 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'text'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
-                "text": "| 'decimal'\n    | 'email'\n    | 'none'\n    | 'numeric'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'url'"
+                "text": "| 'decimal'\r\n    | 'email'\r\n    | 'none'\r\n    | 'numeric'\r\n    | 'search'\r\n    | 'tel'\r\n    | 'text'\r\n    | 'url'"
               }
             },
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds migration documentation for the alert and autocomplete. It also renames a prop to align with the common spelling and 1.0 name.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tests updated

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #
