### PR TITLE
feat: add navbar slots and events for buttons

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1620,6 +1620,10 @@ export interface ModusWcMenuItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusWcMenuItemElement;
 }
+export interface ModusWcNavbarCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusWcNavbarElement;
+}
 export interface ModusWcNumberInputCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusWcNumberInputElement;
@@ -2005,11 +2009,23 @@ declare global {
         prototype: HTMLModusWcModalElement;
         new (): HTMLModusWcModalElement;
     };
+    interface HTMLModusWcNavbarElementEventMap {
+        "helpClick": MouseEvent | KeyboardEvent;
+        "trimbleLogoClick": MouseEvent | KeyboardEvent;
+    }
     /**
      * A customizable navbar component used for top level navigation of all Trimble applications.
      * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcNavbarElement extends Components.ModusWcNavbar, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusWcNavbarElementEventMap>(type: K, listener: (this: HTMLModusWcNavbarElement, ev: ModusWcNavbarCustomEvent<HTMLModusWcNavbarElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusWcNavbarElementEventMap>(type: K, listener: (this: HTMLModusWcNavbarElement, ev: ModusWcNavbarCustomEvent<HTMLModusWcNavbarElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLModusWcNavbarElement: {
         prototype: HTMLModusWcNavbarElement;
@@ -3210,6 +3226,14 @@ declare namespace LocalJSX {
           * Custom CSS class to apply to the host element.
          */
         "customClass"?: string;
