### PR TITLE
chore: add migration stories for time, toast, and tooltip components

### DIFF
--- a/src/components/modus-wc-time-input/modus-wc-time-input.stories.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.stories.ts
@@ -80,7 +80,7 @@ export const Template: Story = {
       custom-class=${ifDefined(args['custom-class'])}
       datalist-id=${ifDefined(args['datalist-id'])}
       ?disabled=${args.disabled}
-      .feedback=${ifDefined(args.feedback)}
+      .feedback=${args.feedback}
       input-id=${ifDefined(args['input-id'])}
       input-tab-index=${ifDefined(args['input-tab-index'])}
       label=${ifDefined(args.label)}
@@ -160,4 +160,56 @@ export const WithErrorFeedback: Story = {
       .value=${args.value}
     ></modus-wc-time-input>
   `,
+};
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 input state was maintained by the component. 2.0 components encourage users to follow a controlled
+  input model. See the Form Inputs [documentation](/docs/documentation-form-inputs--docs) for
+  additional info and examples.
+  - Size values have changed from verbose names (\`medium\`, \`large\`) to abbreviations (\`sm\`, \`md\`, \`lg\`).
+
+#### Prop Mapping
+
+| 1.0 Prop                | 2.0 Prop            | Notes                                   |
+|-------------------------|---------------------|-----------------------------------------|
+| allowed-chars-regex     |                     | Not carried over                        |
+| ampm                    |                     | Not carried over                        |
+| aria-label              | aria-label          |                                         |
+| auto-focus-input        | autofocus           |                                         |
+| auto-format             |                     | Not carried over                        |
+| disable-validation      |                     | Not carried over                        |
+| disabled                | disabled            |                                         |
+| error-text              | feedback.message    | Use \`feedback\` level                  |
+| helper-text             |                     | Not carried over                        |
+| label                   | label               |                                         |
+| max                     | max                 |                                         |
+| min                     | min                 |                                         |
+| placeholder             |                     | Not carried over                        |
+| read-only               | read-only           |                                         |
+| required                | required            |                                         |
+| size                    | size                | \`medium\` → \`md\`, \`large\` → \`lg\` |
+| valid-text              | feedback.message    | Use \`feedback\` level                  |
+| value                   | value               |                                         |
+
+#### Event Mapping
+
+| 1.0 Event      | 2.0 Event   | Notes                                                |
+|----------------|-------------|------------------------------------------------------|
+| timeInputBlur  | inputBlur   |                                                      |
+| valueChange    | inputChange |                                                      |
+        `,
+      },
+    },
+    // To hide the actual story rendering and only show docs:
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  // Simple render function or leave it empty
+  render: () => html`<div></div>`,
 };

--- a/src/components/modus-wc-toast/modus-wc-toast.stories.ts
+++ b/src/components/modus-wc-toast/modus-wc-toast.stories.ts
@@ -55,3 +55,42 @@ const Template: Story = {
 };
 
 export const Default: Story = { ...Template };
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 toast included built-in dismiss functionality with delay timer and dismiss button. 2.0 components focus on positioning only.
+  - In 1.0 toast included built-in icons. 2.0 components rely on slotted content for visual elements.
+  - 2.0 toast components no longer support built-in types/variants, use slotted \`modus-wc-alert\` components instead.
+
+#### Prop Mapping
+
+| 1.0 Prop        | 2.0 Prop    | Notes                                      |
+|-----------------|-------------|--------------------------------------------|
+| aria-label      | aria-label  |                                            |
+| delay           |             | Not carried over                           |
+| dismissible     |             | Not carried over                           |
+| retain-element  |             | Not carried over                           |
+| role            |             | Not carried over                           |
+| show-icon       |             | Not carried over                           |
+| type            |             | Not carried over, use slotted content      |
+
+#### Event Mapping
+
+| 1.0 Event     | 2.0 Event | Notes            |
+|---------------|-----------|------------------|
+| dismissClick  |           | Not carried over |
+        `,
+      },
+    },
+    // To hide the actual story rendering and only show docs:
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  // Simple render function or leave it empty
+  render: () => html`<div></div>`,
+};

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.stories.ts
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.stories.ts
@@ -49,3 +49,30 @@ const Template: Story = {
 };
 
 export const Default: Story = { ...Template };
+
+export const Migration: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `
+#### Breaking Changes
+
+  - In 1.0 tooltip positioning was handled by Popper.js. In 2.0, positioning is handled using CSS.
+  - The \`text\` prop has been renamed to \`content\`.
+
+#### Prop Mapping
+
+| 1.0 Prop    | 2.0 Prop    | Notes                                    |
+|-------------|-------------|------------------------------------------|
+| aria-label  | aria-label  |                                          |
+| disabled    | disabled    |                                          |
+| position    | position    | Added \`auto\` option as default value   |
+| text        | content     |                                          |
+        `,
+      },
+    },
+    controls: { disable: true },
+    canvas: { disable: true },
+  },
+  render: () => html`<div></div>`,
+};

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -578,7 +578,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\r\n\r\nThe component supports a `<slot>` for injecting content within the badge.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\n\nThe component supports a `<slot>` for injecting content within the badge.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcBadge",
           "members": [
             {
@@ -601,7 +601,7 @@
               "default": "'primary'",
               "description": "The color variant of the badge.",
               "type": {
-                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'high-contrast'\r\n    | 'success'\r\n    | 'warning'\r\n    | 'danger'"
+                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'high-contrast'\n    | 'success'\n    | 'warning'\n    | 'danger'"
               }
             },
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds migration documentation for the time, toast, and tooltip components.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [x] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

[AB#570773](https://dev.azure.com/ViewpointVSO/Prism/_boards/board/t/Web/Stories?workitem=570773)
