### PR TITLE
fix: pagination button sizes in modus classic

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -155,6 +155,10 @@ export namespace Components {
          */
         "required"?: boolean;
         /**
+          * A spinner that appears when set to true
+         */
+        "showSpinner"?: boolean;
+        /**
           * The size of the autocomplete (input and menu).
          */
         "size"?: ModusSize;
@@ -2555,6 +2559,10 @@ declare namespace LocalJSX {
           * A value is required for the form to be submittable.
          */
         "required"?: boolean;
+        /**
+          * A spinner that appears when set to true
+         */
+        "showSpinner"?: boolean;
         /**
           * The size of the autocomplete (input and menu).
          */

--- a/src/components/modus-wc-autocomplete/readme.md
+++ b/src/components/modus-wc-autocomplete/readme.md
@@ -31,6 +31,7 @@ Adheres to WCAG 2.2 standards.
 | `placeholder`   | `placeholder`     | Text that appears in the form control when it has no value set.                                         | `string \| undefined`                 | `''`        |
 | `readOnly`      | `read-only`       | Whether the value is editable.                                                                          | `boolean \| undefined`                | `false`     |
 | `required`      | `required`        | A value is required for the form to be submittable.                                                     | `boolean \| undefined`                | `false`     |
+| `showSpinner`   | `show-spinner`    | A spinner that appears when set to true                                                                 | `boolean \| undefined`                | `false`     |
 | `size`          | `size`            | The size of the autocomplete (input and menu).                                                          | `"lg" \| "md" \| "sm" \| undefined`   | `'md'`      |
 | `value`         | `value`           | The value of the control.                                                                               | `string`                              | `''`        |
 
@@ -53,6 +54,7 @@ Adheres to WCAG 2.2 standards.
 - [modus-wc-icon](../modus-wc-icon)
 - [modus-wc-button](../modus-wc-button)
 - [modus-wc-text-input](../modus-wc-text-input)
+- [modus-wc-loader](../modus-wc-loader)
 - [modus-wc-menu-item](../modus-wc-menu-item)
 - [modus-wc-input-label](../modus-wc-input-label)
 - [modus-wc-menu](../modus-wc-menu)
@@ -63,6 +65,7 @@ graph TD;
   modus-wc-autocomplete --> modus-wc-icon
   modus-wc-autocomplete --> modus-wc-button
   modus-wc-autocomplete --> modus-wc-text-input
+  modus-wc-autocomplete --> modus-wc-loader
   modus-wc-autocomplete --> modus-wc-menu-item
   modus-wc-autocomplete --> modus-wc-input-label
   modus-wc-autocomplete --> modus-wc-menu

--- a/src/components/modus-wc-loader/readme.md
+++ b/src/components/modus-wc-loader/readme.md
@@ -21,6 +21,19 @@ Adheres to WCAG 2.2 standards.
 | `variant`     | `variant`      | The variant of the loader.                       | `"ball" \| "bars" \| "dots" \| "infinity" \| "ring" \| "spinner"`                                  | `'spinner'` |
 
 
+## Dependencies
+
+### Used by
+
+ - [modus-wc-autocomplete](../modus-wc-autocomplete)
+
+### Graph
+```mermaid
+graph TD;
+  modus-wc-autocomplete --> modus-wc-loader
+  style modus-wc-loader fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/modus-wc-pagination/modus-wc-pagination.scss
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.scss
@@ -36,6 +36,28 @@
     border: none;
     border-radius: var(--modus-wc-border-radius-md) !important;
     box-shadow: none;
+
+    // Sizes
+    &.modus-wc-btn-sm {
+      height: var(--modus-wc-line-height-md);
+      min-height: var(--modus-wc-line-height-md);
+      max-height: var(--modus-wc-line-height-md);
+      width: var(--modus-wc-line-height-md);
+    }
+
+    &.modus-wc-btn-md {
+      height: var(--modus-wc-line-height-lg);
+      min-height: var(--modus-wc-line-height-lg);
+      max-height: var(--modus-wc-line-height-lg);
+      width: var(--modus-wc-line-height-lg);
+    }
+
+    &.modus-wc-btn-lg {
+      height: var(--modus-wc-line-height-xl);
+      min-height: var(--modus-wc-line-height-xl);
+      max-height: var(--modus-wc-line-height-xl);
+      width: var(--modus-wc-line-height-xl);
+    }
   }
 }
 

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -397,6 +397,15 @@
               }
             },
             {
+              "name": "show-spinner",
+              "fieldName": "showSpinner",
+              "default": "false",
+              "description": "A spinner that appears when set to true",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
               "name": "size",
               "fieldName": "size",
               "default": "'md'",
@@ -1407,7 +1416,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable date picker component used to create date inputs.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable date picker component used to create date inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcDate",
           "members": [
             {
@@ -2460,7 +2469,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create number inputs with types.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create number inputs with types.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcNumberInput",
           "members": [
             {
@@ -2541,7 +2550,7 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'numeric'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
                 "text": "'decimal' | 'none' | 'numeric'"
               }
@@ -3994,7 +4003,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create text inputs with types.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create text inputs with types.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcTextInput",
           "members": [
             {
@@ -4016,7 +4025,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
+                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
               }
             },
             {
@@ -4076,7 +4085,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
+                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
               }
             },
             {
@@ -4117,9 +4126,9 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'text'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
-                "text": "| 'decimal'\n    | 'email'\n    | 'none'\n    | 'numeric'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'url'"
+                "text": "| 'decimal'\r\n    | 'email'\r\n    | 'none'\r\n    | 'numeric'\r\n    | 'search'\r\n    | 'tel'\r\n    | 'text'\r\n    | 'url'"
               }
             },
             {
@@ -4566,7 +4575,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create time inputs.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create time inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcTimeInput",
           "members": [
             {
@@ -4612,7 +4621,7 @@
             {
               "name": "datalist-id",
               "fieldName": "datalistId",
-              "description": "ID of a `<datalist>` element that contains pre-defined time options.\nThe value must be the ID of a `<datalist>` element in the same document.",
+              "description": "ID of a `<datalist>` element that contains pre-defined time options.\r\nThe value must be the ID of a `<datalist>` element in the same document.",
               "type": {
                 "text": "string"
               }
@@ -4713,7 +4722,7 @@
               "name": "show-seconds",
               "fieldName": "showSeconds",
               "default": "false",
-              "description": "Displays the time input format as `HH:mm:ss` if `true`.\nInternally sets the `step` to 1 second.\nIf a `step` value is provided, it will override this attribute.",
+              "description": "Displays the time input format as `HH:mm:ss` if `true`.\r\nInternally sets the `step` to 1 second.\r\nIf a `step` value is provided, it will override this attribute.",
               "type": {
                 "text": "boolean"
               }
@@ -4730,7 +4739,7 @@
             {
               "name": "step",
               "fieldName": "step",
-              "description": "Specifies the granularity that the `value` must adhere to.\nValue of step given in seconds. Default value is 60 seconds.\nOverrides the `seconds` attribute if both are provided.",
+              "description": "Specifies the granularity that the `value` must adhere to.\r\nValue of step given in seconds. Default value is 60 seconds.\r\nOverrides the `seconds` attribute if both are provided.",
               "type": {
                 "text": "number"
               }
@@ -4739,7 +4748,7 @@
               "name": "value",
               "fieldName": "value",
               "default": "''",
-              "description": "The value of the time input.\nAlways in 24-hour format that includes leading zeros:\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\nto be selected based on user's locale (or by the user agent).\nIf time includes seconds the format is always `HH:mm:ss`.",
+              "description": "The value of the time input.\r\nAlways in 24-hour format that includes leading zeros:\r\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\r\nto be selected based on user's locale (or by the user agent).\r\nIf time includes seconds the format is always `HH:mm:ss`.",
               "type": {
                 "text": "string"
               }


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR updates button sizes in the pagination component for modus classic.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tests passing

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #212
