### PR TITLE
Clean up imports & fix dependency issues

### DIFF
--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -36,7 +36,7 @@ jobs:
         id: npm_pack
         working-directory: dist
         run: |
-          modus_wc_tarball=$(npm pack --pack-destination integrations/angular/ng${{ matrix.angular-version }} | tail -n 1)
+          modus_wc_tarball=$(npm pack --pack-destination ../integrations/angular/ng${{ matrix.angular-version }} | tail -n 1)
           echo "modus_wc_tarball=${modus_wc_tarball}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies for angular build

--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Pack modus-wc
         id: npm_pack
+        working-directory: dist
         run: |
           modus_wc_tarball=$(npm pack --pack-destination integrations/angular/ng${{ matrix.angular-version }} | tail -n 1)
           echo "modus_wc_tarball=${modus_wc_tarball}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -58,7 +58,7 @@ jobs:
         id: npm_pack_react
         working-directory: integrations/react/v${{ matrix.react-version }}/dist
         run: |
-          modus_wc_react_tarball=$(npm pack --pack-destination ../test-react-v${{ matrix.react-version }} | tail -n 1)
+          modus_wc_react_tarball=$(npm pack --pack-destination ../../test-react-v${{ matrix.react-version }} | tail -n 1)
           echo "modus_wc_react_tarball=${modus_wc_react_tarball}" >> $GITHUB_OUTPUT
 
       - name: Install Dependencies for Test React App

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Pack modus-webcomponents-react
         id: npm_pack_react
+        working-directory: integrations/react/v${{ matrix.react-version }}
         run: |
           modus_wc_react_tarball=$(npm pack --pack-destination integrations/react/test-react-v${{ matrix.react-version }} | tail -n 1)
           echo "modus_wc_react_tarball=${modus_wc_react_tarball}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -36,7 +36,7 @@ jobs:
         id: npm_pack
         working-directory: dist
         run: |
-          modus_wc_tarball=$(npm pack --pack-destination integrations/react/v${{ matrix.react-version }} | tail -n 1)
+          modus_wc_tarball=$(npm pack --pack-destination ../integrations/react/v${{ matrix.react-version }} | tail -n 1)
           echo "modus_wc_tarball=${modus_wc_tarball}" >> $GITHUB_OUTPUT
 
       - name: Install dependencies for react build

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -58,7 +58,7 @@ jobs:
         id: npm_pack_react
         working-directory: integrations/react/v${{ matrix.react-version }}
         run: |
-          modus_wc_react_tarball=$(npm pack --pack-destination integrations/react/test-react-v${{ matrix.react-version }} | tail -n 1)
+          modus_wc_react_tarball=$(npm pack --pack-destination ../test-react-v${{ matrix.react-version }} | tail -n 1)
           echo "modus_wc_react_tarball=${modus_wc_react_tarball}" >> $GITHUB_OUTPUT
 
       - name: Install Dependencies for Test React App

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Pack modus-webcomponents-react
         id: npm_pack_react
-        working-directory: integrations/react/v${{ matrix.react-version }}
+        working-directory: integrations/react/v${{ matrix.react-version }}/dist
         run: |
           modus_wc_react_tarball=$(npm pack --pack-destination ../test-react-v${{ matrix.react-version }} | tail -n 1)
           echo "modus_wc_react_tarball=${modus_wc_react_tarball}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Pack modus-webcomponents
         id: npm_pack
+        working-directory: dist
         run: |
           modus_wc_tarball=$(npm pack --pack-destination integrations/react/v${{ matrix.react-version }} | tail -n 1)
           echo "modus_wc_tarball=${modus_wc_tarball}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -61,6 +61,9 @@ jobs:
           modus_wc_react_tarball=$(npm pack --pack-destination ../../test-react-v${{ matrix.react-version }} | tail -n 1)
           echo "modus_wc_react_tarball=${modus_wc_react_tarball}" >> $GITHUB_OUTPUT
 
