### PR TITLE
Icons: Remove redundant `aria-label`

### DIFF
--- a/src/components/modus-wc-icon/modus-wc-icon.spec.ts
+++ b/src/components/modus-wc-icon/modus-wc-icon.spec.ts
@@ -5,7 +5,7 @@ describe('modus-wc-icon', () => {
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcIcon],
-      html: '<modus-wc-icon aria-label="Default icon"></modus-wc-icon>',
+      html: '<modus-wc-icon></modus-wc-icon>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -13,7 +13,7 @@ describe('modus-wc-icon', () => {
   it('should render with custom props', async () => {
     const page = await newSpecPage({
       components: [ModusWcIcon],
-      html: '<modus-wc-icon aria-label="Custom icon" custom-class="test-class" decorative="false" size="sm"></modus-wc-icon>',
+      html: '<modus-wc-icon custom-class="test-class" decorative="false" size="sm"></modus-wc-icon>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -21,7 +21,7 @@ describe('modus-wc-icon', () => {
   it('should render with size prop lg', async () => {
     const page = await newSpecPage({
       components: [ModusWcIcon],
-      html: '<modus-wc-icon aria-label="Custom icon" size="lg"></modus-wc-icon>',
+      html: '<modus-wc-icon size="lg"></modus-wc-icon>',
     });
     expect(page.root).toMatchSnapshot();
   });

--- a/src/components/modus-wc-icon/modus-wc-icon.stories.ts
+++ b/src/components/modus-wc-icon/modus-wc-icon.stories.ts
@@ -35,7 +35,6 @@ const Template: Story = {
   render: (args) => {
     return html`
       <modus-wc-icon
-        aria-label="Alert icon"
         custom-class="${ifDefined(args['custom-class'])}"
         ?decorative="${args.decorative}"
         name="${args.name}"
@@ -56,12 +55,7 @@ export const CustomColor: Story = {
           color: red;
         }
       </style>
-      <modus-wc-icon
-        aria-label="Red alert icon"
-        custom-class="red-icon"
-        name="alert"
-        size="${args.size}"
-      >
+      <modus-wc-icon custom-class="red-icon" name="alert" size="${args.size}">
       </modus-wc-icon>
     `;
   },

--- a/src/components/modus-wc-icon/modus-wc-icon.tsx
+++ b/src/components/modus-wc-icon/modus-wc-icon.tsx
@@ -58,10 +58,8 @@ export class ModusWcIcon {
       <Host class="modus-wc-flex modus-wc-items-center">
         <i
           aria-hidden={ariaHidden}
-          aria-label={this.decorative ? null : this.el.ariaLabel}
           class={this.getClasses()}
           role={role}
-          tabindex={-1}
           {...this.inheritedAttributes}
         >
           {this.name}


### PR DESCRIPTION
The icons get `aria-hidden="true"` anyway so no need for a label.


### :page_facing_up: Summary of Changes

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #
