### PR TITLE
fix: add npm token secret to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,17 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: '/'
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
     schedule:
       interval: monthly
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     versioning-strategy: increase
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR attempts to fix the merge-gate npm auth errors seen in recent dependabot PRs (#262 for example).

Adds the npm token secret to the npm package-ecosystem.
Also adds grouping for minor and patch version updates.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan



### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

