### PR TITLE
fix: text input background color bug

### DIFF
--- a/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
+++ b/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modus-wc-autocomplete should close the menu when clicking outside if leaveMenuOpen is false 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="">
   <modus-wc-text-input value="">
-    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
@@ -13,7 +13,7 @@ exports[`modus-wc-autocomplete should close the menu when clicking outside if le
 exports[`modus-wc-autocomplete should display no results ui when no items are available 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="">
   <modus-wc-text-input value="">
-    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <input aria-label="No results test" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
@@ -36,7 +36,7 @@ exports[`modus-wc-autocomplete should display no results ui when no items are av
 exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="">
   <modus-wc-text-input value="">
-    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <input aria-label="Leave menu open test" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
@@ -46,7 +46,7 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 1`
 exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 2`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="">
   <modus-wc-text-input value="">
-    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-disabled modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-disabled modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <input aria-label="Leave menu open test" aria-placeholder="" class="modus-wc-grow" disabled="" inputmode="text" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
@@ -56,7 +56,7 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 2`
 exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 3`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="">
   <modus-wc-text-input value="">
-    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input-readonly modus-wc-w-full">
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-text-input--readonly modus-wc-w-full">
       <input aria-label="Leave menu open test" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" readonly="" type="text" value="">
     </label>
   </modus-wc-text-input>
@@ -83,7 +83,7 @@ exports[`modus-wc-autocomplete should render multi select with selected items 1`
       </div>
     </div>
     <modus-wc-text-input value="">
-      <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+      <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
         <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
       </label>
     </modus-wc-text-input>
@@ -119,7 +119,7 @@ exports[`modus-wc-autocomplete should render multi select without border 1`] = `
       </div>
     </div>
     <modus-wc-text-input value="">
-      <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+      <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
         <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
       </label>
     </modus-wc-text-input>
@@ -139,7 +139,7 @@ exports[`modus-wc-autocomplete should render with custom props 1`] = `
 <modus-wc-autocomplete active-item-value="1" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" disabled="true" input-id="test-id" input-tab-index="1" label="Test label" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1">
   <modus-wc-input-label forid="test-id" labeltext="Test label" required="" size="lg"></modus-wc-input-label>
   <modus-wc-text-input value="Item 1">
-    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-disabled modus-wc-input-lg modus-wc-items-center modus-wc-w-full">
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-disabled modus-wc-input-lg modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <input aria-describedby="description" aria-label="Test autocomplete" aria-placeholder="Test placeholder" aria-required="" class="modus-wc-grow" disabled="" id="test-id" inputmode="text" name="test-name" placeholder="Test placeholder" required="" tabindex="1" type="text" value="Item 1">
     </label>
   </modus-wc-text-input>
@@ -193,7 +193,7 @@ exports[`modus-wc-autocomplete should render with custom props 1`] = `
 exports[`modus-wc-autocomplete should render with default props 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="">
   <modus-wc-text-input value="">
-    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <input aria-label="Default autocomplete" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>

--- a/src/components/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
+++ b/src/components/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
@@ -2,20 +2,20 @@
 
 exports[`modus-wc-date renders with default props 1`] = `
 <modus-wc-date value="">
-  <input aria-label="Default date" class="modus-wc-date modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" type="date" value="">
+  <input aria-label="Default date" class="modus-wc-date-input modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" type="date" value="">
 </modus-wc-date>
 `;
 
 exports[`modus-wc-date should render with custom props 1`] = `
 <modus-wc-date auto-focus="true" bordered="false" custom-class="test-class" disabled="true" input-id="custom-id" input-tab-index="1" label="Test label" max="11/25/2024" min="11/20/2024" name="test-name" readonly="true" required="true" size="lg" value="Test value">
   <modus-wc-input-label forid="custom-id" labeltext="Test label" required="" size="lg"></modus-wc-input-label>
-  <input aria-describedby="description" aria-disabled="" aria-label="Test date" aria-labelledby="Another element" class="modus-wc-date modus-wc-input modus-wc-input-lg modus-wc-w-full test-class" disabled="" id="custom-id" max="11/25/2024" min="11/20/2024" name="test-name" required="" tabindex="1" type="date" value="Test value">
+  <input aria-describedby="description" aria-disabled="" aria-label="Test date" aria-labelledby="Another element" class="modus-wc-date-input modus-wc-input modus-wc-input-lg modus-wc-w-full test-class" disabled="" id="custom-id" max="11/25/2024" min="11/20/2024" name="test-name" required="" tabindex="1" type="date" value="Test value">
 </modus-wc-date>
 `;
 
 exports[`modus-wc-date should render with error feedback 1`] = `
 <modus-wc-date value="">
-  <input aria-label="Error input" class="modus-wc-date modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" type="date" value="">
+  <input aria-label="Error input" class="modus-wc-date-input modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" type="date" value="">
   <modus-wc-input-feedback>
     <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
       <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/modus-wc-date/modus-wc-date.scss
+++ b/src/components/modus-wc-date/modus-wc-date.scss
@@ -2,52 +2,60 @@
   @include feedback-levels();
 }
 
-[data-theme='modus-classic-light'] .modus-wc-input,
-[data-theme='modus-classic-dark'] .modus-wc-input {
-  border-radius: var(--modus-wc-border-radius-md);
+[data-theme='modus-classic-light'] .modus-wc-date-input,
+[data-theme='modus-classic-dark'] .modus-wc-date-input {
+  &.modus-wc-input {
+    border-radius: var(--modus-wc-border-radius-md);
 
-  .modus-wc-input-label {
-    padding-bottom: var(--modus-wc-spacing-2xs);
-  }
+    .modus-wc-input-label {
+      padding-bottom: var(--modus-wc-spacing-2xs);
+    }
 
-  // TODO - add support for xs and xl once added to Modus Figma
+    // TODO - add support for xs and xl once added to Modus Figma
 
-  &.modus-wc-input-sm {
-    font-size: var(--modus-wc-font-size-sm);
-    height: var(--modus-wc-input-height-sm);
-    padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-xs);
-  }
+    &.modus-wc-input-sm {
+      font-size: var(--modus-wc-font-size-sm);
+      height: var(--modus-wc-input-height-sm);
+      padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-xs);
+    }
 
-  &.modus-wc-input-md {
-    font-size: var(--modus-wc-font-size-md);
-    height: var(--modus-wc-input-height-md);
-    padding: var(--modus-wc-spacing-sm);
-  }
+    &.modus-wc-input-md {
+      font-size: var(--modus-wc-font-size-md);
+      height: var(--modus-wc-input-height-md);
+      padding: var(--modus-wc-spacing-sm);
+    }
 
-  &.modus-wc-input-lg {
-    font-size: var(--modus-wc-font-size-lg);
-    height: var(--modus-wc-input-height-lg);
-    padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
-  }
+    &.modus-wc-input-lg {
+      font-size: var(--modus-wc-font-size-lg);
+      height: var(--modus-wc-input-height-lg);
+      padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
+    }
 
-  &:focus {
-    border-color: var(--modus-wc-color-blue-light);
-    border-width: var(--modus-wc-border-width-sm);
-    box-shadow: none; // Removes the Tailwind ring effect
-    outline: none; // Ensures there's no outline on focus
-  }
+    &:focus {
+      border-color: var(--modus-wc-color-blue-light);
+      border-width: var(--modus-wc-border-width-sm);
+      box-shadow: none; // Removes the Tailwind ring effect
+      outline: none; // Ensures there's no outline on focus
+    }
 
-  &.modus-wc-date-readonly {
-    background-color: var(--modus-wc-color-base-100);
-  }
-}
-
-[data-theme='modus-classic-light'] .modus-wc-input {
-  &.modus-wc-input-bordered:not(:disabled):not(:focus) {
-    border-color: var(--modus-wc-color-gray-6);
+    &.modus-wc-date--readonly {
+      background-color: var(--modus-wc-color-base-100);
+    }
   }
 }
 
-[data-theme='modus-classic-dark'] .modus-wc-input:focus {
-  border-color: var(--modus-wc-color-highlight-blue);
+[data-theme='modus-classic-light'] .modus-wc-date-input {
+  &.modus-wc-input {
+    &.modus-wc-input-bordered:not(:disabled):not(:focus) {
+      border-color: var(--modus-wc-color-gray-6);
+    }
+  }
+}
+
+[data-theme='modus-classic-dark'] .modus-wc-date-input {
+  color-scheme: dark; // needed to ensure the calendar icon button is visible in dark mode
+
+  &.modus-wc-input:focus {
+    border-color: var(--modus-wc-color-highlight-blue);
+  }
 }

--- a/src/components/modus-wc-date/modus-wc-date.scss
+++ b/src/components/modus-wc-date/modus-wc-date.scss
@@ -37,7 +37,7 @@
     outline: none; // Ensures there's no outline on focus
   }
 
-  &:read-only {
+  &.modus-wc-date-readonly {
     background-color: var(--modus-wc-color-base-100);
   }
 }

--- a/src/components/modus-wc-date/modus-wc-date.scss
+++ b/src/components/modus-wc-date/modus-wc-date.scss
@@ -38,7 +38,7 @@
       outline: none; // Ensures there's no outline on focus
     }
 
-    &.modus-wc-date--readonly {
+    &.modus-wc-date-input--readonly {
       background-color: var(--modus-wc-color-base-100);
     }
   }

--- a/src/components/modus-wc-date/modus-wc-date.tailwind.ts
+++ b/src/components/modus-wc-date/modus-wc-date.tailwind.ts
@@ -22,7 +22,7 @@ export const convertPropsToClasses = ({
   }
 
   if (readOnly) {
-    classes = `${classes} modus-wc-date-readonly`;
+    classes = `${classes} modus-wc-date--readonly`;
   }
 
   if (size) {

--- a/src/components/modus-wc-date/modus-wc-date.tailwind.ts
+++ b/src/components/modus-wc-date/modus-wc-date.tailwind.ts
@@ -22,7 +22,7 @@ export const convertPropsToClasses = ({
   }
 
   if (readOnly) {
-    classes = `${classes} modus-wc-date--readonly`;
+    classes = `${classes} modus-wc-date-input--readonly`;
   }
 
   if (size) {

--- a/src/components/modus-wc-date/modus-wc-date.tailwind.ts
+++ b/src/components/modus-wc-date/modus-wc-date.tailwind.ts
@@ -1,13 +1,15 @@
-import { IInputFeedbackProp } from '../types';
+import { DaisySize, IInputFeedbackProp } from '../types';
 
 export const convertPropsToClasses = ({
   bordered,
   feedback,
+  readOnly,
   size,
 }: {
   bordered?: boolean;
   feedback?: IInputFeedbackProp;
-  size?: 'sm' | 'md' | 'lg';
+  readOnly?: boolean;
+  size?: DaisySize;
 }): string => {
   let classes = '';
 
@@ -17,6 +19,10 @@ export const convertPropsToClasses = ({
 
   if (feedback) {
     classes = `${classes} modus-wc-input--${feedback.level}`;
+  }
+
+  if (readOnly) {
+    classes = `${classes} modus-wc-date-readonly`;
   }
 
   if (size) {

--- a/src/components/modus-wc-date/modus-wc-date.tsx
+++ b/src/components/modus-wc-date/modus-wc-date.tsx
@@ -90,6 +90,7 @@ export class ModusWcDate {
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
       feedback: this.feedback,
+      readOnly: this.readOnly,
       size: this.size,
     });
 

--- a/src/components/modus-wc-date/modus-wc-date.tsx
+++ b/src/components/modus-wc-date/modus-wc-date.tsx
@@ -86,7 +86,11 @@ export class ModusWcDate {
   }
 
   private getClasses(): string {
-    const classList = ['modus-wc-date', 'modus-wc-input', 'modus-wc-w-full'];
+    const classList = [
+      'modus-wc-date-input',
+      'modus-wc-input',
+      'modus-wc-w-full',
+    ];
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
       feedback: this.feedback,

--- a/src/components/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
+++ b/src/components/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
@@ -3,27 +3,27 @@
 exports[`modus-wc-number-input should render with custom props 1`] = `
 <modus-wc-number-input auto-complete="on" auto-focus="true" class="test-class" currency-symbol="$" custom-class="test-class" disabled="true" input-aria-invalid="true" input-id="test-id" input-mode="decimal" input-tab-index="1" label="Test label" max="10" min="1" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" step="2" type="range" value="test@example.com">
   <modus-wc-input-label forid="test-id" labeltext="Test label" required="" size="lg"></modus-wc-input-label>
-  <div class="modus-wc-flex modus-wc-input-container modus-wc-join">
+  <div class="modus-wc-flex modus-wc-join modus-wc-number-input-container">
     <div class="modus-wc-flex modus-wc-input-bordered modus-wc-input-currency modus-wc-input-lg modus-wc-items-center modus-wc-join-item">
       $
     </div>
-    <input aria-describedby="description" aria-label="Test number input" aria-placeholder="Test placeholder" aria-required="" autocomplete="on" class="modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-join-item modus-wc-w-full" disabled="" id="test-id" inputmode="decimal" max="10" min="1" name="test-name" placeholder="Test placeholder" required="" step="2" tabindex="1" type="range" value="test@example.com">
+    <input aria-describedby="description" aria-label="Test number input" aria-placeholder="Test placeholder" aria-required="" autocomplete="on" class="modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-join-item modus-wc-number-input modus-wc-w-full" disabled="" id="test-id" inputmode="decimal" max="10" min="1" name="test-name" placeholder="Test placeholder" required="" step="2" tabindex="1" type="range" value="test@example.com">
   </div>
 </modus-wc-number-input>
 `;
 
 exports[`modus-wc-number-input should render with default props 1`] = `
 <modus-wc-number-input value="">
-  <div class="modus-wc-input-container">
-    <input aria-label="Default input" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="numeric" placeholder="" type="number" value="">
+  <div class="modus-wc-number-input-container">
+    <input aria-label="Default input" aria-placeholder="" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-number-input modus-wc-w-full" inputmode="numeric" placeholder="" type="number" value="">
   </div>
 </modus-wc-number-input>
 `;
 
 exports[`modus-wc-number-input should render with error feedback 1`] = `
 <modus-wc-number-input value="">
-  <div class="modus-wc-input-container">
-    <input aria-label="Error input" aria-placeholder="" class="modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" inputmode="numeric" placeholder="" type="number" value="">
+  <div class="modus-wc-number-input-container">
+    <input aria-label="Error input" aria-placeholder="" class="modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-number-input modus-wc-w-full" inputmode="numeric" placeholder="" type="number" value="">
   </div>
   <modus-wc-input-feedback>
     <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">

--- a/src/components/modus-wc-number-input/modus-wc-number-input.scss
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.scss
@@ -8,8 +8,8 @@
 }
 
 // TODO - see if we can simplify this styling by overriding tailwind classes (see modus-wc-checkbox.scss)
-[data-theme='modus-classic-light'] .modus-wc-input-container,
-[data-theme='modus-classic-dark'] .modus-wc-input-container {
+[data-theme='modus-classic-light'] .modus-wc-number-input-container,
+[data-theme='modus-classic-dark'] .modus-wc-number-input-container {
   .modus-wc-input-currency {
     background-color: var(--modus-wc-color-base-100);
     border: var(--modus-wc-border-width-xs) solid transparent;
@@ -29,39 +29,41 @@
     }
   }
 
-  .modus-wc-input {
-    .modus-wc-input-label {
-      padding-bottom: var(--modus-wc-spacing-2xs);
-    }
+  .modus-wc-number-input {
+    &.modus-wc-input {
+      .modus-wc-input-label {
+        padding-bottom: var(--modus-wc-spacing-2xs);
+      }
 
-    &.modus-wc-input-sm {
-      padding: var(--modus-wc-spacing-md) 0 var(--modus-wc-spacing-md)
-        var(--modus-wc-spacing-sm);
-    }
+      &.modus-wc-input-sm {
+        padding: var(--modus-wc-spacing-md) 0 var(--modus-wc-spacing-md)
+          var(--modus-wc-spacing-sm);
+      }
 
-    &.modus-wc-input-md {
-      padding: var(--modus-wc-spacing-lg) var(--modus-wc-spacing-lg)
-        var(--modus-wc-spacing-lg) var(--modus-wc-spacing-md);
-    }
+      &.modus-wc-input-md {
+        padding: var(--modus-wc-spacing-lg) var(--modus-wc-spacing-lg)
+          var(--modus-wc-spacing-lg) var(--modus-wc-spacing-md);
+      }
 
-    &.modus-wc-input-lg {
-      padding: var(--modus-wc-spacing-xl) var(--modus-wc-spacing-xl)
-        var(--modus-wc-spacing-xl) var(--modus-wc-spacing-lg);
-    }
+      &.modus-wc-input-lg {
+        padding: var(--modus-wc-spacing-xl) var(--modus-wc-spacing-xl)
+          var(--modus-wc-spacing-xl) var(--modus-wc-spacing-lg);
+      }
 
-    &:focus {
-      border-color: var(--modus-wc-color-highlight-blue);
-      border-width: var(--modus-wc-border-width-sm);
-      box-shadow: none; // Removes the Tailwind ring effect
-      outline: none; // Ensures there's no outline on focus
-    }
+      &:focus {
+        border-color: var(--modus-wc-color-highlight-blue);
+        border-width: var(--modus-wc-border-width-sm);
+        box-shadow: none; // Removes the Tailwind ring effect
+        outline: none; // Ensures there's no outline on focus
+      }
 
-    &:read-only {
-      background-color: var(--modus-wc-color-base-100);
+      &.modus-wc-number-input--readonly {
+        background-color: var(--modus-wc-color-base-100);
+      }
     }
   }
 
-  .modus-wc-input,
+  .modus-wc-number-input,
   .modus-wc-input-currency {
     &::-webkit-inner-spin-button,
     &::-webkit-outer-spin-button {

--- a/src/components/modus-wc-number-input/modus-wc-number-input.tailwind.ts
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.tailwind.ts
@@ -3,10 +3,12 @@ import { IInputFeedbackProp } from '../types';
 export const convertPropsToClasses = ({
   bordered,
   feedback,
+  readOnly,
   size,
 }: {
   bordered?: boolean;
   feedback?: IInputFeedbackProp;
+  readOnly?: boolean;
   size?: string;
 }): string => {
   let classes = '';
@@ -17,6 +19,10 @@ export const convertPropsToClasses = ({
 
   if (feedback) {
     classes = `${classes} modus-wc-input--${feedback.level}`;
+  }
+
+  if (readOnly) {
+    classes = `${classes} modus-wc-number-input--readonly`;
   }
 
   if (size) {

--- a/src/components/modus-wc-number-input/modus-wc-number-input.tsx
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.tsx
@@ -112,6 +112,7 @@ export class ModusWcNumberInput {
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
       feedback: this.feedback,
+      readOnly: this.readOnly,
       size: this.size,
     });
 
@@ -122,7 +123,11 @@ export class ModusWcNumberInput {
   }
 
   private getInputClasses(): string {
-    const classList = ['modus-wc-input', 'modus-wc-w-full'];
+    const classList = [
+      'modus-wc-number-input',
+      'modus-wc-input',
+      'modus-wc-w-full',
+    ];
 
     if (this.currencySymbol) {
       classList.push('modus-wc-join-item');
@@ -143,7 +148,7 @@ export class ModusWcNumberInput {
   }
 
   private getWrapperClasses(): string {
-    const classList = ['modus-wc-input-container'];
+    const classList = ['modus-wc-number-input-container'];
 
     if (this.currencySymbol) {
       classList.push('modus-wc-join');

--- a/src/components/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
+++ b/src/components/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modus-wc-text-input should render with custom props 1`] = `
 <modus-wc-text-input auto-capitalize="words" auto-complete="on" auto-focus="true" clear-aria-label="Clear input" custom-class="test-class" disabled="true" include-clear="true" include-search="true" input-aria-invalid="grammar" input-id="test-id" input-mode="numeric" input-spellcheck="true" input-tab-index="1" label="Test label" max-length="50" min-length="5" name="test-name" pattern="[A-Za-z]{3}" placeholder="Test placeholder" readonly="true" required="true" size="lg" type="email" value="test@example.com">
   <modus-wc-input-label forid="test-id" labeltext="Test label" required="" size="lg"></modus-wc-input-label>
-  <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-disabled modus-wc-input-lg modus-wc-items-center modus-wc-w-full test-class">
+  <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-disabled modus-wc-input-lg modus-wc-items-center modus-wc-text-input modus-wc-w-full test-class">
     <svg aria-hidden="true" class="modus-wc-text-input-icon modus-wc-text-input-icon-search" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
       <path d="m16.38 14.92-.66.05-.41-.41c2.44-2.81 2.28-7.1-.5-9.7S7.8 2.4 5.17 4.94a6.99 6.99 0 0 0-.08 9.98c2.61 2.61 6.77 2.72 9.52.34l.41.41-.05.65 3.89 3.89a.996.996 0 1 0 1.41-1.41l-3.88-3.88Zm-2.81-1.41a5.016 5.016 0 0 1-7.08 0c-1.95-1.95-1.95-5.13 0-7.08s5.13-1.95 7.08 0 1.95 5.13 0 7.08"></path>
     </svg>
@@ -19,7 +19,7 @@ exports[`modus-wc-text-input should render with custom props 1`] = `
 
 exports[`modus-wc-text-input should render with default props 1`] = `
 <modus-wc-text-input value="">
-  <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+  <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
     <input aria-label="Default input" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
   </label>
 </modus-wc-text-input>
@@ -27,7 +27,7 @@ exports[`modus-wc-text-input should render with default props 1`] = `
 
 exports[`modus-wc-text-input should render with error feedback 1`] = `
 <modus-wc-text-input value="">
-  <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-w-full">
+  <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
     <input aria-label="Error input" aria-placeholder="" class="modus-wc-grow" inputmode="text" placeholder="" type="text" value="">
   </label>
   <modus-wc-input-feedback>

--- a/src/components/modus-wc-text-input/modus-wc-text-input.scss
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.scss
@@ -12,130 +12,138 @@ label.modus-wc-input-label {
 }
 
 // TODO - see if we can simplify this styling by overriding tailwind classes (see modus-wc-checkbox.scss)
-[data-theme='modus-classic-light'] .modus-wc-input,
-[data-theme='modus-classic-dark'] .modus-wc-input {
-  border-radius: var(--modus-wc-border-radius-md);
+[data-theme='modus-classic-light'] .modus-wc-text-input,
+[data-theme='modus-classic-dark'] .modus-wc-text-input {
+  &.modus-wc-input {
+    border-radius: var(--modus-wc-border-radius-md);
 
-  .modus-wc-input-label {
-    padding-bottom: var(--modus-wc-spacing-2xs);
-  }
-
-  // TODO - add support for xs and xl once added to Modus Figma
-
-  &.modus-wc-input-sm {
-    font-size: var(--modus-wc-font-size-sm);
-    height: var(--modus-wc-input-height-sm);
-    line-height: var(--modus-wc-line-height-sm);
-    padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-xs);
-  }
-
-  &.modus-wc-input-md {
-    font-size: var(--modus-wc-font-size-md);
-    height: var(--modus-wc-input-height-md);
-    line-height: var(--modus-wc-line-height-md);
-    padding: var(--modus-wc-spacing-sm);
-  }
-
-  &.modus-wc-input-lg {
-    font-size: var(--modus-wc-font-size-lg);
-    height: var(--modus-wc-input-height-lg);
-    line-height: var(--modus-wc-line-height-lg);
-    padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
-  }
-
-  &:focus-within {
-    border-width: var(--modus-wc-border-width-sm);
-    box-shadow: none; // Removes the Tailwind ring effect
-    outline: none; // Ensures there's no outline on focus
-  }
-
-  .modus-wc-text-input-icon {
-    &.modus-wc-text-input-icon-clear {
-      &:focus:not(:focus-visible) {
-        outline: none;
-      }
+    .modus-wc-input-label {
+      padding-bottom: var(--modus-wc-spacing-2xs);
     }
-  }
 
-  &.modus-wc-text-input-readonly {
-    background-color: var(--modus-wc-color-base-100);
-  }
-}
+    // TODO - add support for xs and xl once added to Modus Figma
 
-[data-theme='modus-classic-light'] .modus-wc-input {
-  &.modus-wc-input-bordered:not(:disabled) {
-    border-color: var(--modus-wc-color-accent);
+    &.modus-wc-input-sm {
+      font-size: var(--modus-wc-font-size-sm);
+      height: var(--modus-wc-input-height-sm);
+      line-height: var(--modus-wc-line-height-sm);
+      padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-xs);
+    }
+
+    &.modus-wc-input-md {
+      font-size: var(--modus-wc-font-size-md);
+      height: var(--modus-wc-input-height-md);
+      line-height: var(--modus-wc-line-height-md);
+      padding: var(--modus-wc-spacing-sm);
+    }
+
+    &.modus-wc-input-lg {
+      font-size: var(--modus-wc-font-size-lg);
+      height: var(--modus-wc-input-height-lg);
+      line-height: var(--modus-wc-line-height-lg);
+      padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
+    }
 
     &:focus-within {
-      border-color: var(--modus-wc-color-blue-light);
+      border-width: var(--modus-wc-border-width-sm);
+      box-shadow: none; // Removes the Tailwind ring effect
+      outline: none; // Ensures there's no outline on focus
     }
-  }
 
-  .modus-wc-text-input-icon {
-    color: var(--modus-wc-color-gray-8);
+    .modus-wc-text-input-icon {
+      &.modus-wc-text-input-icon-clear {
+        &:focus:not(:focus-visible) {
+          outline: none;
+        }
+      }
+    }
+
+    &.modus-wc-text-input--readonly {
+      background-color: var(--modus-wc-color-base-100);
+    }
   }
 }
 
-[data-theme='modus-classic-dark'] .modus-wc-input {
-  .modus-wc-text-input-icon {
-    color: var(--modus-wc-color-gray-2);
-  }
+[data-theme='modus-classic-light'] .modus-wc-text-input {
+  &.modus-wc-input {
+    &.modus-wc-input-bordered:not(:disabled) {
+      border-color: var(--modus-wc-color-accent);
 
-  &:focus-within {
-    border-color: var(--modus-wc-color-highlight-blue);
+      &:focus-within {
+        border-color: var(--modus-wc-color-blue-light);
+      }
+    }
+
+    .modus-wc-text-input-icon {
+      color: var(--modus-wc-color-gray-8);
+    }
+  }
+}
+
+[data-theme='modus-classic-dark'] .modus-wc-text-input {
+  &.modus-wc-input {
+    .modus-wc-text-input-icon {
+      color: var(--modus-wc-color-gray-2);
+    }
+
+    &:focus-within {
+      border-color: var(--modus-wc-color-highlight-blue);
+    }
   }
 }
 
 // Icon sizes
-.modus-wc-input {
-  &.modus-wc-input-sm {
+.modus-wc-text-input {
+  &.modus-wc-input {
+    &.modus-wc-input-sm {
+      .modus-wc-text-input-icon {
+        height: var(--modus-wc-line-height-sm);
+        width: var(--modus-wc-line-height-sm);
+      }
+    }
+
+    &.modus-wc-input-md {
+      .modus-wc-text-input-icon {
+        height: var(--modus-wc-line-height-md);
+        width: var(--modus-wc-line-height-md);
+      }
+    }
+
+    &.modus-wc-input-lg {
+      .modus-wc-text-input-icon {
+        height: var(--modus-wc-line-height-lg);
+        width: var(--modus-wc-line-height-lg);
+      }
+    }
+
     .modus-wc-text-input-icon {
-      height: var(--modus-wc-line-height-sm);
-      width: var(--modus-wc-line-height-sm);
-    }
-  }
-
-  &.modus-wc-input-md {
-    .modus-wc-text-input-icon {
-      height: var(--modus-wc-line-height-md);
-      width: var(--modus-wc-line-height-md);
-    }
-  }
-
-  &.modus-wc-input-lg {
-    .modus-wc-text-input-icon {
-      height: var(--modus-wc-line-height-lg);
-      width: var(--modus-wc-line-height-lg);
-    }
-  }
-
-  .modus-wc-text-input-icon {
-    &.modus-wc-text-input-icon-clear {
-      cursor: pointer;
-    }
-  }
-
-  .modus-wc-clear-icon-container {
-    align-items: center;
-    display: flex;
-    justify-content: center;
-    min-width: var(--modus-wc-line-height-md);
-
-    &.modus-wc-clear-icon-hidden {
-      pointer-events: none;
-      visibility: hidden;
+      &.modus-wc-text-input-icon-clear {
+        cursor: pointer;
+      }
     }
 
-    &.modus-wc-clear-icon-visible {
-      visibility: visible;
+    .modus-wc-clear-icon-container {
+      align-items: center;
+      display: flex;
+      justify-content: center;
+      min-width: var(--modus-wc-line-height-md);
+
+      &.modus-wc-clear-icon-hidden {
+        pointer-events: none;
+        visibility: hidden;
+      }
+
+      &.modus-wc-clear-icon-visible {
+        visibility: visible;
+      }
     }
-  }
 
-  &.modus-wc-input-sm .modus-wc-clear-icon-container {
-    min-width: var(--modus-wc-line-height-sm);
-  }
+    &.modus-wc-input-sm .modus-wc-clear-icon-container {
+      min-width: var(--modus-wc-line-height-sm);
+    }
 
-  &.modus-wc-input-lg .modus-wc-clear-icon-container {
-    min-width: var(--modus-wc-line-height-lg);
+    &.modus-wc-input-lg .modus-wc-clear-icon-container {
+      min-width: var(--modus-wc-line-height-lg);
+    }
   }
 }

--- a/src/components/modus-wc-text-input/modus-wc-text-input.tailwind.ts
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.tailwind.ts
@@ -28,7 +28,7 @@ export const convertPropsToClasses = ({
   }
 
   if (readOnly) {
-    classes = `${classes} modus-wc-text-input-readonly`;
+    classes = `${classes} modus-wc-text-input--readonly`;
   }
 
   if (size) {

--- a/src/components/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.tsx
@@ -154,6 +154,7 @@ export class ModusWcTextInput {
 
   private getClasses(): string {
     const classList = [
+      'modus-wc-text-input',
       'modus-wc-input',
       'modus-wc-w-full',
       'modus-wc-flex',

--- a/src/components/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
+++ b/src/components/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
@@ -3,19 +3,19 @@
 exports[`modus-wc-time-input should render with custom props 1`] = `
 <modus-wc-time-input auto-complete="on" bordered="" custom-class="custom" datalist-id="time-options" disabled="" input-id="time-input" input-tab-index="1" label="Test label" max="23:59" min="00:00" name="time" read-only="" required="" show-seconds="" size="lg" step="30" value="12:00">
   <modus-wc-input-label forid="time-input" labeltext="Test label" required="" size="lg"></modus-wc-input-label>
-  <input aria-describedby="desc" aria-label="Time input" aria-required="" autocomplete="on" class="custom modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-w-full" disabled="" id="time-input" list="time-options" max="23:59" min="00:00" name="time" readonly="" required="" step="1" tabindex="1" type="time" value="12:00">
+  <input aria-describedby="desc" aria-label="Time input" aria-required="" autocomplete="on" class="custom modus-wc-input modus-wc-input-bordered modus-wc-input-lg modus-wc-time-input modus-wc-time-input--readonly modus-wc-w-full" disabled="" id="time-input" list="time-options" max="23:59" min="00:00" name="time" readonly="" required="" step="1" tabindex="1" type="time" value="12:00">
 </modus-wc-time-input>
 `;
 
 exports[`modus-wc-time-input should render with default props 1`] = `
 <modus-wc-time-input datalist-id="test-list" value="">
-  <input aria-label="Default input" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" list="test-list" step="60" type="time" value="">
+  <input aria-label="Default input" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-time-input modus-wc-w-full" list="test-list" step="60" type="time" value="">
 </modus-wc-time-input>
 `;
 
 exports[`modus-wc-time-input should render with error feedback 1`] = `
 <modus-wc-time-input value="">
-  <input aria-label="Error input" class="modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" list="modus-wc-datalist-test-random-id" step="60" type="time" value="">
+  <input aria-label="Error input" class="modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-time-input modus-wc-w-full" list="modus-wc-datalist-test-random-id" step="60" type="time" value="">
   <modus-wc-input-feedback>
     <div class="modus-wc-input-feedback modus-wc-input-feedback--error modus-wc-input-feedback--md">
       <svg class="mi-outline mi-warning modus-wc-input-feedback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/modus-wc-time-input/modus-wc-time-input.scss
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.scss
@@ -7,55 +7,61 @@
   @include feedback-levels();
 }
 
-[data-theme='modus-classic-light'] .modus-wc-input,
-[data-theme='modus-classic-dark'] .modus-wc-input {
-  border-radius: var(--modus-wc-border-radius-md);
+[data-theme='modus-classic-light'] .modus-wc-time-input,
+[data-theme='modus-classic-dark'] .modus-wc-time-input {
+  &.modus-wc-input {
+    border-radius: var(--modus-wc-border-radius-md);
 
-  .modus-wc-input-label {
-    padding-bottom: var(--modus-wc-spacing-2xs);
-  }
+    .modus-wc-input-label {
+      padding-bottom: var(--modus-wc-spacing-2xs);
+    }
 
-  &.modus-wc-input-sm {
-    font-size: var(--modus-wc-font-size-sm);
-    height: var(--modus-wc-input-height-sm);
-    padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-xs);
-  }
+    &.modus-wc-input-sm {
+      font-size: var(--modus-wc-font-size-sm);
+      height: var(--modus-wc-input-height-sm);
+      padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-xs);
+    }
 
-  &.modus-wc-input-md {
-    font-size: var(--modus-wc-font-size-md);
-    height: var(--modus-wc-input-height-md);
-    padding: var(--modus-wc-spacing-sm);
-  }
+    &.modus-wc-input-md {
+      font-size: var(--modus-wc-font-size-md);
+      height: var(--modus-wc-input-height-md);
+      padding: var(--modus-wc-spacing-sm);
+    }
 
-  &.modus-wc-input-lg {
-    font-size: var(--modus-wc-font-size-lg);
-    height: var(--modus-wc-input-height-lg);
-    padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
-  }
+    &.modus-wc-input-lg {
+      font-size: var(--modus-wc-font-size-lg);
+      height: var(--modus-wc-input-height-lg);
+      padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
+    }
 
-  &:focus,
-  &:focus-within {
-    border-color: var(--modus-wc-color-blue-light);
-    border-width: var(--modus-wc-border-width-sm);
-    box-shadow: none; // Removes the Tailwind ring effect
-    outline: none; // Ensures there's no outline on focus
-  }
+    &:focus,
+    &:focus-within {
+      border-color: var(--modus-wc-color-blue-light);
+      border-width: var(--modus-wc-border-width-sm);
+      box-shadow: none; // Removes the Tailwind ring effect
+      outline: none; // Ensures there's no outline on focus
+    }
 
-  &.modus-wc-time-input-readonly {
-    background-color: var(--modus-wc-color-base-100);
-  }
-}
-
-[data-theme='modus-classic-light'] .modus-wc-input {
-  &.modus-wc-input-bordered:not(:disabled):not(:focus) {
-    border-color: var(--modus-wc-color-gray-6);
+    &.modus-wc-time-input--readonly {
+      background-color: var(--modus-wc-color-base-100);
+    }
   }
 }
 
-[data-theme='modus-classic-dark'] .modus-wc-input {
-  color-scheme: dark; // needed to ensure the clock icon button is visible in dark mode
+[data-theme='modus-classic-light'] .modus-wc-time-input {
+  &.modus-wc-input {
+    &.modus-wc-input-bordered:not(:disabled):not(:focus) {
+      border-color: var(--modus-wc-color-gray-6);
+    }
+  }
+}
 
-  &:focus {
-    border-color: var(--modus-wc-color-highlight-blue);
+[data-theme='modus-classic-dark'] .modus-wc-time-input {
+  &.modus-wc-input {
+    color-scheme: dark; // needed to ensure the clock icon button is visible in dark mode
+
+    &:focus {
+      border-color: var(--modus-wc-color-highlight-blue);
+    }
   }
 }

--- a/src/components/modus-wc-time-input/modus-wc-time-input.scss
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.scss
@@ -41,7 +41,7 @@
     outline: none; // Ensures there's no outline on focus
   }
 
-  &:read-only {
+  &.modus-wc-time-input-readonly {
     background-color: var(--modus-wc-color-base-100);
   }
 }

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tailwind.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tailwind.ts
@@ -22,7 +22,7 @@ export const convertPropsToClasses = ({
   }
 
   if (readOnly) {
-    classes = `${classes} modus-wc-time-input-readonly`;
+    classes = `${classes} modus-wc-time-input--readonly`;
   }
 
   if (size) {

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tailwind.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tailwind.ts
@@ -1,13 +1,15 @@
-import { IInputFeedbackProp, ModusSize } from '../types';
+import { DaisySize, IInputFeedbackProp } from '../types';
 
 export const convertPropsToClasses = ({
   bordered,
   feedback,
+  readOnly,
   size,
 }: {
   bordered?: boolean;
   feedback?: IInputFeedbackProp;
-  size?: ModusSize;
+  readOnly?: boolean;
+  size?: DaisySize;
 }): string => {
   let classes = '';
 
@@ -17,6 +19,10 @@ export const convertPropsToClasses = ({
 
   if (feedback) {
     classes = `${classes} modus-wc-input--${feedback.level}`;
+  }
+
+  if (readOnly) {
+    classes = `${classes} modus-wc-time-input-readonly`;
   }
 
   if (size) {

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tsx
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tsx
@@ -130,6 +130,7 @@ export class ModusWcTimeInput {
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,
       feedback: this.feedback,
+      readOnly: this.readOnly,
       size: this.size,
     });
 

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tsx
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tsx
@@ -125,7 +125,11 @@ export class ModusWcTimeInput {
   }
 
   private getClasses(): string {
-    const classList = ['modus-wc-input', 'modus-wc-w-full'];
+    const classList = [
+      'modus-wc-time-input',
+      'modus-wc-input',
+      'modus-wc-w-full',
+    ];
 
     const propClasses = convertPropsToClasses({
       bordered: this.bordered,

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1407,7 +1407,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable date picker component used to create date inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable date picker component used to create date inputs.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcDate",
           "members": [
             {
@@ -4566,7 +4566,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create time inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create time inputs.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcTimeInput",
           "members": [
             {
@@ -4612,7 +4612,7 @@
             {
               "name": "datalist-id",
               "fieldName": "datalistId",
-              "description": "ID of a `<datalist>` element that contains pre-defined time options.\r\nThe value must be the ID of a `<datalist>` element in the same document.",
+              "description": "ID of a `<datalist>` element that contains pre-defined time options.\nThe value must be the ID of a `<datalist>` element in the same document.",
               "type": {
                 "text": "string"
               }
@@ -4713,7 +4713,7 @@
               "name": "show-seconds",
               "fieldName": "showSeconds",
               "default": "false",
-              "description": "Displays the time input format as `HH:mm:ss` if `true`.\r\nInternally sets the `step` to 1 second.\r\nIf a `step` value is provided, it will override this attribute.",
+              "description": "Displays the time input format as `HH:mm:ss` if `true`.\nInternally sets the `step` to 1 second.\nIf a `step` value is provided, it will override this attribute.",
               "type": {
                 "text": "boolean"
               }
@@ -4730,7 +4730,7 @@
             {
               "name": "step",
               "fieldName": "step",
-              "description": "Specifies the granularity that the `value` must adhere to.\r\nValue of step given in seconds. Default value is 60 seconds.\r\nOverrides the `seconds` attribute if both are provided.",
+              "description": "Specifies the granularity that the `value` must adhere to.\nValue of step given in seconds. Default value is 60 seconds.\nOverrides the `seconds` attribute if both are provided.",
               "type": {
                 "text": "number"
               }
@@ -4739,7 +4739,7 @@
               "name": "value",
               "fieldName": "value",
               "default": "''",
-              "description": "The value of the time input.\r\nAlways in 24-hour format that includes leading zeros:\r\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\r\nto be selected based on user's locale (or by the user agent).\r\nIf time includes seconds the format is always `HH:mm:ss`.",
+              "description": "The value of the time input.\nAlways in 24-hour format that includes leading zeros:\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\nto be selected based on user's locale (or by the user agent).\nIf time includes seconds the format is always `HH:mm:ss`.",
               "type": {
                 "text": "string"
               }

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -2460,7 +2460,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create number inputs with types.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create number inputs with types.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcNumberInput",
           "members": [
             {
@@ -2541,7 +2541,7 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'numeric'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
                 "text": "'decimal' | 'none' | 'numeric'"
               }
@@ -3994,7 +3994,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create text inputs with types.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create text inputs with types.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcTextInput",
           "members": [
             {
@@ -4016,7 +4016,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
+                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
               }
             },
             {
@@ -4076,7 +4076,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
+                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
               }
             },
             {
@@ -4117,9 +4117,9 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'text'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
-                "text": "| 'decimal'\r\n    | 'email'\r\n    | 'none'\r\n    | 'numeric'\r\n    | 'search'\r\n    | 'tel'\r\n    | 'text'\r\n    | 'url'"
+                "text": "| 'decimal'\n    | 'email'\n    | 'none'\n    | 'numeric'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'url'"
               }
             },
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR fixes #282 where text inputs would sometimes have an incorrect background color.

This bug was caused by style bleeding from the `date` and `time` inputs. Since those components all use the `.modus-wc-input` class selector, it was causing style overrides when used together. 

This PR adds component named class selectors to our form inputs that share `.modus-wc-input` (date, number, text, time) to increase specificity and prevent style leakages.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tested manually in storybook.
Unit tests passing.
Tested published package in guided entry (v`0.0.0-beta.32-react18`)
![chrome_EaNMuD6NWY](https://github.com/user-attachments/assets/18bd1a04-65ab-4c92-867d-9fcf4aaf8786)

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #282 
