### PR TITLE
fix: multiple Checkbox styling bugs

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -345,7 +345,7 @@ export namespace Components {
         /**
           * The size of the input.
          */
-        "size"?: DaisySize;
+        "size"?: ModusSize;
         /**
           * The value of the checkbox.
          */
@@ -2745,7 +2745,7 @@ declare namespace LocalJSX {
         /**
           * The size of the input.
          */
-        "size"?: DaisySize;
+        "size"?: ModusSize;
         /**
           * The value of the checkbox.
          */

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.scss
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.scss
@@ -21,9 +21,20 @@
   border-radius: var(--modus-wc-border-radius-sm);
   border-width: var(--modus-wc-border-width-sm);
 
-  &.modus-wc-checkbox-xl {
-    height: 4rem;
-    width: 4rem;
+  // Sizes
+  &.modus-wc-checkbox-sm {
+    height: 0.75rem;
+    width: 0.75rem;
+  }
+
+  &.modus-wc-checkbox-md {
+    height: 1rem;
+    width: 1rem;
+  }
+
+  &.modus-wc-checkbox-lg {
+    height: 1.25rem;
+    width: 1.25rem;
   }
 
   &:checked {

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.scss
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.scss
@@ -41,6 +41,11 @@
 
   &:disabled {
     opacity: 0.3;
+
+    &:not(:checked) {
+      background-color: unset;
+      border: var(--modus-wc-border-width-sm) solid var(--modus-wc-color-gray-4);
+    }
   }
 
   &:focus {

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.stories.ts
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.stories.ts
@@ -2,7 +2,7 @@ import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { DaisySize } from '../types';
+import { ModusSize } from '../types';
 
 interface CheckboxArgs {
   'custom-class'?: string;
@@ -13,7 +13,7 @@ interface CheckboxArgs {
   label?: string;
   name?: string;
   required?: boolean;
-  size?: DaisySize;
+  size?: ModusSize;
   value: boolean;
 }
 
@@ -33,7 +33,7 @@ const meta: Meta<CheckboxArgs> = {
   argTypes: {
     size: {
       control: { type: 'select' },
-      options: ['xs', 'sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg'],
     },
   },
   decorators: [withActions],

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.stories.ts
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.stories.ts
@@ -80,7 +80,7 @@ export const Migration: Story = {
   additional info and examples.
   - The \`checked\` prop is now \`value\` in 2.0.
   - The \`checkboxClick\` event is now \`inputChange\` in 2.0.
-  - Size values have changed from verbose names (\`small\`, \`medium\`) to abbreviations (\`xs\`, \`sm\`, \`md\`, \`lg\`).
+  - Size values have changed from verbose names (\`small\`, \`medium\`) to abbreviations (\`sm\`, \`md\`, \`lg\`).
 
 #### Prop Mapping
 

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.tailwind.ts
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.tailwind.ts
@@ -1,9 +1,9 @@
-import { DaisySize } from '../types';
+import { ModusSize } from '../types';
 
 export const convertPropsToClasses = ({
   size,
 }: {
-  size?: DaisySize;
+  size?: ModusSize;
 }): string => {
   let classes = '';
 

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.tsx
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.tsx
@@ -8,8 +8,7 @@ import {
   Event as StencilEvent,
 } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-checkbox.tailwind';
-import { DAISY_TO_MODUS_LABEL_SIZE } from '../constants';
-import { DaisySize } from '../types';
+import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
@@ -53,7 +52,7 @@ export class ModusWcCheckbox {
   @Prop() required?: boolean = false;
 
   /** The size of the input. */
-  @Prop() size?: DaisySize = 'md';
+  @Prop() size?: ModusSize = 'md';
 
   /** The value of the checkbox. */
   @Prop({ mutable: true, reflect: true }) value: boolean = false;
@@ -110,8 +109,6 @@ export class ModusWcCheckbox {
   };
 
   render() {
-    const labelSize = this.size && DAISY_TO_MODUS_LABEL_SIZE[this.size];
-
     return (
       <Host class="modus-wc-checkbox-host">
         <input
@@ -135,7 +132,7 @@ export class ModusWcCheckbox {
             forId={this.inputId}
             labelText={this.label}
             required={this.required}
-            size={labelSize}
+            size={this.size}
           />
         )}
       </Host>

--- a/src/components/modus-wc-checkbox/readme.md
+++ b/src/components/modus-wc-checkbox/readme.md
@@ -13,18 +13,18 @@ Adheres to WCAG 2.2 standards.
 
 ## Properties
 
-| Property        | Attribute         | Description                                                                     | Type                                        | Default     |
-| --------------- | ----------------- | ------------------------------------------------------------------------------- | ------------------------------------------- | ----------- |
-| `customClass`   | `custom-class`    | Custom CSS class to apply to the inner div.                                     | `string \| undefined`                       | `''`        |
-| `disabled`      | `disabled`        | The disabled state of the checkbox.                                             | `boolean \| undefined`                      | `false`     |
-| `indeterminate` | `indeterminate`   | The indeterminate state of the checkbox.                                        | `boolean`                                   | `false`     |
-| `inputId`       | `input-id`        | The ID of the input element.                                                    | `string \| undefined`                       | `undefined` |
-| `inputTabIndex` | `input-tab-index` | The tabindex of the input.                                                      | `number \| undefined`                       | `undefined` |
-| `label`         | `label`           | The text to display within the label.                                           | `string \| undefined`                       | `undefined` |
-| `name`          | `name`            | Name of the form control. Submitted with the form as part of a name/value pair. | `string \| undefined`                       | `''`        |
-| `required`      | `required`        | A value is required for the form to be submittable.                             | `boolean \| undefined`                      | `false`     |
-| `size`          | `size`            | The size of the input.                                                          | `"lg" \| "md" \| "sm" \| "xs" \| undefined` | `'md'`      |
-| `value`         | `value`           | The value of the checkbox.                                                      | `boolean`                                   | `false`     |
+| Property        | Attribute         | Description                                                                     | Type                                | Default     |
+| --------------- | ----------------- | ------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
+| `customClass`   | `custom-class`    | Custom CSS class to apply to the inner div.                                     | `string \| undefined`               | `''`        |
+| `disabled`      | `disabled`        | The disabled state of the checkbox.                                             | `boolean \| undefined`              | `false`     |
+| `indeterminate` | `indeterminate`   | The indeterminate state of the checkbox.                                        | `boolean`                           | `false`     |
+| `inputId`       | `input-id`        | The ID of the input element.                                                    | `string \| undefined`               | `undefined` |
+| `inputTabIndex` | `input-tab-index` | The tabindex of the input.                                                      | `number \| undefined`               | `undefined` |
+| `label`         | `label`           | The text to display within the label.                                           | `string \| undefined`               | `undefined` |
+| `name`          | `name`            | Name of the form control. Submitted with the form as part of a name/value pair. | `string \| undefined`               | `''`        |
+| `required`      | `required`        | A value is required for the form to be submittable.                             | `boolean \| undefined`              | `false`     |
+| `size`          | `size`            | The size of the input.                                                          | `"lg" \| "md" \| "sm" \| undefined` | `'md'`      |
+| `value`         | `value`           | The value of the checkbox.                                                      | `boolean`                           | `false`     |
 
 
 ## Events


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR fixes 2 checkbox bugs:
1. The unchecked disabled state should not have a background color
2. The sizes for modus classic do not match the mocks

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Manual

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #210 and #225