+        /**
+          * Event emitted when the help button is clicked or activated via keyboard.
+         */
+        "onHelpClick"?: (event: ModusWcNavbarCustomEvent<MouseEvent | KeyboardEvent>) => void;
+        /**
+          * Event emitted when the Trimble logo is clicked or activated via keyboard.
+         */
+        "onTrimbleLogoClick"?: (event: ModusWcNavbarCustomEvent<MouseEvent | KeyboardEvent>) => void;
     }
     /**
      * A customizable input component used to create number inputs with types.

--- a/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
+++ b/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
@@ -13,7 +13,8 @@ exports[`modus-wc-navbar should render with custom props and slots 1`] = `
               <path d="M4 18h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1m0-5h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1M3 7c0 .55.45 1 1 1h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1"></path>
             </svg>
           </modus-wc-button>
-          <modus-wc-button customclass="logo" size="xs" variant="borderless">
+          <div class="hidden menu"></div>
+          <modus-wc-button customclass="trimble-logo" size="xs" variant="borderless">
             <svg data-name="Art Black" id="Art_Black" viewBox="0 0 444.68 100" xmlns="http://www.w3.org/2000/svg">
               <path d="M115.85,87.13v-62H93V11.21h62.57v14h-23v62Z" fill="#0063a3"></path>
               <path d="M141.9,87.13V32.74h16.52v8.84h.1c3-4.62,8.21-10.26,18.47-10.26h.51V46c-.61-.11-3.49-.31-4.51-.31a18.27,18.27,0,0,0-14.57,7.49v34Z" fill="#0063a3"></path>
@@ -61,6 +62,7 @@ exports[`modus-wc-navbar should render with custom props and slots 1`] = `
               <path d="M10 20h4c0 1.1-.9 2-2 2s-2-.9-2-2m9.67-2.69C18.36 15.96 17 13.66 17 10a5 5 0 0 0-4-4.9V4c0-.55-.45-1-1-1s-1 .45-1 1v1.1A5 5 0 0 0 7 10c0 3.66-1.37 5.96-2.67 7.31-.61.64-.16 1.69.72 1.69h13.91c.88 0 1.33-1.05.72-1.69Z"></path>
             </svg>
           </modus-wc-button>
+          <div class="hidden notifications"></div>
           <modus-wc-button shape="square" size="xs" variant="borderless">
             <svg class="mi-help mi-solid" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 16.25a1.25 1.25 0 1 1 0-2.5 1.25 1.25 0 0 1 0 2.5m2.82-6.72-.77.79c-.42.43-.69.78-.83 1.34-.07.28-.1.58-.1.92v.25H10.9v-.68c0-.41.07-.81.2-1.21.18-.52.48-1.01.87-1.4l1.07-1.09c.35-.33.49-.81.4-1.32-.09-.52-.5-.97-1.01-1.12a1.467 1.467 0 0 0-1.81.93c-.14.44-.51.73-.94.73h-.26c-.31 0-.59-.14-.78-.39s-.25-.58-.16-.89a3.72 3.72 0 0 1 2.97-2.61c.17-.03.34-.04.51-.04 1.15 0 2.3.63 3.06 1.68 1.13 1.57.72 3.19-.19 4.1Z"></path>
@@ -71,6 +73,7 @@ exports[`modus-wc-navbar should render with custom props and slots 1`] = `
               <path d="M5 8h2c.6 0 1-.4 1-1V5c0-.6-.4-1-1-1H5c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m6 12h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m-6 0h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1H5c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m0-6h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1H5c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m6 0h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m5-9v2c0 .6.4 1 1 1h2c.6 0 1-.4 1-1V5c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1m-5 3h2c.6 0 1-.4 1-1V5c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m6 6h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m0 6h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1"></path>
             </svg>
           </modus-wc-button>
+          <div class="apps hidden"></div>
         </div>
       </div>
     </div>
@@ -91,7 +94,8 @@ exports[`modus-wc-navbar should render with no props 1`] = `
               <path d="M4 18h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1m0-5h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1s.45 1 1 1M3 7c0 .55.45 1 1 1h16c.55 0 1-.45 1-1s-.45-1-1-1H4c-.55 0-1 .45-1 1"></path>
             </svg>
           </modus-wc-button>
-          <modus-wc-button customclass="logo" size="xs" variant="borderless">
+          <div class="hidden menu"></div>
+          <modus-wc-button customclass="trimble-logo" size="xs" variant="borderless">
             <svg data-name="Art Black" id="Art_Black" viewBox="0 0 444.68 100" xmlns="http://www.w3.org/2000/svg">
               <path d="M115.85,87.13v-62H93V11.21h62.57v14h-23v62Z" fill="#0063a3"></path>
               <path d="M141.9,87.13V32.74h16.52v8.84h.1c3-4.62,8.21-10.26,18.47-10.26h.51V46c-.61-.11-3.49-.31-4.51-.31a18.27,18.27,0,0,0-14.57,7.49v34Z" fill="#0063a3"></path>
@@ -129,6 +133,7 @@ exports[`modus-wc-navbar should render with no props 1`] = `
               <path d="M10 20h4c0 1.1-.9 2-2 2s-2-.9-2-2m9.67-2.69C18.36 15.96 17 13.66 17 10a5 5 0 0 0-4-4.9V4c0-.55-.45-1-1-1s-1 .45-1 1v1.1A5 5 0 0 0 7 10c0 3.66-1.37 5.96-2.67 7.31-.61.64-.16 1.69.72 1.69h13.91c.88 0 1.33-1.05.72-1.69Z"></path>
             </svg>
           </modus-wc-button>
+          <div class="hidden notifications"></div>
           <modus-wc-button shape="square" size="xs" variant="borderless">
             <svg class="mi-help mi-solid" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 16.25a1.25 1.25 0 1 1 0-2.5 1.25 1.25 0 0 1 0 2.5m2.82-6.72-.77.79c-.42.43-.69.78-.83 1.34-.07.28-.1.58-.1.92v.25H10.9v-.68c0-.41.07-.81.2-1.21.18-.52.48-1.01.87-1.4l1.07-1.09c.35-.33.49-.81.4-1.32-.09-.52-.5-.97-1.01-1.12a1.467 1.467 0 0 0-1.81.93c-.14.44-.51.73-.94.73h-.26c-.31 0-.59-.14-.78-.39s-.25-.58-.16-.89a3.72 3.72 0 0 1 2.97-2.61c.17-.03.34-.04.51-.04 1.15 0 2.3.63 3.06 1.68 1.13 1.57.72 3.19-.19 4.1Z"></path>
@@ -139,6 +144,7 @@ exports[`modus-wc-navbar should render with no props 1`] = `
               <path d="M5 8h2c.6 0 1-.4 1-1V5c0-.6-.4-1-1-1H5c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m6 12h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m-6 0h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1H5c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m0-6h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1H5c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m6 0h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m5-9v2c0 .6.4 1 1 1h2c.6 0 1-.4 1-1V5c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1m-5 3h2c.6 0 1-.4 1-1V5c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m6 6h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1m0 6h2c.6 0 1-.4 1-1v-2c0-.6-.4-1-1-1h-2c-.6 0-1 .4-1 1v2c0 .6.4 1 1 1"></path>
             </svg>
           </modus-wc-button>
+          <div class="apps hidden"></div>
         </div>
       </div>
     </div>

--- a/src/components/modus-wc-navbar/modus-wc-navbar.scss
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.scss
@@ -7,15 +7,34 @@ modus-wc-navbar .modus-wc-navbar {
     color: var(--modus-wc-color-black);
   }
 
-  [slot='start'] {
-    display: flex;
+  // Common dropdown styles
+  %dropdown-menu {
+    position: absolute;
+    top: 38px;
 
-    modus-wc-button {
-      padding-inline-end: 8px;
+    &.hidden {
+      display: none;
     }
 
-    .logo.modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary {
-      padding: 0 16px;
+    &.visible {
+      display: block;
+    }
+  }
+
+  [slot='start'] {
+    display: flex;
+    position: relative;
+
+    modus-wc-button {
+      padding-inline-end: var(--modus-wc-spacing-sm);
+    }
+
+    .menu {
+      @extend %dropdown-menu;
+    }
+
+    .trimble-logo.modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary {
+      padding: 0 var(--modus-wc-spacing-lg);
 
       svg {
         height: 24px;
@@ -25,24 +44,37 @@ modus-wc-navbar .modus-wc-navbar {
 
   [slot='center'] {
     display: flex;
+    position: relative;
   }
 
   [slot='end'] {
     display: flex;
+    position: relative;
 
     modus-wc-button {
-      padding-inline-start: 8px;
+      padding-inline-start: var(--modus-wc-spacing-sm);
+    }
+
+    .notifications {
+      @extend %dropdown-menu;
+
+      right: 64px;
+    }
+
+    .apps {
+      @extend %dropdown-menu;
     }
   }
 }
 
 [data-theme='modus-classic-dark'] modus-wc-navbar .modus-wc-navbar,
 [data-theme='modus-modern-dark'] modus-wc-navbar .modus-wc-navbar {
-  &:not(.logo) .modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary {
+  &:not(.trimble-logo)
+    .modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary {
     color: var(--modus-wc-color-white);
   }
 
-  .logo.modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary path {
+  .trimble-logo.modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary path {
     fill: var(--modus-wc-color-white);
   }
 }

--- a/src/components/modus-wc-navbar/modus-wc-navbar.stories.ts
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.stories.ts
@@ -1,3 +1,4 @@
+import { withActions } from '@storybook/addon-actions/decorator';
 import { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -9,7 +10,11 @@ interface NavbarArgs {
 const meta: Meta<NavbarArgs> = {
   title: 'Components/Navbar',
   component: 'modus-wc-navbar',
+  decorators: [withActions],
   parameters: {
+    actions: {
+      handles: ['helpClick', 'trimbleLogoClick'],
+    },
     layout: 'padded',
   },
 };
@@ -22,7 +27,16 @@ const Template: Story = {
   render: (args) => {
     // prettier-ignore
     return html`
-<modus-wc-navbar custom-class="${ifDefined(args['custom-class'])}"></modus-wc-navbar>
+<style>
+  div[id^='story--components-navbar--default'] {
+    height: 100px;
+  }
+</style>
+<modus-wc-navbar custom-class="${ifDefined(args['custom-class'])}">
+  <div slot="menu">Menu contents</div>
+  <div slot="notifications">Notification contents</div>
+  <div slot="apps">App drawer contents</div>
+</modus-wc-navbar>
     `;
   },
 };

--- a/src/components/modus-wc-navbar/modus-wc-navbar.tsx
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.tsx
@@ -1,4 +1,14 @@
-import { Component, Element, h, Host, Prop } from '@stencil/core';
+import {
+  Component,
+  Element,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Prop,
+  State,
+  Event as StencilEvent,
+} from '@stencil/core';
 import { AppsSolidIcon } from '../../icons/apps-solid.icon';
 import { HelpSolidIcon } from '../../icons/help-solid.icon';
 import { MenuSolidIcon } from '../../icons/menu-solid.icon';
@@ -18,6 +28,9 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 })
 export class ModusWcNavbar {
   private inheritedAttributes: Attributes = {};
+  private menuRef?: HTMLDivElement;
+  private notificationsRef?: HTMLDivElement;
+  private appsRef?: HTMLDivElement;
 
   /** Reference to the host element */
   @Element() el!: HTMLElement;
