### PR TITLE
fix: input heights in modus classic

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -660,6 +660,10 @@ export namespace Components {
          */
         "disabled"?: boolean;
         /**
+          * The focused state of the menu item.
+         */
+        "focused"?: boolean;
+        /**
           * The text rendered in the menu item.
          */
         "label": string;
@@ -3108,6 +3112,10 @@ declare namespace LocalJSX {
           * The disabled state of the menu item.
          */
         "disabled"?: boolean;
+        /**
+          * The focused state of the menu item.
+         */
+        "focused"?: boolean;
         /**
           * The text rendered in the menu item.
          */

--- a/src/components/modus-wc-autocomplete/readme.md
+++ b/src/components/modus-wc-autocomplete/readme.md
@@ -52,7 +52,7 @@ Adheres to WCAG 2.2 standards.
 ### Depends on
 
 - [modus-wc-icon](../modus-wc-icon)
-- [modus-wc-button](../modus-wc-button)
+- [modus-wc-chip](../modus-wc-chip)
 - [modus-wc-text-input](../modus-wc-text-input)
 - [modus-wc-loader](../modus-wc-loader)
 - [modus-wc-menu-item](../modus-wc-menu-item)
@@ -63,7 +63,7 @@ Adheres to WCAG 2.2 standards.
 ```mermaid
 graph TD;
   modus-wc-autocomplete --> modus-wc-icon
-  modus-wc-autocomplete --> modus-wc-button
+  modus-wc-autocomplete --> modus-wc-chip
   modus-wc-autocomplete --> modus-wc-text-input
   modus-wc-autocomplete --> modus-wc-loader
   modus-wc-autocomplete --> modus-wc-menu-item

--- a/src/components/modus-wc-button/readme.md
+++ b/src/components/modus-wc-button/readme.md
@@ -38,13 +38,11 @@ Adheres to WCAG 2.2 standards.
 ### Used by
 
  - [modus-wc-alert](../modus-wc-alert)
- - [modus-wc-autocomplete](../modus-wc-autocomplete)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-alert --> modus-wc-button
-  modus-wc-autocomplete --> modus-wc-button
   style modus-wc-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/components/modus-wc-chip/readme.md
+++ b/src/components/modus-wc-chip/readme.md
@@ -33,6 +33,19 @@ Adheres to WCAG 2.2 standards.
 | `chipRemove` | Event emitted when the close chip icon button is clicked.         | `CustomEvent<KeyboardEvent \| MouseEvent>` |
 
 
+## Dependencies
+
+### Used by
+
+ - [modus-wc-autocomplete](../modus-wc-autocomplete)
+
+### Graph
+```mermaid
+graph TD;
+  modus-wc-autocomplete --> modus-wc-chip
+  style modus-wc-chip fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/modus-wc-menu-item/readme.md
+++ b/src/components/modus-wc-menu-item/readme.md
@@ -18,6 +18,7 @@ Adheres to WCAG 2.2 standards.
 | `bordered`    | `bordered`     |                                                              | `boolean \| undefined`              | `undefined` |
 | `customClass` | `custom-class` | Custom CSS class to apply to the li element.                 | `string \| undefined`               | `''`        |
 | `disabled`    | `disabled`     | The disabled state of the menu item.                         | `boolean \| undefined`              | `undefined` |
+| `focused`     | `focused`      | The focused state of the menu item.                          | `boolean \| undefined`              | `undefined` |
 | `label`       | `label`        | The text rendered in the menu item.                          | `string`                            | `''`        |
 | `selected`    | `selected`     | The selected state of the menu item.                         | `boolean \| undefined`              | `undefined` |
 | `size`        | `size`         | The size of the menu item.                                   | `"lg" \| "md" \| "sm" \| undefined` | `'md'`      |

--- a/src/components/modus-wc-number-input/modus-wc-number-input.scss
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.scss
@@ -40,18 +40,18 @@
       }
 
       &.modus-wc-input-sm {
-        padding: var(--modus-wc-spacing-md) 0 var(--modus-wc-spacing-md)
-          var(--modus-wc-spacing-sm);
+        padding: var(--modus-wc-spacing-sm) var(--modus-wc-spacing-xs);
+        padding-inline-end: 0; // Align spinner buttons
       }
 
       &.modus-wc-input-md {
-        padding: var(--modus-wc-spacing-lg) var(--modus-wc-spacing-lg)
-          var(--modus-wc-spacing-lg) var(--modus-wc-spacing-md);
+        padding: var(--modus-wc-spacing-sm);
+        padding-inline-end: var(--modus-wc-spacing-lg); // Align spinner buttons
       }
 
       &.modus-wc-input-lg {
-        padding: var(--modus-wc-spacing-xl) var(--modus-wc-spacing-xl)
-          var(--modus-wc-spacing-xl) var(--modus-wc-spacing-lg);
+        padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
+        padding-inline-end: var(--modus-wc-spacing-xl); // Align spinner buttons
       }
 
       &:focus {
@@ -79,6 +79,7 @@
     &.modus-wc-input-sm {
       font-size: var(--modus-wc-font-size-sm);
       height: var(--modus-wc-input-height-sm);
+      line-height: var(--modus-wc-line-height-sm);
 
       &::-webkit-inner-spin-button,
       &::-webkit-outer-spin-button {
@@ -90,6 +91,7 @@
     &.modus-wc-input-md {
       font-size: var(--modus-wc-font-size-md);
       height: var(--modus-wc-input-height-md);
+      line-height: var(--modus-wc-line-height-md);
 
       &::-webkit-inner-spin-button,
       &::-webkit-outer-spin-button {
@@ -101,6 +103,7 @@
     &.modus-wc-input-lg {
       font-size: var(--modus-wc-font-size-lg);
       height: var(--modus-wc-input-height-lg);
+      line-height: var(--modus-wc-line-height-xl);
 
       &::-webkit-inner-spin-button,
       &::-webkit-outer-spin-button {

--- a/src/components/modus-wc-number-input/modus-wc-number-input.scss
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.scss
@@ -21,15 +21,15 @@
     white-space: nowrap;
 
     &.modus-wc-input-sm {
-      padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
+      padding: 0 var(--modus-wc-spacing-xs);
     }
 
     &.modus-wc-input-md {
-      padding: var(--modus-wc-spacing-lg);
+      padding: 0 var(--modus-wc-spacing-sm);
     }
 
     &.modus-wc-input-lg {
-      padding: var(--modus-wc-spacing-xl);
+      padding: 0 var(--modus-wc-spacing-md);
     }
   }
 

--- a/src/components/modus-wc-text-input/modus-wc-text-input.scss
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.scss
@@ -40,7 +40,7 @@ label.modus-wc-input-label {
     &.modus-wc-input-lg {
       font-size: var(--modus-wc-font-size-lg);
       height: var(--modus-wc-input-height-lg);
-      line-height: var(--modus-wc-line-height-lg);
+      line-height: var(--modus-wc-line-height-xl);
       padding: var(--modus-wc-spacing-md) var(--modus-wc-spacing-sm);
     }
 

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -249,6 +249,18 @@
             },
             {
               "kind": "method",
+              "name": "handleKeyDown",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
               "name": "handleMenuVisibilityChange"
             },
             {
@@ -2149,6 +2161,14 @@
               "name": "disabled",
               "fieldName": "disabled",
               "description": "The disabled state of the menu item.",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "name": "focused",
+              "fieldName": "focused",
+              "description": "The focused state of the menu item.",
               "type": {
                 "text": "boolean"
               }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -105,7 +105,7 @@
   // Inputs
   --modus-wc-input-height-sm: 1.5rem; // 24px
   --modus-wc-input-height-md: 2rem; // 32px
-  --modus-wc-input-height-lg: 2.5rem; // 40px
+  --modus-wc-input-height-lg: 3rem; // 48px
 
   /**
   * The following variables are applied to themes for applications to override.


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR aligns input heights to match the modus classic mocks. Some additional adjustments were required to align the number input spinner buttons.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Manual

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #283 
