### PR TITLE
fix: remove npm token from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
           - 'patch'
     schedule:
       interval: monthly
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     versioning-strategy: increase
 
   - package-ecosystem: github-actions


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Reverts adding our npm token to the `dependabot.yml` config which caused syntax issues.

I did a little more digging on this and it looks like the reason the dependabot PRs are failing our merge-gate workflow are due to our use of repository secrets which dependabot does not have access to by design (see this [notice from 2021](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)).

One resolution for this would be to use `pull_request_target` event for the merge-gate, but that comes with its own [security risks](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #
