### PR TITLE
chore: add migration stories for select, slider, tabs, and textarea components

### DIFF
--- a/src/components/modus-wc-select/modus-wc-select.stories.ts
+++ b/src/components/modus-wc-select/modus-wc-select.stories.ts
@@ -94,7 +94,7 @@ export const Default: Story = {
       ?bordered=${args.bordered}
       custom-class=${ifDefined(args['custom-class'])}
       ?disabled=${args.disabled}
-      .feedback=${ifDefined(args.feedback)}
+      .feedback=${args.feedback}
       input-aria-invalid=${ifDefined(args['input-aria-invalid'])}
       input-id=${ifDefined(args['input-id'])}
       input-tab-index=${ifDefined(args['input-tab-index'])}
@@ -124,4 +124,49 @@ export const WithErrorFeedback: Story = {
       .value=${args.value}
     ></modus-wc-select>
   `,
+};
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 input state was maintained by the component. 2.0 components encourage users to follow a controlled
+  input model. See the Form Inputs [documentation](/docs/documentation-form-inputs--docs) for
+  additional info and examples.
+  - The options format has changed to use a standardized \`ISelectOption\` object array.
+  - Size values have changed from verbose names (\`medium\`, \`large\`) to abbreviations (\`sm\`, \`md\`, \`lg\`).
+
+#### Prop Mapping
+
+| 1.0 Prop              | 2.0 Prop            | Notes                                                |
+|-----------------------|---------------------|------------------------------------------------------|
+| aria-label            | aria-label          |                                                      |
+| disabled              | disabled            |                                                      |
+| error-text            | feedback.message    | Use \`feedback\` level                               |
+| helper-text           |                     | Not carried over                                     |
+| label                 | label               |                                                      |
+| options               | options             | Format changed to require array of \`ISelectOption\` objects |
+| options-display-prop  |                     | Not carried over                                     |
+| placeholder           |                     | Not carried over                                     |
+| required              | required            |                                                      |
+| size                  | size                | \`medium\` → \`md\`, \`large\` → \`lg\`              |
+| valid-text            | feedback.message    | Use \`feedback\` level                               |
+| value                 | value               |                                                      |
+
+#### Event Mapping
+
+| 1.0 Event    | 2.0 Event   | Notes            |
+|--------------|-------------|------------------|
+| valueChange  | inputChange |                  |
+| inputBlur    | inputBlur   |                  |
+        `,
+      },
+    },
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  render: () => html`<div></div>`,
 };

--- a/src/components/modus-wc-slider/modus-wc-slider.stories.ts
+++ b/src/components/modus-wc-slider/modus-wc-slider.stories.ts
@@ -70,3 +70,40 @@ export const Default: Story = {
     `;
   },
 };
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 input state was maintained by the component. 2.0 components encourage users to follow a controlled
+  input model. See the Form Inputs [documentation](/docs/documentation-form-inputs--docs) for additional info and examples.
+  - Property names have changed: \`max-value\` → \`max\`, \`min-value\` → \`min\`.
+
+#### Prop Mapping
+
+| 1.0 Prop    | 2.0 Prop     | Notes |
+|-------------|--------------|-------|
+| aria-label  | aria-label   |       |
+| disabled    | disabled     |       |
+| label       | label        |       |
+| max-value   | max          |       |
+| min-value   | min          |       |
+| value       | value        |       |
+
+#### Event Mapping
+
+| 1.0 Event   | 2.0 Event   | Notes            |
+|-------------|-------------|------------------|
+| valueChange |             | Not carried over |
+| valueInput  | inputChange |                  |
+        `,
+      },
+    },
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  render: () => html`<div></div>`,
+};

