### PR TITLE
fix publishing workflows

### DIFF
--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -52,19 +52,30 @@ jobs:
         run: npm ci
         working-directory: .
 
-      - name: Build Web Components
+      - name: Build Base Web Components
         run: npm run build:ci
         working-directory: .
+
+      - name: Pack Base Web Components
+        working-directory: ./dist
+        run: |
+          TARBALL=$(npm pack)
+          echo "TARBALL=${TARBALL}" >> $GITHUB_ENV
 
       - name: Update to use new WebComponent version
         run: |
           jq --arg version "${{ github.event.inputs.version }}" \
           '.dependencies["@trimble-oss/moduswebcomponents"] = $version' package.json > package.json.tmp && \
-          mv package.json.tmp package.json && npm i && \
+          mv package.json.tmp package.json && \
           cd projects/trimble-oss/moduswebcomponents-angular && \
           jq --arg version "${{ github.event.inputs.version }}" \
           '.peerDependencies["@trimble-oss/moduswebcomponents"] = $version' package.json > package.json.tmp && \
           mv package.json.tmp package.json
+
+      - run: npm i
+
+      - name: Install local WebComponent dependency (for build)
+        run: npm install file:../../../dist/${TARBALL} --no-save
 
       - name: Update package.json version
         run: |

--- a/.github/workflows/publish-react.yml
+++ b/.github/workflows/publish-react.yml
@@ -54,15 +54,26 @@ jobs:
             package-lock.json
             integrations/react/v${{ matrix.react-version }}/package-lock.json
 
-      - name: Build Web Components
+      - name: Build Base Web Components
         run: npm run build:ci
         working-directory: .
+
+      - name: Pack Base Web Components
+        working-directory: ./dist
+        run: |
+          TARBALL=$(npm pack)
+          echo "TARBALL=${TARBALL}" >> $GITHUB_ENV
 
       - name: Update to use new WebComponent version
         run: |
           jq --arg version "${{ github.event.inputs.version }}" \
           '.dependencies["@trimble-oss/moduswebcomponents"] = $version' package.json > package.json.tmp && \
-          mv package.json.tmp package.json && npm i
+          mv package.json.tmp package.json
+
+      - run: npm i
+
+      - name: Install local WebComponent dependency (for build)
+        run: npm install file:../../../dist/${TARBALL} --no-save
 
       - name: Update package.json version
         run: |
@@ -72,6 +83,8 @@ jobs:
 
       - name: Build distribution
         run: npm run build
+
+      - run: cd dist
 
       - name: Package distribution
         run: npm pack


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Essentially, previously the integration publish workflows were pulling down the version from npm in order to do the build linking (no affect on the output code, really, just devDependency equivalent). However, this is an issue when there's a large incompatible change.

Now, the various integration workflows use the built version of the base library in order to then build their own library.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Works https://github.com/trimble-oss/modus-wc-2.0/actions/runs/14803679414

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

AB#606813
