### PR TITLE
Pagination: Add button text 

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -881,9 +881,17 @@ export namespace Components {
          */
         "customClass"?: string;
         /**
+          * Text for the next button
+         */
+        "nextButtonText"?: string;
+        /**
           * The current page number
          */
         "page": number;
+        /**
+          * Text for the previous button
+         */
+        "prevButtonText"?: string;
         /**
           * Size of the pagination buttons
          */
@@ -3503,6 +3511,10 @@ declare namespace LocalJSX {
          */
         "customClass"?: string;
         /**
+          * Text for the next button
+         */
+        "nextButtonText"?: string;
+        /**
           * Event emitted when page changes
          */
         "onPageChange"?: (event: ModusWcPaginationCustomEvent<IPageChange>) => void;
@@ -3510,6 +3522,10 @@ declare namespace LocalJSX {
           * The current page number
          */
         "page"?: number;
+        /**
+          * Text for the previous button
+         */
+        "prevButtonText"?: string;
         /**
           * Size of the pagination buttons
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -881,7 +881,7 @@ export namespace Components {
          */
         "customClass"?: string;
         /**
-          * Text for the next button
+          * The next page button text. If not set, an icon control will be used.
          */
         "nextButtonText"?: string;
         /**
@@ -889,7 +889,7 @@ export namespace Components {
          */
         "page": number;
         /**
-          * Text for the previous button
+          * The previous page button text. If not set, an icon control will be used.
          */
         "prevButtonText"?: string;
         /**
@@ -3511,7 +3511,7 @@ declare namespace LocalJSX {
          */
         "customClass"?: string;
         /**
-          * Text for the next button
+          * The next page button text. If not set, an icon control will be used.
          */
         "nextButtonText"?: string;
         /**
@@ -3523,7 +3523,7 @@ declare namespace LocalJSX {
          */
         "page"?: number;
         /**
-          * Text for the previous button
+          * The previous page button text. If not set, an icon control will be used.
          */
         "prevButtonText"?: string;
         /**

--- a/src/components/modus-wc-pagination/modus-wc-pagination.scss
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.scss
@@ -35,7 +35,7 @@ modus-wc-pagination .modus-wc-pagination {
   }
 
   .modus-wc-pagination-button-text {
-    padding: 0 var(--modus-wc-spacing-xs) !important;
+    padding: calc(var(--modus-wc-spacing-sm) - 2px) !important;
     width: auto !important;
   }
 

--- a/src/components/modus-wc-pagination/modus-wc-pagination.scss
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.scss
@@ -34,6 +34,11 @@ modus-wc-pagination .modus-wc-pagination {
     }
   }
 
+  .modus-wc-pagination-button-text {
+    padding: 0 var(--modus-wc-spacing-xs) !important;
+    width: auto !important;
+  }
+
   .modus-wc-pagination-btn:not(:disabled) {
     background-color: var(--modus-wc-color-base-100);
     color: var(--modus-wc-color-base-content);

--- a/src/components/modus-wc-pagination/modus-wc-pagination.scss
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.scss
@@ -35,7 +35,7 @@ modus-wc-pagination .modus-wc-pagination {
   }
 
   .modus-wc-pagination-button-text {
-    padding: calc(var(--modus-wc-spacing-sm) - 2px) !important;
+    padding: calc(var(--modus-wc-spacing-sm) - 2px);
     width: auto !important;
   }
 

--- a/src/components/modus-wc-pagination/modus-wc-pagination.spec.ts
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.spec.ts
@@ -405,4 +405,48 @@ describe('modus-wc-pagination', () => {
     expect(lastPageButton).not.toBeNull();
     expect(pageThreeButton!.getAttribute('aria-label')).toBe('Page 3');
   });
+
+  it('should apply custom text for the previous page button', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcPagination],
+      html: `<modus-wc-pagination aria-label="pagination test" count="10" page="3"></modus-wc-pagination>`,
+    });
+
+    // Get the component instance and set custom text for the previous button
+    // eslint-disable-next-line no-undef
+    const pagination = page.root as HTMLModusWcPaginationElement;
+
+    pagination.prevButtonText = 'Go Back';
+    await page.waitForChanges();
+
+    // Check that the custom text is applied to the previous button
+    const previousPageButton = page.root!.querySelector(
+      'button[aria-label="Previous page"]'
+    );
+
+    expect(previousPageButton).not.toBeNull();
+    expect(previousPageButton!.textContent?.trim()).toBe('Go Back');
+  });
+
+  it('should apply custom text for the next page button', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcPagination],
+      html: `<modus-wc-pagination aria-label="pagination test" count="10" page="3"></modus-wc-pagination>`,
+    });
+
+    // Get the component instance and set custom text for the next button
+    // eslint-disable-next-line no-undef
+    const pagination = page.root as HTMLModusWcPaginationElement;
+
+    pagination.nextButtonText = 'Go Forward';
+    await page.waitForChanges();
+
+    // Check that the custom text is applied to the next button
+    const nextPageButton = page.root!.querySelector(
+      'button[aria-label="Next page"]'
+    );
+
+    expect(nextPageButton).not.toBeNull();
+    expect(nextPageButton!.textContent?.trim()).toBe('Go Forward');
+  });
 });

--- a/src/components/modus-wc-pagination/modus-wc-pagination.spec.ts
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.spec.ts
@@ -419,9 +419,10 @@ describe('modus-wc-pagination', () => {
     pagination.prevButtonText = 'Go Back';
     await page.waitForChanges();
 
-    // Check that the custom text is applied to the previous button
-    const previousPageButton = page.root!.querySelector(
-      'button[aria-label="Previous page"]'
+    // Find all buttons and locate the one with the matching text
+    const buttons = page.root!.querySelectorAll('button');
+    const previousPageButton = Array.from(buttons).find(
+      (btn) => btn.textContent?.trim() === 'Go Back'
     );
 
     expect(previousPageButton).not.toBeNull();
@@ -441,9 +442,10 @@ describe('modus-wc-pagination', () => {
     pagination.nextButtonText = 'Go Forward';
     await page.waitForChanges();
 
-    // Check that the custom text is applied to the next button
-    const nextPageButton = page.root!.querySelector(
-      'button[aria-label="Next page"]'
+    // Find all buttons and locate the one with the matching text
+    const buttons = page.root!.querySelectorAll('button');
+    const nextPageButton = Array.from(buttons).find(
+      (btn) => btn.textContent?.trim() === 'Go Forward'
     );
 
     expect(nextPageButton).not.toBeNull();

--- a/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
@@ -16,10 +16,10 @@ interface PaginationArgs {
   'aria-label-values'?: IAriaLabelValues;
   count: number;
   'custom-class'?: string;
-  page: number;
-  size?: 'sm' | 'md' | 'lg';
-  'prev-button-text'?: string;
   'next-button-text'?: string;
+  page: number;
+  'prev-button-text'?: string;
+  size?: 'sm' | 'md' | 'lg';
 }
 
 const meta: Meta<PaginationArgs> = {
@@ -31,8 +31,6 @@ const meta: Meta<PaginationArgs> = {
     'custom-class': '',
     page: 1,
     size: 'md',
-    'prev-button-text': '',
-    'next-button-text': '',
   },
   argTypes: {
     'aria-label-values': {
@@ -92,10 +90,10 @@ export const Default: Story = {
       .ariaLabelValues=${args['aria-label-values']}
       count=${args.count}
       custom-class=${ifDefined(args['custom-class'])}
-      page=${args.page}
-      size=${ifDefined(args.size)}
-      prev-button-text="${ifDefined(args['prev-button-text'])}"
       next-button-text="${ifDefined(args['next-button-text'])}"
+      page=${args.page}
+      prev-button-text="${ifDefined(args['prev-button-text'])}"
+      size=${ifDefined(args.size)}
     ></modus-wc-pagination>
   `,
 };

--- a/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
@@ -18,6 +18,8 @@ interface PaginationArgs {
   'custom-class'?: string;
   page: number;
   size?: 'sm' | 'md' | 'lg';
+  'prev-button-text'?: string;
+  'next-button-text'?: string;
 }
 
 const meta: Meta<PaginationArgs> = {
@@ -29,6 +31,8 @@ const meta: Meta<PaginationArgs> = {
     'custom-class': '',
     page: 1,
     size: 'md',
+    'prev-button-text': '',
+    'next-button-text': '',
   },
   argTypes: {
     'aria-label-values': {
@@ -90,6 +94,8 @@ export const Default: Story = {
       custom-class=${ifDefined(args['custom-class'])}
       page=${args.page}
       size=${ifDefined(args.size)}
+      prev-button-text="${ifDefined(args['prev-button-text'])}"
+      next-button-text="${ifDefined(args['next-button-text'])}"
     ></modus-wc-pagination>
   `,
 };
@@ -117,8 +123,6 @@ export const Migration: Story = {
 | aria-label            | aria-label         |                                                             |
 | max-page              | count              |                                                             |
 | min-page              |                    | Not carried over, minimum page is always 1                  |
-| next-page-button-text |                    | Not carried over                                            |
-| prev-page-button-text |                    | Not carried over                                            |
 | size                  | size               | \`small\` → \`sm\`, \`medium\` → \`md\`, \`large\` → \`lg\` |
 
 #### Event Mapping

--- a/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.stories.ts
@@ -123,6 +123,8 @@ export const Migration: Story = {
 | aria-label            | aria-label         |                                                             |
 | max-page              | count              |                                                             |
 | min-page              |                    | Not carried over, minimum page is always 1                  |
+| next-page-button-text | next-button-text   |                                                             |
+| prev-page-button-text | prev-button-text   |                                                             |
 | size                  | size               | \`small\` → \`sm\`, \`medium\` → \`md\`, \`large\` → \`lg\` |
 
 #### Event Mapping

--- a/src/components/modus-wc-pagination/modus-wc-pagination.tsx
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.tsx
@@ -66,6 +66,12 @@ export class ModusWcPagination {
   /** The current page number */
   @Prop() page: number = 1;
 
+  /** Text for the previous button */
+  @Prop() prevButtonText?: string;
+
+  /** Text for the next button */
+  @Prop() nextButtonText?: string;
+
   /** Size of the pagination buttons */
   @Prop() size: ModusSize = 'md';
 
@@ -166,11 +172,15 @@ export class ModusWcPagination {
 
         <button
           aria-label={ariaLabels.previousPage}
-          class={buttonClasses}
+          class={`${buttonClasses} ${this.prevButtonText ? 'modus-wc-pagination-button-text' : ''}`}
           disabled={isFirstPage}
           onClick={() => this.handlePageClick(this.page - 1)}
         >
-          <ChevronLeftSolidIcon className="modus-wc-pagination-icon" />
+          {this.prevButtonText ? (
+            <span>{this.prevButtonText}</span>
+          ) : (
+            <ChevronLeftSolidIcon className="modus-wc-pagination-icon" />
+          )}
         </button>
 
         {this.visiblePages.map((page) => (
@@ -186,11 +196,15 @@ export class ModusWcPagination {
 
         <button
           aria-label={ariaLabels.nextPage}
-          class={buttonClasses}
+          class={`${buttonClasses} ${this.nextButtonText ? 'modus-wc-pagination-button-text' : ''}`}
           disabled={isLastPage}
           onClick={() => this.handlePageClick(this.page + 1)}
         >
-          <ChevronRightSolidIcon className="modus-wc-pagination-icon" />
+          {this.nextButtonText ? (
+            <span>{this.nextButtonText}</span>
+          ) : (
+            <ChevronRightSolidIcon className="modus-wc-pagination-icon" />
+          )}
         </button>
 
         {shouldShowFirstLastButtons && (

--- a/src/components/modus-wc-pagination/modus-wc-pagination.tsx
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.tsx
@@ -63,14 +63,14 @@ export class ModusWcPagination {
   /** Custom CSS class to apply */
   @Prop() customClass?: string = '';
 
+  /** The next page button text. If not set, an icon control will be used. */
+  @Prop() nextButtonText?: string;
+
   /** The current page number */
   @Prop() page: number = 1;
 
-  /** Text for the previous button */
+  /** The previous page button text. If not set, an icon control will be used. */
   @Prop() prevButtonText?: string;
-
-  /** Text for the next button */
-  @Prop() nextButtonText?: string;
 
   /** Size of the pagination buttons */
   @Prop() size: ModusSize = 'md';

--- a/src/components/modus-wc-pagination/modus-wc-pagination.tsx
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.tsx
@@ -171,7 +171,7 @@ export class ModusWcPagination {
         )}
 
         <button
-          aria-label={ariaLabels.previousPage}
+          aria-label={this.prevButtonText ? undefined : ariaLabels.previousPage}
           class={`${buttonClasses} ${this.prevButtonText ? 'modus-wc-pagination-button-text' : ''}`}
           disabled={isFirstPage}
           onClick={() => this.handlePageClick(this.page - 1)}
@@ -195,7 +195,7 @@ export class ModusWcPagination {
         ))}
 
         <button
-          aria-label={ariaLabels.nextPage}
+          aria-label={this.nextButtonText ? undefined : ariaLabels.nextPage}
           class={`${buttonClasses} ${this.nextButtonText ? 'modus-wc-pagination-button-text' : ''}`}
           disabled={isLastPage}
           onClick={() => this.handlePageClick(this.page + 1)}

--- a/src/components/modus-wc-pagination/readme.md
+++ b/src/components/modus-wc-pagination/readme.md
@@ -18,7 +18,9 @@ Adheres to WCAG 2.2 standards.
 | `ariaLabelValues` | `aria-label-values` | Aria label values for pagination buttons | `IAriaLabelValues \| undefined` | `undefined` |
 | `count`           | `count`             | Total number of pages                    | `number`                        | `1`         |
 | `customClass`     | `custom-class`      | Custom CSS class to apply                | `string \| undefined`           | `''`        |
+| `nextButtonText`  | `next-button-text`  | Text for the next button                 | `string \| undefined`           | `undefined` |
 | `page`            | `page`              | The current page number                  | `number`                        | `1`         |
+| `prevButtonText`  | `prev-button-text`  | Text for the previous button             | `string \| undefined`           | `undefined` |
 | `size`            | `size`              | Size of the pagination buttons           | `"lg" \| "md" \| "sm"`          | `'md'`      |
 
 

--- a/src/components/modus-wc-pagination/readme.md
+++ b/src/components/modus-wc-pagination/readme.md
@@ -13,15 +13,15 @@ Adheres to WCAG 2.2 standards.
 
 ## Properties
 
-| Property          | Attribute           | Description                              | Type                            | Default     |
-| ----------------- | ------------------- | ---------------------------------------- | ------------------------------- | ----------- |
-| `ariaLabelValues` | `aria-label-values` | Aria label values for pagination buttons | `IAriaLabelValues \| undefined` | `undefined` |
-| `count`           | `count`             | Total number of pages                    | `number`                        | `1`         |
-| `customClass`     | `custom-class`      | Custom CSS class to apply                | `string \| undefined`           | `''`        |
-| `nextButtonText`  | `next-button-text`  | Text for the next button                 | `string \| undefined`           | `undefined` |
-| `page`            | `page`              | The current page number                  | `number`                        | `1`         |
-| `prevButtonText`  | `prev-button-text`  | Text for the previous button             | `string \| undefined`           | `undefined` |
-| `size`            | `size`              | Size of the pagination buttons           | `"lg" \| "md" \| "sm"`          | `'md'`      |
+| Property          | Attribute           | Description                                                              | Type                            | Default     |
+| ----------------- | ------------------- | ------------------------------------------------------------------------ | ------------------------------- | ----------- |
+| `ariaLabelValues` | `aria-label-values` | Aria label values for pagination buttons                                 | `IAriaLabelValues \| undefined` | `undefined` |
+| `count`           | `count`             | Total number of pages                                                    | `number`                        | `1`         |
+| `customClass`     | `custom-class`      | Custom CSS class to apply                                                | `string \| undefined`           | `''`        |
+| `nextButtonText`  | `next-button-text`  | The next page button text. If not set, an icon control will be used.     | `string \| undefined`           | `undefined` |
+| `page`            | `page`              | The current page number                                                  | `number`                        | `1`         |
+| `prevButtonText`  | `prev-button-text`  | The previous page button text. If not set, an icon control will be used. | `string \| undefined`           | `undefined` |
+| `size`            | `size`              | Size of the pagination buttons                                           | `"lg" \| "md" \| "sm"`          | `'md'`      |
 
 
 ## Events

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -2695,7 +2695,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "Pagination component to navigate through pages of content.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "Pagination component to navigate through pages of content.",
           "name": "ModusWcPagination",
           "members": [
             {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -2937,7 +2937,7 @@
             {
               "name": "next-button-text",
               "fieldName": "nextButtonText",
-              "description": "Text for the next button",
+              "description": "The next page button text. If not set, an icon control will be used.",
               "type": {
                 "text": "string"
               }
@@ -2954,7 +2954,7 @@
             {
               "name": "prev-button-text",
               "fieldName": "prevButtonText",
-              "description": "Text for the previous button",
+              "description": "The previous page button text. If not set, an icon control will be used.",
               "type": {
                 "text": "string"
               }

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -2695,7 +2695,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "Pagination component to navigate through pages of content.",
+          "description": "Pagination component to navigate through pages of content",
           "name": "ModusWcPagination",
           "members": [
             {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -2887,7 +2887,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "Pagination component to navigate through pages of content.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "Pagination component to navigate through pages of content.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcPagination",
           "members": [
             {
@@ -2935,12 +2935,28 @@
               }
             },
             {
+              "name": "next-button-text",
+              "fieldName": "nextButtonText",
+              "description": "Text for the next button",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
               "name": "page",
               "fieldName": "page",
               "default": "1",
               "description": "The current page number",
               "type": {
                 "text": "number"
+              }
+            },
+            {
+              "name": "prev-button-text",
+              "fieldName": "prevButtonText",
+              "description": "Text for the previous button",
+              "type": {
+                "text": "string"
               }
             },
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Added `prevButtonText` and `nextButtonText` props
- If provided, button renders text instead of icon
- Adjusted styles to accommodate text-based buttons

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

https://didactic-adventure-wgwryqr.pages.github.io/pr-preview/pr-385/?path=/story/components-pagination--default&args=prev-button-text:prev;next-button-text:next&globals=theme:modus-classic-light

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #379
