### PR TITLE
fix: spinner button sizes in number input

### DIFF
--- a/src/components/modus-wc-number-input/modus-wc-number-input.scss
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.scss
@@ -63,20 +63,44 @@
 
   .modus-wc-input,
   .modus-wc-input-currency {
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      margin-top: auto;
+      margin-bottom: auto;
+    }
+
     // TODO - add support for xs and xl once added to Modus Figma
     &.modus-wc-input-sm {
       font-size: var(--modus-wc-font-size-sm);
       height: var(--modus-wc-input-height-sm);
+
+      &::-webkit-inner-spin-button,
+      &::-webkit-outer-spin-button {
+        font-size: var(--modus-wc-font-size-sm);
+        height: var(--modus-wc-input-height-sm);
+      }
     }
 
     &.modus-wc-input-md {
       font-size: var(--modus-wc-font-size-md);
       height: var(--modus-wc-input-height-md);
+
+      &::-webkit-inner-spin-button,
+      &::-webkit-outer-spin-button {
+        font-size: var(--modus-wc-font-size-md);
+        height: var(--modus-wc-input-height-md);
+      }
     }
 
     &.modus-wc-input-lg {
       font-size: var(--modus-wc-font-size-lg);
       height: var(--modus-wc-input-height-lg);
+
+      &::-webkit-inner-spin-button,
+      &::-webkit-outer-spin-button {
+        font-size: var(--modus-wc-font-size-lg);
+        height: 3rem;
+      }
     }
   }
 }

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -236,7 +236,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable autocomplete component used to create searchable text inputs.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable autocomplete component used to create searchable text inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcAutocomplete",
           "members": [
             {
@@ -275,7 +275,7 @@
               "name": "debounce-ms",
               "fieldName": "debounceMs",
               "default": "300",
-              "description": "The debounce timeout in milliseconds.\nSet to 0 to disable debouncing.",
+              "description": "The debounce timeout in milliseconds.\r\nSet to 0 to disable debouncing.",
               "type": {
                 "text": "number"
               }
@@ -309,7 +309,7 @@
               "name": "items",
               "fieldName": "items",
               "default": "[]",
-              "description": "The items to display in the menu.\nCreating a new array of items will ensure proper component re-render.",
+              "description": "The items to display in the menu.\r\nCreating a new array of items will ensure proper component re-render.",
               "type": {
                 "text": "IAutocompleteItem[]"
               }
@@ -435,7 +435,7 @@
               "type": {
                 "text": "EventEmitter<Event>"
               },
-              "description": "Event emitted when the input value changes.\nThis event is debounced based on the debounceMs prop."
+              "description": "Event emitted when the input value changes.\r\nThis event is debounced based on the debounceMs prop."
             },
             {
               "kind": "field",


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR fixes the spinner button sizes within the number inputs for the modus classic theme. I am not fixing the modus modern theme as Mitch is currently working in there and I don't want to step on any toes.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #214 
