### PR TITLE
make 'getting started' be the first page to load

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -51,7 +51,11 @@ const preview: Preview = {
         const aTitle = a.title.toLowerCase();
         const bTitle = b.title.toLowerCase();
 
-        // Make Documentation section appear first
+        // Make "Documentation/Getting Started" appear first (what page we go to on load)
+        if (aTitle === 'documentation/getting started') return -1;
+        if (bTitle === 'documentation/getting started') return 1;
+
+        // Then make Documentation section appear next
         if (
           aTitle.startsWith('documentation') &&
           !bTitle.startsWith('documentation')


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

we now properly navigate to 'Getting Started' if you go to the base (bare) URL of the storybook

this is determined by the first in the order - we can't just do this vis `stories:` because we already have a custom sort

![image](https://github.com/user-attachments/assets/fa2c0fa4-625a-4488-bbf8-ffe49035ebe1)


### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

[AB#576805](https://dev.azure.com/ViewpointVSO/74194628-0b6e-4b03-95a4-2d06c069dcbe/_workitems/edit/576805)