+      - name: Copy modus-webcomponents tarball to test app directory (relative resolution)
+        run: cp integrations/react/v${{ matrix.react-version }}/${{ steps.npm_pack.outputs.modus_wc_tarball }} integrations/react/test-react-v${{ matrix.react-version }}/
+
       - name: Install Dependencies for Test React App
         run: npm ci
         working-directory: integrations/react/test-react-v${{ matrix.react-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      # - uses: google/wireit@setup-github-actions-caching/v2
+      - uses: google/wireit@setup-github-actions-caching/v2
 
       - name: Install dependencies
         run: npm ci
@@ -49,6 +49,8 @@ jobs:
 
       - name: Set npm Registry Auth Token
         run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+
+      - run: cd dist
 
       - name: Pack the package
         run: npm pack

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ node_modules/
 # Build output
 dist/
 www/
-loader/
 storybook-static/
 .wireit/
 src/styles/output.css

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ www/
 storybook-static/
 .wireit/
 src/styles/output.css
+# built npm packages
+*.tgz
 
 # Stencil
 .stencil/
@@ -26,3 +28,4 @@ coverage/
 
 # Logs
 *.log
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,4 @@
 dist
-loader
 integrations
 src/**/*.d.ts
 src/custom-elements.json

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -4,7 +4,7 @@ import { themes } from '@storybook/theming';
 import type { Preview } from '@storybook/web-components';
 import { setCustomElementsManifest } from '@storybook/web-components';
 import { createElement } from 'react';
-import { defineCustomElements } from '../loader';
+import { defineCustomElements } from '../dist/loader';
 import customElements from '../src/custom-elements.json';
 import a11yConfig from './a11yConfig';
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install @trimble-oss/moduswebcomponents
 Import our styling in your main JavaScript or CSS file:
 
 ```javascript
-import '@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css';
+import '@trimble-oss/moduswebcomponents/modus-wc-styles.css';
 ```
 
 ## Basic Usage

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,8 +27,8 @@ Ensure that all changes intended for the release are merged into the branch you 
 After the workflow completes, verify that the following have been successfully published:
 
 - The `@trimble-oss/moduswebcomponents` package to the npm registry.
-- The `@trimble-cms/modus-wc-react` package to the npm registry.
-- The `@trimble-cms/modus-wc-angular` package to the npm registry.
+- The `@trimble-oss/moduswebcomponents-react` package to the npm registry.
+- The `@trimble-oss/moduswebcomponents-angular` package to the npm registry.
 - The [GitHub releases](https://github.com/trimble-oss/modus-wc-2.0/releases) for all three packages.
 
 That's it! :octocat:
@@ -54,10 +54,10 @@ The `Publish & Release` workflow will handle the following steps:
 - Publish the `@trimble-oss/moduswebcomponents` package to the npm registry.
 - Trigger the `Publish & Release - Angular` workflow to publish the React package.
   - Update the version in `integrations/angular/ng<version#>/package.json`.
-  - Build the `@trimble-cms/modus-wc-angular` package.
-  - Publish the `@trimble-cms/modus-wc-angular` package to the npm registry.
+  - Build the `@trimble-oss/moduswebcomponents-angular` package.
+  - Publish the `@trimble-oss/moduswebcomponents-angular` package to the npm registry.
 - Trigger the `Publish & Release - React` workflow to publish the React package.
   - Update the version in `integrations/react/package.json`.
-  - Build the `@trimble-cms/modus-wc-react` package.
-  - Publish the `@trimble-cms/modus-wc-react` package to the npm registry.
+  - Build the `@trimble-oss/moduswebcomponents-react` package.
+  - Publish the `@trimble-oss/moduswebcomponents-react` package to the npm registry.
 - Create GitHub releases for all three packages.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,3 +61,14 @@ The `Publish & Release` workflow will handle the following steps:
   - Build the `@trimble-oss/moduswebcomponents-react` package.
   - Publish the `@trimble-oss/moduswebcomponents-react` package to the npm registry.
 - Create GitHub releases for all three packages.
+
+
+## Notes
+
+For reference, we publish from inside of the `dist` folder in order to publish [flatly](https://davidwells.io/blog/publishing-flat-npm-packages-for-easier-import-paths-smaller-consumer-bundle-sizes).
+
+This means if you're using tools like `npm pack` or `npm publish`, you'll need to that from inside `dist` as well.
+
+This lets us make imports like `import "@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css";` not contain the `dist/` in the import path.
+
+We set the customElementsDir on the output targets to `components` to achieve this.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,7 +62,6 @@ The `Publish & Release` workflow will handle the following steps:
   - Publish the `@trimble-oss/moduswebcomponents-react` package to the npm registry.
 - Create GitHub releases for all three packages.
 
-
 ## Notes
 
 For reference, we publish from inside of the `dist` folder in order to publish [flatly](https://davidwells.io/blog/publishing-flat-npm-packages-for-easier-import-paths-smaller-consumer-bundle-sizes).

--- a/docs/adding-angular-integrations.md
+++ b/docs/adding-angular-integrations.md
@@ -158,7 +158,7 @@ npm install @trimble-oss/moduswebcomponents
 You will need to import our styling in your main JavaScript or CSS file:
 
 ```js
-import '@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css';
+import '@trimble-oss/moduswebcomponents/modus-wc-styles.css';
 ```
 
 You may need to edit the build script in the angular workspace (`ng18/`) to specifically target the `projects/trimble-oss/moduswebcomponents-angular` component library.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,7 +76,6 @@ export default [
       '.storybook/**',
       'dist/**',
       'integrations/**',
-      'loader/**',
       'node_modules/**',
       'src/components.d.ts',
       'storybook-static/**',

--- a/integrations/angular/ng17/projects/trimble-oss/moduswebcomponents-angular/README.md
+++ b/integrations/angular/ng17/projects/trimble-oss/moduswebcomponents-angular/README.md
@@ -12,7 +12,7 @@ The components in this library were programmatically generated using the [Stenci
 - You will need to import our styling in your main JavaScript or CSS file:
 
   ```js
-  import "@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css";
+  import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
   ```
 
 - Add the following snippet to your `main.ts` (or any main module)

--- a/integrations/angular/ng18/angular.json
+++ b/integrations/angular/ng18/angular.json
@@ -36,5 +36,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/integrations/angular/ng18/projects/trimble-oss/moduswebcomponents-angular/README.md
+++ b/integrations/angular/ng18/projects/trimble-oss/moduswebcomponents-angular/README.md
@@ -12,7 +12,7 @@ The components in this library were programmatically generated using the [Stenci
 - You will need to import our styling in your main JavaScript or CSS file:
 
   ```js
-  import "@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css";
+  import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
   ```
 
 - Add the following snippet to your `main.ts` (or any main module)

--- a/integrations/react/test-react-v17/README.md
+++ b/integrations/react/test-react-v17/README.md
@@ -6,7 +6,7 @@ This application has been created using create-vite (React + TypeScript + Vite) 
 
 Setting up this small react project relies on `npm link`. See the docs [here](https://docs.npmjs.com/cli/v10/commands/npm-link)
 
-From inside the `/` (root stencil) directory:
+From inside the `/dist` (root dist folder) directory:
 
 1. Run `npm install`
 2. Run `npm run build`

--- a/integrations/react/test-react-v17/README.md
+++ b/integrations/react/test-react-v17/README.md
@@ -6,11 +6,12 @@ This application has been created using create-vite (React + TypeScript + Vite) 
 
 Setting up this small react project relies on `npm link`. See the docs [here](https://docs.npmjs.com/cli/v10/commands/npm-link)
 
-From inside the `/dist` (root dist folder) directory:
+From inside the `/` (root folder) directory:
 
 1. Run `npm install`
 2. Run `npm run build`
-3. Run `npm link`
+
+Then, run `npm link` from inside the `/dist` (root dist folder) directory.
 
 From inside the `/integrations/react/v17` directory:
 

--- a/integrations/react/test-react-v17/package-lock.json
+++ b/integrations/react/test-react-v17/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "test-react-v17",
 			"version": "0.0.1",
 			"dependencies": {
-				"@trimble-oss/moduswebcomponents-react": "file:../v17",
+				"@trimble-oss/moduswebcomponents-react": "file:../v17/dist",
 				"react": "^17.0",
 				"react-dom": "^17.0"
 			},
@@ -35,6 +35,7 @@
 				"@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
 			},
 			"devDependencies": {
+				"copyfiles": "^2.4.1",
 				"rimraf": "^6.0.1",
 				"symlink-dir": "^6.0.3",
 				"typescript": "^5.6.3"
@@ -44,6 +45,7 @@
 				"react-dom": "^17.0"
 			}
 		},
+		"../v17/dist": {},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -1278,7 +1280,7 @@
 			]
 		},
 		"node_modules/@trimble-oss/moduswebcomponents-react": {
-			"resolved": "../v17",
+			"resolved": "../v17/dist",
 			"link": true
 		},
 		"node_modules/@types/babel__core": {

--- a/integrations/react/test-react-v17/package.json
+++ b/integrations/react/test-react-v17/package.json
@@ -14,8 +14,7 @@
 		"preview": "npm run build && vite preview --open"
 	},
 	"dependencies": {
-		"@trimble-oss/moduswebcomponents-react": "file:../v17",
-    "@trimble-oss/moduswebcomponents": "file:../../../dist",
+		"@trimble-oss/moduswebcomponents-react": "file:../v17/dist",
 		"react": "^17.0",
 		"react-dom": "^17.0"
 	},

--- a/integrations/react/test-react-v17/package.json
+++ b/integrations/react/test-react-v17/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"@trimble-oss/moduswebcomponents-react": "file:../v17",
+    "@trimble-oss/moduswebcomponents": "file:../../../dist",
 		"react": "^17.0",
 		"react-dom": "^17.0"
 	},

--- a/integrations/react/test-react-v17/src/App.tsx
+++ b/integrations/react/test-react-v17/src/App.tsx
@@ -2,7 +2,7 @@ import {
 	ModusWcThemeProvider,
 	ModusWcThemeSwitcher,
 } from "@trimble-oss/moduswebcomponents-react";
-import "@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css";
+import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
 import * as ModusReactExamples from "./examples";
 import "./App.css";
 

--- a/integrations/react/test-react-v17/src/App.tsx
+++ b/integrations/react/test-react-v17/src/App.tsx
@@ -2,7 +2,7 @@ import {
 	ModusWcThemeProvider,
 	ModusWcThemeSwitcher,
 } from "@trimble-oss/moduswebcomponents-react";
-import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
+import "@trimble-oss/moduswebcomponents-react/modus-wc-styles.css";
 import * as ModusReactExamples from "./examples";
 import "./App.css";
 

--- a/integrations/react/test-react-v18/README.md
+++ b/integrations/react/test-react-v18/README.md
@@ -6,11 +6,12 @@ This application has been created using create-vite (React + TypeScript + Vite) 
 
 Setting up this small react project relies on `npm link`. See the docs [here](https://docs.npmjs.com/cli/v10/commands/npm-link)
 
-From inside the `/dist` (root dist folder) directory:
+From inside the `/` (root folder) directory:
 
 1. Run `npm install`
 2. Run `npm run build`
-3. Run `npm link`
+
+Then, run `npm link` from inside the `/dist` (root dist folder) directory.
 
 From inside the `/integrations/react/v18` directory:
 

--- a/integrations/react/test-react-v18/README.md
+++ b/integrations/react/test-react-v18/README.md
@@ -6,7 +6,7 @@ This application has been created using create-vite (React + TypeScript + Vite) 
 
 Setting up this small react project relies on `npm link`. See the docs [here](https://docs.npmjs.com/cli/v10/commands/npm-link)
 
-From inside the `/` (root stencil) directory:
+From inside the `/dist` (root dist folder) directory:
 
 1. Run `npm install`
 2. Run `npm run build`

--- a/integrations/react/test-react-v18/package-lock.json
+++ b/integrations/react/test-react-v18/package-lock.json
@@ -8,8 +8,7 @@
 			"name": "test-react-v18",
 			"version": "0.0.1",
 			"dependencies": {
-				"@trimble-oss/moduswebcomponents": "file:../../../dist",
-				"@trimble-oss/moduswebcomponents-react": "file:../v18",
+				"@trimble-oss/moduswebcomponents-react": "file:../v18/dist",
 				"react": "^18.3",
 				"react-dom": "^18.3"
 			},
@@ -30,6 +29,7 @@
 		"../../../dist": {
 			"name": "@trimble-oss/moduswebcomponents",
 			"version": "0.0.0-alpha.1",
+			"extraneous": true,
 			"license": "MIT",
 			"devDependencies": {
 				"@eslint/js": "^9.11.1",
@@ -90,6 +90,26 @@
 				"@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
 			},
 			"devDependencies": {
+				"copyfiles": "^2.4.1",
+				"rimraf": "^6.0.1",
+				"symlink-dir": "^6.0.3",
+				"typescript": "^5.6.3"
+			},
+			"peerDependencies": {
+				"react": "^18.3",
+				"react-dom": "^18.3"
+			}
+		},
+		"../v18/dist": {
+			"name": "@trimble-oss/moduswebcomponents-react",
+			"version": "0.0.1-react18",
+			"license": "MIT",
+			"dependencies": {
+				"@stencil/react-output-target": "^0.7.4",
+				"@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
+			},
+			"devDependencies": {
+				"copyfiles": "^2.4.1",
 				"rimraf": "^6.0.1",
 				"symlink-dir": "^6.0.3",
 				"typescript": "^5.6.3"
@@ -1332,12 +1352,8 @@
 				"win32"
 			]
 		},
-		"node_modules/@trimble-oss/moduswebcomponents": {
-			"resolved": "../../../dist",
-			"link": true
-		},
 		"node_modules/@trimble-oss/moduswebcomponents-react": {
-			"resolved": "../v18",
+			"resolved": "../v18/dist",
 			"link": true
 		},
 		"node_modules/@types/babel__core": {

--- a/integrations/react/test-react-v18/package-lock.json
+++ b/integrations/react/test-react-v18/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "test-react-v18",
 			"version": "0.0.1",
 			"dependencies": {
+				"@trimble-oss/moduswebcomponents": "file:../../../dist",
 				"@trimble-oss/moduswebcomponents-react": "file:../v18",
 				"react": "^18.3",
 				"react-dom": "^18.3"
@@ -24,6 +25,60 @@
 				"typescript": "~5.6.3",
 				"typescript-eslint": "^8.15",
 				"vite": "^5.4"
+			}
+		},
+		"../../../dist": {
+			"name": "@trimble-oss/moduswebcomponents",
+			"version": "0.0.0-alpha.1",
+			"license": "MIT",
+			"devDependencies": {
+				"@eslint/js": "^9.11.1",
+				"@stencil/angular-output-target": "^0.9.1",
+				"@stencil/core": "^4.22.0",
+				"@stencil/react-output-target": "^0.7.4",
+				"@stencil/sass": "^3.0.12",
+				"@stencil/store": "^2.1.2",
+				"@storybook/addon-a11y": "^8.6.12",
+				"@storybook/addon-essentials": "^8.6.12",
+				"@storybook/addon-links": "^8.6.12",
+				"@storybook/addon-themes": "^8.6.12",
+				"@storybook/blocks": "^8.6.12",
+				"@storybook/test": "^8.6.12",
+				"@storybook/web-components": "^8.6.12",
+				"@storybook/web-components-vite": "^8.6.12",
+				"@tailwindcss/typography": "^0.5.15",
+				"@types/jest": "^29.5.13",
+				"@typescript-eslint/eslint-plugin": "^8.13.0",
+				"@typescript-eslint/parser": "^8.13.0",
+				"concurrently": "^9.0.1",
+				"daisyui": "^4.12.13",
+				"eslint": "^9.11.1",
+				"eslint-config-prettier": "^9.1.0",
+				"eslint-import-resolver-typescript": "^3.7.0",
+				"eslint-plugin-import": "^2.31.0",
+				"eslint-plugin-jsx-a11y": "^6.10.0",
+				"eslint-plugin-prettier": "^5.2.1",
+				"globals": "^15.10.0",
+				"jest": "^29.7.0",
+				"jest-cli": "^29.7.0",
+				"marked": "^15.0.8",
+				"prettier": "3.5.3",
+				"puppeteer": "^23.5.3",
+				"stencil-tailwind-plugin": "^1.8.0",
+				"stylelint": "16.18.0",
+				"stylelint-config-standard-scss": "14.0.0",
+				"stylelint-order": "6.0.4",
+				"tailwindcss": "^3.4.14",
+				"ts-loader": "^9.5.1",
+				"typescript": "^5.6.2",
+				"wireit": "^0.14.12"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@rollup/rollup-linux-x64-gnu": "4.9.5",
+				"@trimble-oss/custom-elements-manifest-analyzer": "^0.0.4"
 			}
 		},
 		"../v18": {
@@ -1276,6 +1331,10 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@trimble-oss/moduswebcomponents": {
+			"resolved": "../../../dist",
+			"link": true
 		},
 		"node_modules/@trimble-oss/moduswebcomponents-react": {
 			"resolved": "../v18",

--- a/integrations/react/test-react-v18/package.json
+++ b/integrations/react/test-react-v18/package.json
@@ -14,8 +14,7 @@
 		"preview": "npm run build && vite preview --open"
 	},
 	"dependencies": {
-		"@trimble-oss/moduswebcomponents-react": "file:../v18",
-    "@trimble-oss/moduswebcomponents": "file:../../../dist",
+		"@trimble-oss/moduswebcomponents-react": "file:../v18/dist",
 		"react": "^18.3",
 		"react-dom": "^18.3"
 	},

--- a/integrations/react/test-react-v18/package.json
+++ b/integrations/react/test-react-v18/package.json
@@ -15,6 +15,7 @@
 	},
 	"dependencies": {
 		"@trimble-oss/moduswebcomponents-react": "file:../v18",
+    "@trimble-oss/moduswebcomponents": "file:../../../dist",
 		"react": "^18.3",
 		"react-dom": "^18.3"
 	},

--- a/integrations/react/test-react-v18/src/App.tsx
+++ b/integrations/react/test-react-v18/src/App.tsx
@@ -2,7 +2,7 @@ import {
 	ModusWcThemeProvider,
 	ModusWcThemeSwitcher,
 } from "@trimble-oss/moduswebcomponents-react";
-import "@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css";
+import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
 import * as ModusReactExamples from "./examples";
 import "./App.css";
 

--- a/integrations/react/test-react-v18/src/App.tsx
+++ b/integrations/react/test-react-v18/src/App.tsx
@@ -2,7 +2,7 @@ import {
 	ModusWcThemeProvider,
 	ModusWcThemeSwitcher,
 } from "@trimble-oss/moduswebcomponents-react";
-import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
+import "@trimble-oss/moduswebcomponents-react/modus-wc-styles.css";
 import * as ModusReactExamples from "./examples";
 import "./App.css";
 

--- a/integrations/react/test-react-v19/README.md
+++ b/integrations/react/test-react-v19/README.md
@@ -6,7 +6,7 @@ This application has been created using create-vite (React + TypeScript + Vite) 
 
 Setting up this small react project relies on `npm link`. See the docs [here](https://docs.npmjs.com/cli/v11/commands/npm-link)
 
-From inside the `/` (root stencil) directory:
+From inside the `/dist` (root dist folder) directory:
 
 1. Run `npm install`
 2. Run `npm run build`

--- a/integrations/react/test-react-v19/README.md
+++ b/integrations/react/test-react-v19/README.md
@@ -6,11 +6,12 @@ This application has been created using create-vite (React + TypeScript + Vite) 
 
 Setting up this small react project relies on `npm link`. See the docs [here](https://docs.npmjs.com/cli/v11/commands/npm-link)
 
-From inside the `/dist` (root dist folder) directory:
+From inside the `/` (root folder) directory:
 
 1. Run `npm install`
 2. Run `npm run build`
-3. Run `npm link`
+
+Then, run `npm link` from inside the `/dist` (root dist folder) directory.
 
 From inside the `/integrations/react/v19` directory:
 

--- a/integrations/react/test-react-v19/package-lock.json
+++ b/integrations/react/test-react-v19/package-lock.json
@@ -8,7 +8,7 @@
       "name": "test-react-v19",
       "version": "0.0.1",
       "dependencies": {
-        "@trimble-oss/moduswebcomponents-react": "file:../v19",
+        "@trimble-oss/moduswebcomponents-react": "file:../v19/dist",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -54,15 +54,17 @@
         "@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
       },
       "devDependencies": {
+        "copyfiles": "^2.4.1",
         "rimraf": "^6.0.1",
         "symlink-dir": "^6.0.3",
         "typescript": "^5.6.3"
       },
       "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "^19.0",
+        "react-dom": "^19.0"
       }
     },
+    "../v19/dist": {},
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -1297,7 +1299,7 @@
       ]
     },
     "node_modules/@trimble-oss/moduswebcomponents-react": {
-      "resolved": "../v19",
+      "resolved": "../v19/dist",
       "link": true
     },
     "node_modules/@types/babel__core": {

--- a/integrations/react/test-react-v19/package.json
+++ b/integrations/react/test-react-v19/package.json
@@ -14,8 +14,7 @@
     "preview": "npm run build && vite preview --open"
   },
   "dependencies": {
-    "@trimble-oss/moduswebcomponents-react": "file:../v19",
-    "@trimble-oss/moduswebcomponents": "file:../../../dist",
+    "@trimble-oss/moduswebcomponents-react": "file:../v19/dist",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/integrations/react/test-react-v19/package.json
+++ b/integrations/react/test-react-v19/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@trimble-oss/moduswebcomponents-react": "file:../v19",
+    "@trimble-oss/moduswebcomponents": "file:../../../dist",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/integrations/react/test-react-v19/src/App.tsx
+++ b/integrations/react/test-react-v19/src/App.tsx
@@ -2,6 +2,7 @@ import {
 	ModusWcThemeProvider,
 	ModusWcThemeSwitcher,
 } from "@trimble-oss/moduswebcomponents-react";
+import "@trimble-oss/moduswebcomponents-react/modus-wc-styles.css";
 import * as ModusReactExamples from "./examples";
 import "./App.css";
 

--- a/integrations/react/v17/README.md
+++ b/integrations/react/v17/README.md
@@ -16,7 +16,7 @@ npm install @trimble-oss/moduswebcomponents-react@1.0.0-react17
 Import our styling in your main JavaScript or CSS file:
 
 ```javascript
-import "@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css";
+import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
 ```
 
 ## Example Usage

--- a/integrations/react/v17/package-lock.json
+++ b/integrations/react/v17/package-lock.json
@@ -13,6 +13,7 @@
         "@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
       },
       "devDependencies": {
+        "copyfiles": "^2.4.1",
         "rimraf": "^6.0.1",
         "symlink-dir": "^6.0.3",
         "typescript": "^5.6.3"
@@ -430,6 +431,97 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -481,6 +573,99 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/copyfiles/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/copyfiles/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/copyfiles/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/copyfiles/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -619,6 +804,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -696,6 +891,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -708,6 +910,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -850,6 +1062,25 @@
         "node": ">= 4"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
@@ -918,6 +1149,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1052,6 +1290,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1072,6 +1321,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1084,6 +1343,16 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -1133,6 +1402,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1189,6 +1465,19 @@
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1229,6 +1518,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reusify": {
@@ -1283,6 +1582,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.20.2",
@@ -1353,6 +1659,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -1499,6 +1812,50 @@
         "node": ">=18.12"
       }
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1554,6 +1911,23 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1657,6 +2031,107 @@
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",

--- a/integrations/react/v17/package.json
+++ b/integrations/react/v17/package.json
@@ -9,6 +9,7 @@
     "@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
   },
   "devDependencies": {
+    "copyfiles": "^2.4.1",
     "rimraf": "^6.0.1",
     "symlink-dir": "^6.0.3",
     "typescript": "^5.6.3"
@@ -17,18 +18,20 @@
     "react": "^17.0",
     "react-dom": "^17.0"
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "index.js",
+  "module": "index.js",
+  "types": "types/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "prebuild": "npm run symlink",
-    "build": "npm run clean && npm run tsc",
+    "build": "npm run clean && npm run tsc && npm run copy-css && npm run copy-meta",
     "clean": "rimraf dist",
     "tsc": "tsc -p . --outDir ./dist",
-    "symlink": "symlink-dir ../stencil-generated/ src/stencil-generated/"
+    "symlink": "symlink-dir ../stencil-generated/ src/stencil-generated/",
+    "copy-css": "copyfiles -f node_modules/@trimble-oss/moduswebcomponents/modus-wc-styles.css dist",
+    "copy-meta": "copyfiles -f README.md package.json dist"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/integrations/react/v17/package.json
+++ b/integrations/react/v17/package.json
@@ -21,9 +21,6 @@
   "main": "index.js",
   "module": "index.js",
   "types": "types/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "prebuild": "npm run symlink",
     "build": "npm run clean && npm run tsc && npm run copy-css && npm run copy-meta",

--- a/integrations/react/v18/README.md
+++ b/integrations/react/v18/README.md
@@ -16,7 +16,7 @@ npm install @trimble-oss/moduswebcomponents-react@1.0.0-react18
 Import our styling in your main JavaScript or CSS file:
 
 ```javascript
-import "@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css";
+import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
 ```
 
 ## Example Usage

--- a/integrations/react/v18/package-lock.json
+++ b/integrations/react/v18/package-lock.json
@@ -13,6 +13,7 @@
         "@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
       },
       "devDependencies": {
+        "copyfiles": "^2.4.1",
         "rimraf": "^6.0.1",
         "symlink-dir": "^6.0.3",
         "typescript": "^5.6.3"
@@ -387,6 +388,97 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -438,6 +530,99 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/copyfiles/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/copyfiles/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/copyfiles/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/copyfiles/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -576,6 +761,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -653,6 +848,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -665,6 +867,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -807,6 +1019,25 @@
         "node": ">= 4"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
@@ -875,6 +1106,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1009,6 +1247,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1017,6 +1266,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -1031,6 +1290,16 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -1080,6 +1349,13 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -1133,6 +1409,19 @@
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1173,6 +1462,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reusify": {
@@ -1227,6 +1526,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -1295,6 +1601,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -1441,6 +1754,50 @@
         "node": ">=18.12"
       }
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1496,6 +1853,23 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1599,6 +1973,107 @@
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",

--- a/integrations/react/v18/package.json
+++ b/integrations/react/v18/package.json
@@ -21,9 +21,6 @@
   "main": "index.js",
   "module": "index.js",
   "types": "types/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "prebuild": "npm run symlink",
     "build": "npm run clean && npm run tsc && npm run copy-css && npm run copy-meta",

--- a/integrations/react/v18/package.json
+++ b/integrations/react/v18/package.json
@@ -9,6 +9,7 @@
     "@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
   },
   "devDependencies": {
+    "copyfiles": "^2.4.1",
     "rimraf": "^6.0.1",
     "symlink-dir": "^6.0.3",
     "typescript": "^5.6.3"
@@ -17,18 +18,20 @@
     "react": "^18.3",
     "react-dom": "^18.3"
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "index.js",
+  "module": "index.js",
+  "types": "types/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "prebuild": "npm run symlink",
-    "build": "npm run clean && npm run tsc",
+    "build": "npm run clean && npm run tsc && npm run copy-css && npm run copy-meta",
     "clean": "rimraf dist",
     "tsc": "tsc -p . --outDir ./dist",
-    "symlink": "symlink-dir ../stencil-generated/ src/stencil-generated/"
+    "symlink": "symlink-dir ../stencil-generated/ src/stencil-generated/",
+    "copy-css": "copyfiles -f node_modules/@trimble-oss/moduswebcomponents/modus-wc-styles.css dist",
+    "copy-meta": "copyfiles -f README.md package.json dist"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/integrations/react/v19/README.md
+++ b/integrations/react/v19/README.md
@@ -13,9 +13,15 @@ npm install @trimble-oss/moduswebcomponents-react@<latest-version>-react<target-
 npm install @trimble-oss/moduswebcomponents-react@1.0.0-react19
 ```
 
+Import our styling in your main JavaScript or CSS file:
+
+```javascript
+import "@trimble-oss/moduswebcomponents/modus-wc-styles.css";
+```
+
 ## Example Usage
 
-No extra setup is required to use the Modus React Components. You can use the components as you would any other React component.
+You can use the components as you would any other React component.
 
 - Use a Modus Button in your `App.tsx`
 

--- a/integrations/react/v19/package-lock.json
+++ b/integrations/react/v19/package-lock.json
@@ -13,13 +13,14 @@
         "@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
       },
       "devDependencies": {
+        "copyfiles": "^2.4.1",
         "rimraf": "^6.0.1",
         "symlink-dir": "^6.0.3",
         "typescript": "^5.6.3"
       },
       "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react": "^19.0",
+        "react-dom": "^19.0"
       }
     },
     "node_modules/@custom-elements-manifest/find-dependencies": {
@@ -422,6 +423,97 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -473,6 +565,99 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/copyfiles/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/copyfiles/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/copyfiles/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/copyfiles/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -623,6 +808,16 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -700,6 +895,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -712,6 +914,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob": {
@@ -854,6 +1066,25 @@
         "node": ">= 4"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
@@ -922,6 +1153,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1056,6 +1294,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -1064,6 +1313,16 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -1078,6 +1337,16 @@
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -1128,6 +1397,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1177,6 +1453,19 @@
       "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1217,6 +1506,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reusify": {
@@ -1271,6 +1570,13 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -1337,6 +1643,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -1483,6 +1796,50 @@
         "node": ">=18.12"
       }
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1538,6 +1895,23 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1641,6 +2015,107 @@
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",

--- a/integrations/react/v19/package.json
+++ b/integrations/react/v19/package.json
@@ -9,26 +9,29 @@
     "@trimble-oss/moduswebcomponents": "0.0.0-alpha.1"
   },
   "devDependencies": {
+    "copyfiles": "^2.4.1",
     "rimraf": "^6.0.1",
     "symlink-dir": "^6.0.3",
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.0",
+    "react-dom": "^19.0"
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/types/index.d.ts",
+  "main": "index.js",
+  "module": "index.js",
+  "types": "types/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "prebuild": "npm run symlink",
-    "build": "npm run clean && npm run tsc",
+    "build": "npm run clean && npm run tsc && npm run copy-css && npm run copy-meta",
     "clean": "rimraf dist",
     "tsc": "tsc -p . --outDir ./dist",
-    "symlink": "symlink-dir ../stencil-generated/ src/stencil-generated/"
+    "symlink": "symlink-dir ../stencil-generated/ src/stencil-generated/",
+    "copy-css": "copyfiles -f node_modules/@trimble-oss/moduswebcomponents/modus-wc-styles.css dist",
+    "copy-meta": "copyfiles -f README.md package.json dist"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/integrations/react/v19/package.json
+++ b/integrations/react/v19/package.json
@@ -21,9 +21,6 @@
   "main": "index.js",
   "module": "index.js",
   "types": "types/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "prebuild": "npm run symlink",
     "build": "npm run clean && npm run tsc && npm run copy-css && npm run copy-meta",

--- a/package.json
+++ b/package.json
@@ -34,24 +34,19 @@
     "url": "git+https://github.com/trimble-oss/modus-wc-2.0.git"
   },
   "type": "module",
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
-  "es2017": "dist/esm/index.js",
-  "esnext": "dist/esm/index.js",
-  "collection": "dist/collection/collection-manifest.json",
-  "collection:main": "dist/collection/index.js",
-  "unpkg": "dist/modus-wc/modus-wc.esm.js",
-  "jsdelivr": "dist/modus-wc/modus-wc.js",
-  "types": "dist/types/components.d.ts",
-  "modus-wc-styles.css": "dist/modus-wc-styles.css",
-  "files": [
-    "dist/",
-    "loader/"
-  ],
+  "main": "index.cjs.js",
+  "module": "index.js",
+  "es2017": "esm/index.js",
+  "esnext": "esm/index.js",
+  "collection": "collection/collection-manifest.json",
+  "collection:main": "collection/index.js",
+  "unpkg": "modus-wc/modus-wc.esm.js",
+  "jsdelivr": "modus-wc/modus-wc.js",
+  "types": "types/components.d.ts",
   "scripts": {
     "build": "wireit",
     "build:ci": "wireit",
-    "clean": "npx rimraf .wireit .stencil .storybook-static dist loader",
+    "clean": "npx rimraf .wireit .stencil .storybook-static dist",
     "lint": "wireit",
     "lint:eslint": "wireit",
     "lint:prettier": "wireit",
@@ -212,7 +207,6 @@
       "output": [
         "src/components.d.ts",
         "dist/**",
-        "loader/**",
         "integrations/react/stencil-generated/**",
         "integrations/angular/ng18/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/**",
         "integrations/angular/ng17/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/**",
@@ -249,7 +243,6 @@
         "src/",
         ".storybook",
         "dist/",
-        "loader/",
         "stencil.config.ts"
       ],
       "output": [

--- a/src/stories/frameworks/angular.mdx
+++ b/src/stories/frameworks/angular.mdx
@@ -36,7 +36,7 @@ npm install @trimble-oss/moduswebcomponents @trimble-oss/moduswebcomponents-angu
 You will need to import our styling in your main JavaScript or CSS file:
 
 ```js
-import '@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css';
+import '@trimble-oss/moduswebcomponents/modus-wc-styles.css';
 ```
 
 ### 3. Import Modus Angular Web Components library into your Angular app's module:
@@ -83,7 +83,7 @@ npm install @trimble-oss/moduswebcomponents @trimble-oss/moduswebcomponents-angu
 You will need to import our styling in your main JavaScript or CSS file:
 
 ```js
-import '@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css';
+import '@trimble-oss/moduswebcomponents/modus-wc-styles.css';
 ```
 
 ### 3. Import your component library into your component.

--- a/src/stories/frameworks/react.mdx
+++ b/src/stories/frameworks/react.mdx
@@ -38,7 +38,7 @@ npm install @trimble-oss/moduswebcomponents-react@1.0.0-react18
 You will need to import our styling in your main JavaScript or CSS file:
 
 ```js
-import '@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css';
+import '@trimble-oss/moduswebcomponents/modus-wc-styles.css';
 ```
 
 ### 3. Use the component library as normal.

--- a/src/stories/getting-started.mdx
+++ b/src/stories/getting-started.mdx
@@ -22,7 +22,7 @@ npm install @trimble-oss/moduswebcomponents
 You will need to import our styling in your main JavaScript or CSS file:
 
 ```js
-import '@trimble-oss/moduswebcomponents/dist/modus-wc-styles.css';
+import '@trimble-oss/moduswebcomponents/modus-wc-styles.css';
 ```
 
 ### 2. Set the theme:

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -25,6 +25,7 @@ export const config: Config = {
   outputTargets: [
     {
       // Required for the Angular integration
+      // Could potentially switch https://stenciljs.com/docs/angular#do-i-have-to-use-the-dist-output-target
       type: 'dist',
       esmLoaderPath: '../dist/loader',
     },
@@ -49,6 +50,7 @@ export const config: Config = {
     },
     angularOutputTarget({
       componentCorePackage: '@trimble-oss/moduswebcomponents',
+      customElementsDir: 'components',
       outputType: 'component',
       directivesProxyFile:
         './integrations/angular/ng17/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/components.ts',
@@ -58,6 +60,7 @@ export const config: Config = {
     }),
     angularOutputTarget({
       componentCorePackage: '@trimble-oss/moduswebcomponents',
+      customElementsDir: 'components',
       outputType: 'component',
       directivesProxyFile:
         './integrations/angular/ng18/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/components.ts',
@@ -67,6 +70,7 @@ export const config: Config = {
     }),
     angularOutputTarget({
       componentCorePackage: '@trimble-oss/moduswebcomponents',
+      customElementsDir: 'components',
       outputType: 'component',
       directivesProxyFile:
         './integrations/angular/ng19/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/components.ts',
@@ -75,6 +79,7 @@ export const config: Config = {
       valueAccessorConfigs: angularValueAccessorBindings,
     }),
     reactOutputTarget({
+      customElementsDir: 'components',
       outDir: './integrations/react/stencil-generated',
     }),
   ],

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -21,11 +21,12 @@ setPluginConfigurationDefaults(tailwindOpts);
 export const config: Config = {
   namespace: 'modus-wc',
   sourceMap: false,
+  validatePrimaryPackageOutputTarget: true,
   outputTargets: [
     {
       // Required for the Angular integration
       type: 'dist',
-      esmLoaderPath: '../loader',
+      esmLoaderPath: '../dist/loader',
     },
     {
       // Required for the React integration
@@ -35,7 +36,13 @@ export const config: Config = {
       // > This gives build tools the best chance to deduplicate code, remove dead code, and so on.
       // minify: true,
       isPrimaryPackageOutputTarget: true,
-      copy: [{ src: './styles/output.css', dest: 'dist/modus-wc-styles.css' }],
+      copy: [
+        // This is scoped to /src
+        { src: './styles/output.css', dest: 'dist/modus-wc-styles.css' },
+        { src: '../README.md', dest: 'dist/README.md' },
+        { src: '../LICENSE', dest: 'dist/LICENSE' },
+        { src: '../package.json', dest: 'dist/package.json' },
+      ],
     },
     {
       type: 'docs-readme',


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

* We now publish from inside the `/dist` folder
  * This causes there to no longer be a `/dist/` in the import structure of files like `modus-wc-styles.css`
  * We also do this for `moduswebcomponents-react` for the same reason.
* We now copy the `modus-wc-styles.css` into `moduswebcomponents-react`
  * This preserves the behavior of only having to have `@trimble-oss/moduswebcomponents-react` installed, otherwise you'd've had to have the base package as a devdependency to grab the CSS file. This was an undetected bug with #372 due to faulty CI.
  * This causes a 104kb inflation of the file (since the same file will be in the moduswebcomponents transitive dependency), resulting in a total library size (of moduswebcomponents-react) to be 180kb/24kb gzipped. I think this price is worth avoiding JS loaders and making it easy on users, but perhaps people have other opinions.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tested with our test react project and stuart's test angular project. The whole process of packaging, publishing, installing was tested.

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

AB#606813
