### PR TITLE
fix: chip styles broken when also rendering button

### DIFF
--- a/src/components/modus-wc-chip/modus-wc-chip.scss
+++ b/src/components/modus-wc-chip/modus-wc-chip.scss
@@ -4,7 +4,7 @@
 */
 
 // Default Styles
-.modus-wc-chip {
+modus-wc-chip .modus-wc-chip {
   &.modus-wc-btn {
     $modus-wc-chip-active-filled-bg: color-mix(
       in sRGB,
@@ -23,7 +23,8 @@
 
       height: var(--modus-wc-spacing-xl);
       min-height: var(--modus-wc-spacing-xl);
-      padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-md);
+      // Using important due to the button's high specificity
+      padding: var(--modus-wc-spacing-xs) var(--modus-wc-spacing-md) !important;
 
       .modus-wc-avatar {
         height: var(--modus-wc-spacing-lg);
@@ -41,7 +42,8 @@
 
       height: var(--modus-wc-spacing-2xl);
       min-height: var(--modus-wc-spacing-2xl);
-      padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-md);
+      // Using important due to the button's high specificity
+      padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-md) !important;
 
       .modus-wc-avatar {
         height: var(--modus-wc-spacing-lg);
@@ -59,7 +61,8 @@
 
       height: var(--modus-wc-spacing-3xl);
       min-height: var(--modus-wc-spacing-3xl);
-      padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-lg);
+      // Using important due to the button's high specificity
+      padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-lg) !important;
 
       .modus-wc-avatar {
         height: var(--modus-wc-spacing-xl);
@@ -102,7 +105,7 @@
 
     &.modus-wc-chip--outline {
       background-color: transparent;
-      border-color: var(--modus-wc-color-gray-4);
+      border: var(--modus-wc-border-width-xs) solid var(--modus-wc-color-gray-4);
     }
 
     &:hover:not(.modus-wc-chip--active):not(.modus-wc-chip--error) {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR increases the specificity of the chip CSS while also implementing the rare `!important` value for padding. This is necessary due to the high CSS specificity within the button regarding padding of not circle and square shaped buttons.

This problem could only be found on pages where a button and a chip were rendered, thus loading the button styling.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Manual testing

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #234