@@ -25,8 +38,67 @@ export class ModusWcNavbar {
   /** Custom CSS class to apply to the host element. */
   @Prop() customClass?: string = '';
 
+  /** Event emitted when the help button is clicked or activated via keyboard. */
+  @StencilEvent() helpClick!: EventEmitter<MouseEvent | KeyboardEvent>;
+
+  /** Event emitted when the Trimble logo is clicked or activated via keyboard. */
+  @StencilEvent() trimbleLogoClick!: EventEmitter<MouseEvent | KeyboardEvent>;
+
+  @State() menuOpen: boolean = false;
+  @State() notificationsOpen: boolean = false;
+  @State() appsOpen: boolean = false;
+
   componentWillLoad() {
     this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
+
+  // TODO - add coverage
+  // istanbul ignore next
+  @Listen('click', { target: 'document' })
+  handleClickOutside(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+
+    if (this.menuOpen) {
+      const menuButton = this.el.querySelector(
+        'modus-wc-button:has(svg[class*="menu"])'
+      );
+      if (
+        this.menuRef &&
+        !this.menuRef.contains(target) &&
+        menuButton !== target &&
+        !menuButton?.contains(target)
+      ) {
+        this.menuOpen = false;
+      }
+    }
+
+    if (this.notificationsOpen) {
+      const notificationsButton = this.el.querySelector(
+        'modus-wc-button:has(svg[class*="notifications"])'
+      );
+      if (
+        this.notificationsRef &&
+        !this.notificationsRef.contains(target) &&
+        notificationsButton !== target &&
+        !notificationsButton?.contains(target)
+      ) {
+        this.notificationsOpen = false;
+      }
+    }
+
+    if (this.appsOpen) {
+      const appsButton = this.el.querySelector(
+        'modus-wc-button:has(svg[class*="apps"])'
+      );
+      if (
+        this.appsRef &&
+        !this.appsRef.contains(target) &&
+        appsButton !== target &&
+        !appsButton?.contains(target)
+      ) {
+        this.appsOpen = false;
+      }
+    }
   }
 
   private getClasses(): string {
@@ -38,17 +110,71 @@ export class ModusWcNavbar {
     return classList.join(' ');
   }
 
+  // TODO - add coverage
+  // istanbul ignore next
+  private handleHelpClick = (
+    event: CustomEvent<MouseEvent | KeyboardEvent>
+  ) => {
+    this.helpClick.emit(event.detail);
+  };
+
+  // TODO - add coverage
+  // istanbul ignore next
+  private handleTrimbleLogoClick = (
+    event: CustomEvent<MouseEvent | KeyboardEvent>
+  ) => {
+    this.trimbleLogoClick.emit(event.detail);
+  };
+
+  // TODO - add coverage
+  // istanbul ignore next
+  private toggleMenu = () => {
+    this.menuOpen = !this.menuOpen;
+  };
+
+  // TODO - add coverage
+  // istanbul ignore next
+  private toggleNotifications = () => {
+    this.notificationsOpen = !this.notificationsOpen;
+  };
+
+  // TODO - add coverage
+  // istanbul ignore next
+  private toggleApps = () => {
+    this.appsOpen = !this.appsOpen;
+  };
+
+  // TODO - add coverage
+  // istanbul ignore next
   render() {
     return (
       <Host class={this.getClasses()} {...this.inheritedAttributes}>
         <modus-wc-toolbar>
           <div slot="start">
-            <modus-wc-button shape="square" size="xs" variant="borderless">
+            <modus-wc-button
+              onButtonClick={this.toggleMenu}
+              shape="square"
+              size="xs"
+              variant="borderless"
+            >
               <MenuSolidIcon />
             </modus-wc-button>
-            <modus-wc-button customClass="logo" size="xs" variant="borderless">
+            <div
+              class={`menu ${this.menuOpen ? 'visible' : 'hidden'}`}
+              ref={(el) => (this.menuRef = el)}
+            >
+              <slot name="menu" />
+            </div>
+
+            <modus-wc-button
+              customClass="trimble-logo"
+              onButtonClick={this.handleTrimbleLogoClick}
+              size="xs"
+              variant="borderless"
+            >
               <TrimbleLogoFullIcon />
             </modus-wc-button>
+
             <slot name="start" />
           </div>
 
@@ -58,15 +184,45 @@ export class ModusWcNavbar {
 
           <div slot="end">
             <slot name="end" />
-            <modus-wc-button shape="square" size="xs" variant="borderless">
+
+            <modus-wc-button
+              onButtonClick={this.toggleNotifications}
+              shape="square"
+              size="xs"
+              variant="borderless"
+            >
               <NotificationsSolidIcon />
             </modus-wc-button>
-            <modus-wc-button shape="square" size="xs" variant="borderless">
+            <div
+              class={`notifications ${this.notificationsOpen ? 'visible' : 'hidden'}`}
+              ref={(el) => (this.notificationsRef = el)}
+            >
+              <slot name="notifications" />
+            </div>
+
+            <modus-wc-button
+              onButtonClick={this.handleHelpClick}
+              shape="square"
+              size="xs"
+              variant="borderless"
+            >
               <HelpSolidIcon />
             </modus-wc-button>
-            <modus-wc-button shape="square" size="xs" variant="borderless">
+
+            <modus-wc-button
+              onButtonClick={this.toggleApps}
+              shape="square"
+              size="xs"
+              variant="borderless"
+            >
               <AppsSolidIcon />
             </modus-wc-button>
+            <div
+              class={`apps ${this.appsOpen ? 'visible' : 'hidden'}`}
+              ref={(el) => (this.appsRef = el)}
+            >
+              <slot name="apps" />
+            </div>
           </div>
         </modus-wc-toolbar>
       </Host>

--- a/src/components/modus-wc-navbar/readme.md
+++ b/src/components/modus-wc-navbar/readme.md
@@ -18,6 +18,14 @@ Adheres to WCAG 2.2 standards.
 | `customClass` | `custom-class` | Custom CSS class to apply to the host element. | `string \| undefined` | `''`    |
 
 
+## Events
+
+| Event              | Description                                                               | Type                                       |
+| ------------------ | ------------------------------------------------------------------------- | ------------------------------------------ |
+| `helpClick`        | Event emitted when the help button is clicked or activated via keyboard.  | `CustomEvent<KeyboardEvent \| MouseEvent>` |
+| `trimbleLogoClick` | Event emitted when the Trimble logo is clicked or activated via keyboard. | `CustomEvent<KeyboardEvent \| MouseEvent>` |
+
+
 ## Dependencies
 
 ### Depends on

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -2390,8 +2390,16 @@
         {
           "kind": "class",
           "description": "A customizable navbar component used for top level navigation of all Trimble applications.\r\n\r\nAdheres to WCAG 2.2 standards.",
-          "name": "ModusWcToolbar",
+          "name": "ModusWcNavbar",
           "members": [
+            {
+              "kind": "field",
+              "name": "appsOpen",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
             {
               "kind": "field",
               "name": "el",
@@ -2399,6 +2407,22 @@
                 "text": "HTMLElement"
               },
               "description": "Reference to the host element"
+            },
+            {
+              "kind": "field",
+              "name": "menuOpen",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "notificationsOpen",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
             },
             {
               "kind": "method",
@@ -2424,9 +2448,9 @@
       "exports": [
         {
           "kind": "js",
-          "name": "ModusWcToolbar",
+          "name": "ModusWcNavbar",
           "declaration": {
-            "name": "ModusWcToolbar",
+            "name": "ModusWcNavbar",
             "module": "src/components/modus-wc-navbar/modus-wc-navbar.tsx"
           }
         },
@@ -2434,7 +2458,7 @@
           "kind": "custom-element-definition",
           "name": "modus-wc-navbar",
           "declaration": {
-            "name": "ModusWcToolbar",
+            "name": "ModusWcNavbar",
             "module": "src/components/modus-wc-navbar/modus-wc-navbar.tsx"
           }
         }


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds slots for `menu`, `notifications`, and `apps` bound to their respective buttons. Clicking the buttons toggles the slot visibility. Clicking outside of the button and slot, hides it. I have decided to always add these elements to the DOM to avoid styling shifts and/or delays when a menu is made visible.

Event emitters have been added to the trimble logo and help buttons so that the developer can handle click however they want.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tests added + added `// TODO` comments for ignored code

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #286 