--- a/src/components/modus-wc-tabs/modus-wc-tabs.stories.ts
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.stories.ts
@@ -136,3 +136,64 @@ export const TabsWithPanel: Story = {
     `;
   },
 };
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 2.0 tabs use the \`ITab\` interface, see details of interface changes below.
+  - Size values have changed from verbose names (\`small\`, \`medium\`) to abbreviations (\`xs\`, \`sm\`, \`md\`, \`lg\`).
+  - The \`tabChange\` event now emits an object with both previous and new tab indices, rather than just the tab ID.
+
+#### Prop Mapping
+
+| 1.0 Prop     | 2.0 Prop           | Notes                                                          |
+|--------------|--------------------|----------------------------------------------------------------|
+| aria-label   | aria-label         |                                                                |
+| full-width   |                    | Not carried over, use CSS instead                              |
+| size         | size               | \`small\` → \`sm\`, \`medium\` → \`md\`                        |
+| tabs         | tabs               | Tab object structure has changed. See Interface changes below. |
+
+#### Event Mapping
+
+| 1.0 Event   | 2.0 Event | Notes                                                 |
+|-------------|-----------|-------------------------------------------------------|
+| tabChange   | tabChange | Now emits \`{ previousTab: number; newTab: number }\` |
+
+#### Interfaces
+
+##### 1.0
+
+\`\`\`typescript
+export interface Tab {
+  active?: boolean;
+  iconOnly?: string;
+  id: string;
+  label?: string;
+  leftIcon?: string;
+  rightIcon?: string;
+}
+\`\`\`
+
+##### 2.0
+
+\`\`\`typescript
+export interface ITab {
+  customClass?: string;
+  disabled?: boolean;
+  icon?: string;
+  iconPosition?: 'left' | 'right';
+  label?: string;
+}
+\`\`\`
+        `,
+      },
+    },
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  render: () => html`<div></div>`,
+};

--- a/src/components/modus-wc-textarea/modus-wc-textarea.stories.ts
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.stories.ts
@@ -108,7 +108,7 @@ export const Default: Story = {
         custom-class=${ifDefined(args['custom-class'])}
         enterkeyhint=${ifDefined(args.enterkeyhint)}
         ?disabled=${args.disabled}
-        .feedback=${ifDefined(args.feedback)}
+        .feedback=${args.feedback}
         input-aria-invalid=${ifDefined(args['input-aria-invalid'])}
         input-id=${ifDefined(args['input-id'])}
         input-tab-index=${ifDefined(args['input-tab-index'])}
@@ -142,4 +142,55 @@ export const WithErrorFeedback: Story = {
       .value=${args.value}
     ></modus-wc-textarea>
   `,
+};
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 input state was maintained by the component. 2.0 components encourage users to follow a controlled
+  input model. See the Form Inputs [documentation](/docs/documentation-form-inputs--docs) for
+  additional info and examples.
+  - Size values have changed from verbose names (\`medium\`, \`large\`) to abbreviations (\`sm\`, \`md\`, \`lg\`).
+
+#### Prop Mapping
+
+| 1.0 Prop                     | 2.0 Prop            | Notes                                                       |
+|------------------------------|---------------------|-------------------------------------------------------------|
+| aria-label                   | aria-label          |                                                             |
+| autocorrect                  | auto-correct        |                                                             |
+| auto-focus-input             |                     | Not carried over                                            |
+| clearable                    |                     | Not carried over                                            |
+| disabled                     | disabled            |                                                             |
+| enterkeyhint                 | enterkeyhint        |                                                             |
+| error-text                   | feedback.message    | Use \`feedback\` level                                      |
+| helper-text                  |                     | Not carried over                                            |
+| label                        | label               |                                                             |
+| max-length                   | max-length          |                                                             |
+| min-length                   |                     | Not carried over                                            |
+| placeholder                  | placeholder         |                                                             |
+| read-only                    | readonly            |                                                             |
+| rows                         | rows                |                                                             |
+| required                     | required            |                                                             |
+| size                         | size                | \`medium\` → \`md\`, \`large\` → \`lg\`                     |
+| spellcheck                   | spellcheck          |                                                             |
+| text-align                   |                     | Not carried over, use CSS instead                           |
+| valid-text                   | feedback.message    | Use \`feedback\` level                                      |
+| value                        | value               |                                                             |
+
+#### Event Mapping
+
+| 1.0 Event   | 2.0 Event   | Notes            |
+|-------------|-------------|------------------|
+| valueChange | inputChange |                  |
+        `,
+      },
+    },
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  render: () => html`<div></div>`,
 };


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds migration documentation for the select, slider, tabs, and textarea components.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :clipboard: Test Plan

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [x] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

[AB#570773](https://dev.azure.com/ViewpointVSO/Prism/_boards/board/t/Web/Stories?workitem=570773)
