### PR TITLE
Docs: remove repetitive 'Adheres to WCAG 2.2 standards'

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -41,7 +41,6 @@ export namespace Components {
     /**
      * A customizable accordion component used for showing and hiding related groups of content.
      * The component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcAccordion {
         /**
@@ -50,16 +49,15 @@ export namespace Components {
         "customClass"?: string;
     }
     /**
-     * A customizable alert component used to inform the user about important events.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable alert component used to inform the user about important events
      */
     interface ModusWcAlert {
         /**
-          * The description of the alert. *
+          * The description of the alert.
          */
         "alertDescription"?: string;
         /**
-          * The title of the alert. *
+          * The title of the alert.
          */
         "alertTitle": string;
         /**
@@ -71,7 +69,7 @@ export namespace Components {
          */
         "dismissible"?: boolean;
         /**
-          * The Modus icon to render. *
+          * The Modus icon to render.
          */
         "icon"?: string;
         /**
@@ -85,7 +83,6 @@ export namespace Components {
     }
     /**
      * A customizable autocomplete component used to create searchable text inputs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcAutocomplete {
         /**
@@ -167,7 +164,6 @@ export namespace Components {
     }
     /**
      * A customizable avatar component used to create avatars with different images.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcAvatar {
         /**
@@ -194,7 +190,6 @@ export namespace Components {
     /**
      * A customizable badge component used to create badges with different sizes, types, and colors.
      * The component supports a `<slot>` for injecting content within the badge.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcBadge {
         /**
@@ -222,7 +217,6 @@ export namespace Components {
     }
     /**
      * A customizable breadcrumbs component used to help users navigate through a website.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcBreadcrumbs {
         /**
@@ -240,8 +234,7 @@ export namespace Components {
     }
     /**
      * A customizable button component used to create buttons with different sizes, variants, and types.
-     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button
      */
     interface ModusWcButton {
         /**
@@ -282,8 +275,7 @@ export namespace Components {
         "variant": 'borderless' | 'filled' | 'outlined';
     }
     /**
-     * A customizable card component used to group and display content in a way that is easily readable.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable card component used to group and display content in a way that is easily readable
      */
     interface ModusWcCard {
         /**
@@ -308,8 +300,7 @@ export namespace Components {
         "padding"?: 'normal' | 'compact';
     }
     /**
-     * A customizable checkbox component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable checkbox component
      */
     interface ModusWcCheckbox {
         /**
@@ -354,8 +345,7 @@ export namespace Components {
         "value": boolean;
     }
     /**
-     * A customizable chip component used to display information in a compact area.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable chip component used to display information in a compact area
      */
     interface ModusWcChip {
         /**
@@ -395,7 +385,6 @@ export namespace Components {
      * A customizable collapse component used for showing and hiding content.
      * The component supports a 'header' and 'content' `<slot>` for injecting custom HTML.
      * Do not set
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcCollapse {
         /**
@@ -520,7 +509,6 @@ export namespace Components {
     /**
      * A customizable icon component used to render Modus icons.
      * <b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcIcon {
         /**
@@ -543,7 +531,6 @@ export namespace Components {
     /**
      * A customizable feedback component used to provide additional context related to form input interactions.
      * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcInputFeedback {
         /**
@@ -569,8 +556,7 @@ export namespace Components {
     }
     /**
      * A customizable input label component.
-     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text
      */
     interface ModusWcInputLabel {
         /**
@@ -599,8 +585,7 @@ export namespace Components {
         "subLabelText"?: string;
     }
     /**
-     * A customizable loader component used to indicate the loading of content.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable loader component used to indicate the loading of content
      */
     interface ModusWcLoader {
         /**
@@ -622,8 +607,7 @@ export namespace Components {
     }
     /**
      * A customizable menu component used to display a list of li elements vertically or horizontally.
-     * The component supports a `<slot>` for injecting custom li elements inside the ul.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting custom li elements inside the ul
      */
     interface ModusWcMenu {
         /**
@@ -644,8 +628,7 @@ export namespace Components {
         "size"?: ModusSize;
     }
     /**
-     * A customizable menu item component used to display the item portion of a menu.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable menu item component used to display the item portion of a menu
      */
     interface ModusWcMenuItem {
         "bordered"?: boolean;
@@ -688,8 +671,7 @@ export namespace Components {
     }
     /**
      * A customizable modal component used to display content in a dialog.
-     * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML
      */
     interface ModusWcModal {
         /**
@@ -724,8 +706,7 @@ export namespace Components {
     /**
      * A customizable navbar component used for top level navigation of all Trimble applications.
      * The component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.
-     * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML.
-     * Adheres to WCAG 2.2 standards.
+     * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML
      */
     interface ModusWcNavbar {
         /**
@@ -778,8 +759,7 @@ export namespace Components {
         "visibility"?: INavbarVisibility;
     }
     /**
-     * A customizable input component used to create number inputs with types.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable input component used to create number inputs with types
      */
     interface ModusWcNumberInput {
         /**
@@ -864,8 +844,7 @@ export namespace Components {
         "value": string;
     }
     /**
-     * Pagination component to navigate through pages of content.
-     * Adheres to WCAG 2.2 standards.
+     * Pagination component to navigate through pages of content
      */
     interface ModusWcPagination {
         /**
@@ -891,8 +870,7 @@ export namespace Components {
     }
     /**
      * A customizable progress component used to show the progress of a task or show the passing of time.
-     * The radial variant supports slotting in custom HTML to be displayed within the progress circle.
-     * Adheres to WCAG 2.2 standards.
+     * The radial variant supports slotting in custom HTML to be displayed within the progress circle
      */
     interface ModusWcProgress {
         /**
@@ -921,8 +899,7 @@ export namespace Components {
         "variant"?: 'default' | 'radial';
     }
     /**
-     * A customizable radio component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable radio component
      */
     interface ModusWcRadio {
         /**
@@ -963,8 +940,7 @@ export namespace Components {
         "value": boolean;
     }
     /**
-     * A rating component that allows users to choose a rating from predefined options.
-     * Adheres to WCAG 2.2 standards.
+     * A rating component that allows users to choose a rating from predefined options
      */
     interface ModusWcRating {
         /**
@@ -1001,8 +977,7 @@ export namespace Components {
         "variant": ModusWcRatingVariant;
     }
     /**
-     * A customizable select component used to pick a value from a list of options.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable select component used to pick a value from a list of options
      */
     interface ModusWcSelect {
         /**
@@ -1055,8 +1030,7 @@ export namespace Components {
         "value": string;
     }
     /**
-     * A customizable skeleton component used to create skeletons of various sizes and shapes.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable skeleton component used to create skeletons of various sizes and shapes
      */
     interface ModusWcSkeleton {
         /**
@@ -1077,8 +1051,7 @@ export namespace Components {
         "width": string;
     }
     /**
-     * A customizable slider component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable slider component
      */
     interface ModusWcSlider {
         /**
@@ -1132,7 +1105,6 @@ export namespace Components {
     }
     /**
      * Used to show a list of steps in a process.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcStepper {
         /**
@@ -1149,8 +1121,7 @@ export namespace Components {
         "steps": IStepperItem[];
     }
     /**
-     * A customizable checkbox component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable checkbox component
      */
     interface ModusWcSwitch {
         /**
@@ -1196,7 +1167,6 @@ export namespace Components {
     }
     /**
      * A customizable table component used to show a list of data in a table format.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTable {
         /**
@@ -1222,7 +1192,6 @@ export namespace Components {
     }
     /**
      * A customizable tabs component used to create groups of tabs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTabs {
         /**
@@ -1248,7 +1217,6 @@ export namespace Components {
     }
     /**
      * A customizable input component used to create text inputs with types.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTextInput {
         /**
@@ -1372,7 +1340,6 @@ export namespace Components {
     }
     /**
      * A customizable textarea component.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTextarea {
         /**
@@ -1456,7 +1423,6 @@ export namespace Components {
     /**
      * A theme switcher component used to toggle the application theme and/or mode.
      * Allows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcThemeSwitcher {
         /**
@@ -1466,7 +1432,6 @@ export namespace Components {
     }
     /**
      * A customizable input component used to create time inputs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTimeInput {
         /**
@@ -1549,7 +1514,6 @@ export namespace Components {
     /**
      * A customizable toast component used to stack elements, positioned on the corner of a page.
      * The component supports a `<slot>` for injecting additional custom content inside the toast.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcToast {
         /**
@@ -1567,7 +1531,6 @@ export namespace Components {
     }
     /**
      * A customizable toolbar component used to organize content across the entire page.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcToolbar {
         /**
@@ -1577,7 +1540,6 @@ export namespace Components {
     }
     /**
      * A customizable tooltip component used to create tooltips with different content.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTooltip {
         /**
@@ -1607,7 +1569,6 @@ export namespace Components {
     }
     /**
      * A customizable typography component used to render text with different sizes, variants, and weights.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTypography {
         /**
@@ -1659,10 +1620,6 @@ export interface ModusWcChipCustomEvent<T> extends CustomEvent<T> {
 export interface ModusWcCollapseCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusWcCollapseElement;
-}
-export interface ModusWcDateCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLModusWcDateElement;
 }
 export interface ModusWcMenuItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -1734,7 +1691,6 @@ declare global {
     /**
      * A customizable accordion component used for showing and hiding related groups of content.
      * The component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcAccordionElement extends Components.ModusWcAccordion, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcAccordionElementEventMap>(type: K, listener: (this: HTMLModusWcAccordionElement, ev: ModusWcAccordionCustomEvent<HTMLModusWcAccordionElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1754,8 +1710,7 @@ declare global {
         "dismissClick": any;
     }
     /**
-     * A customizable alert component used to inform the user about important events.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable alert component used to inform the user about important events
      */
     interface HTMLModusWcAlertElement extends Components.ModusWcAlert, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcAlertElementEventMap>(type: K, listener: (this: HTMLModusWcAlertElement, ev: ModusWcAlertCustomEvent<HTMLModusWcAlertElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1780,7 +1735,6 @@ declare global {
     }
     /**
      * A customizable autocomplete component used to create searchable text inputs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcAutocompleteElement extends Components.ModusWcAutocomplete, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcAutocompleteElementEventMap>(type: K, listener: (this: HTMLModusWcAutocompleteElement, ev: ModusWcAutocompleteCustomEvent<HTMLModusWcAutocompleteElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1798,7 +1752,6 @@ declare global {
     };
     /**
      * A customizable avatar component used to create avatars with different images.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcAvatarElement extends Components.ModusWcAvatar, HTMLStencilElement {
     }
@@ -1809,7 +1762,6 @@ declare global {
     /**
      * A customizable badge component used to create badges with different sizes, types, and colors.
      * The component supports a `<slot>` for injecting content within the badge.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcBadgeElement extends Components.ModusWcBadge, HTMLStencilElement {
     }
@@ -1822,7 +1774,6 @@ declare global {
     }
     /**
      * A customizable breadcrumbs component used to help users navigate through a website.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcBreadcrumbsElement extends Components.ModusWcBreadcrumbs, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcBreadcrumbsElementEventMap>(type: K, listener: (this: HTMLModusWcBreadcrumbsElement, ev: ModusWcBreadcrumbsCustomEvent<HTMLModusWcBreadcrumbsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1843,8 +1794,7 @@ declare global {
     }
     /**
      * A customizable button component used to create buttons with different sizes, variants, and types.
-     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button
      */
     interface HTMLModusWcButtonElement extends Components.ModusWcButton, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcButtonElementEventMap>(type: K, listener: (this: HTMLModusWcButtonElement, ev: ModusWcButtonCustomEvent<HTMLModusWcButtonElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1861,8 +1811,7 @@ declare global {
         new (): HTMLModusWcButtonElement;
     };
     /**
-     * A customizable card component used to group and display content in a way that is easily readable.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable card component used to group and display content in a way that is easily readable
      */
     interface HTMLModusWcCardElement extends Components.ModusWcCard, HTMLStencilElement {
     }
@@ -1876,8 +1825,7 @@ declare global {
         "inputFocus": FocusEvent;
     }
     /**
-     * A customizable checkbox component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable checkbox component
      */
     interface HTMLModusWcCheckboxElement extends Components.ModusWcCheckbox, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcCheckboxElementEventMap>(type: K, listener: (this: HTMLModusWcCheckboxElement, ev: ModusWcCheckboxCustomEvent<HTMLModusWcCheckboxElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1898,8 +1846,7 @@ declare global {
         "chipRemove": MouseEvent | KeyboardEvent;
     }
     /**
-     * A customizable chip component used to display information in a compact area.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable chip component used to display information in a compact area
      */
     interface HTMLModusWcChipElement extends Components.ModusWcChip, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcChipElementEventMap>(type: K, listener: (this: HTMLModusWcChipElement, ev: ModusWcChipCustomEvent<HTMLModusWcChipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1922,7 +1869,6 @@ declare global {
      * A customizable collapse component used for showing and hiding content.
      * The component supports a 'header' and 'content' `<slot>` for injecting custom HTML.
      * Do not set
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcCollapseElement extends Components.ModusWcCollapse, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcCollapseElementEventMap>(type: K, listener: (this: HTMLModusWcCollapseElement, ev: ModusWcCollapseCustomEvent<HTMLModusWcCollapseElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1938,32 +1884,8 @@ declare global {
         prototype: HTMLModusWcCollapseElement;
         new (): HTMLModusWcCollapseElement;
     };
-    interface HTMLModusWcDateElementEventMap {
-        "inputBlur": FocusEvent;
-        "inputChange": InputEvent;
-        "inputFocus": FocusEvent;
-    }
     /**
-     * A customizable date picker component used to create date inputs.
-     * Adheres to WCAG 2.2 standards.
-     */
-    interface HTMLModusWcDateElement extends Components.ModusWcDate, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLModusWcDateElementEventMap>(type: K, listener: (this: HTMLModusWcDateElement, ev: ModusWcDateCustomEvent<HTMLModusWcDateElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLModusWcDateElementEventMap>(type: K, listener: (this: HTMLModusWcDateElement, ev: ModusWcDateCustomEvent<HTMLModusWcDateElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    }
-    var HTMLModusWcDateElement: {
-        prototype: HTMLModusWcDateElement;
-        new (): HTMLModusWcDateElement;
-    };
-    /**
-     * A customizable divider component used to separate content horizontally or vertically.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable divider component used to separate content horizontally or vertically
      */
     interface HTMLModusWcDividerElement extends Components.ModusWcDivider, HTMLStencilElement {
     }
@@ -1974,7 +1896,6 @@ declare global {
     /**
      * A customizable icon component used to render Modus icons.
      * <b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcIconElement extends Components.ModusWcIcon, HTMLStencilElement {
     }
@@ -1985,7 +1906,6 @@ declare global {
     /**
      * A customizable feedback component used to provide additional context related to form input interactions.
      * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcInputFeedbackElement extends Components.ModusWcInputFeedback, HTMLStencilElement {
     }
@@ -1995,8 +1915,7 @@ declare global {
     };
     /**
      * A customizable input label component.
-     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text
      */
     interface HTMLModusWcInputLabelElement extends Components.ModusWcInputLabel, HTMLStencilElement {
     }
@@ -2005,8 +1924,7 @@ declare global {
         new (): HTMLModusWcInputLabelElement;
     };
     /**
-     * A customizable loader component used to indicate the loading of content.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable loader component used to indicate the loading of content
      */
     interface HTMLModusWcLoaderElement extends Components.ModusWcLoader, HTMLStencilElement {
     }
@@ -2016,8 +1934,7 @@ declare global {
     };
     /**
      * A customizable menu component used to display a list of li elements vertically or horizontally.
-     * The component supports a `<slot>` for injecting custom li elements inside the ul.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting custom li elements inside the ul
      */
     interface HTMLModusWcMenuElement extends Components.ModusWcMenu, HTMLStencilElement {
     }
@@ -2029,8 +1946,7 @@ declare global {
         "itemSelect": { value: string };
     }
     /**
-     * A customizable menu item component used to display the item portion of a menu.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable menu item component used to display the item portion of a menu
      */
     interface HTMLModusWcMenuItemElement extends Components.ModusWcMenuItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcMenuItemElementEventMap>(type: K, listener: (this: HTMLModusWcMenuItemElement, ev: ModusWcMenuItemCustomEvent<HTMLModusWcMenuItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2048,8 +1964,7 @@ declare global {
     };
     /**
      * A customizable modal component used to display content in a dialog.
-     * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML
      */
     interface HTMLModusWcModalElement extends Components.ModusWcModal, HTMLStencilElement {
     }
@@ -2076,8 +1991,7 @@ declare global {
     /**
      * A customizable navbar component used for top level navigation of all Trimble applications.
      * The component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.
-     * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML.
-     * Adheres to WCAG 2.2 standards.
+     * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML
      */
     interface HTMLModusWcNavbarElement extends Components.ModusWcNavbar, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcNavbarElementEventMap>(type: K, listener: (this: HTMLModusWcNavbarElement, ev: ModusWcNavbarCustomEvent<HTMLModusWcNavbarElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2099,8 +2013,7 @@ declare global {
         "inputFocus": FocusEvent;
     }
     /**
-     * A customizable input component used to create number inputs with types.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable input component used to create number inputs with types
      */
     interface HTMLModusWcNumberInputElement extends Components.ModusWcNumberInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcNumberInputElementEventMap>(type: K, listener: (this: HTMLModusWcNumberInputElement, ev: ModusWcNumberInputCustomEvent<HTMLModusWcNumberInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2120,8 +2033,7 @@ declare global {
         "pageChange": IPageChange;
     }
     /**
-     * Pagination component to navigate through pages of content.
-     * Adheres to WCAG 2.2 standards.
+     * Pagination component to navigate through pages of content
      */
     interface HTMLModusWcPaginationElement extends Components.ModusWcPagination, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcPaginationElementEventMap>(type: K, listener: (this: HTMLModusWcPaginationElement, ev: ModusWcPaginationCustomEvent<HTMLModusWcPaginationElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2139,8 +2051,7 @@ declare global {
     };
     /**
      * A customizable progress component used to show the progress of a task or show the passing of time.
-     * The radial variant supports slotting in custom HTML to be displayed within the progress circle.
-     * Adheres to WCAG 2.2 standards.
+     * The radial variant supports slotting in custom HTML to be displayed within the progress circle
      */
     interface HTMLModusWcProgressElement extends Components.ModusWcProgress, HTMLStencilElement {
     }
@@ -2154,8 +2065,7 @@ declare global {
         "inputFocus": FocusEvent;
     }
     /**
-     * A customizable radio component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable radio component
      */
     interface HTMLModusWcRadioElement extends Components.ModusWcRadio, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcRadioElementEventMap>(type: K, listener: (this: HTMLModusWcRadioElement, ev: ModusWcRadioCustomEvent<HTMLModusWcRadioElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2175,8 +2085,7 @@ declare global {
         "ratingChange": IRatingChange;
     }
     /**
-     * A rating component that allows users to choose a rating from predefined options.
-     * Adheres to WCAG 2.2 standards.
+     * A rating component that allows users to choose a rating from predefined options
      */
     interface HTMLModusWcRatingElement extends Components.ModusWcRating, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcRatingElementEventMap>(type: K, listener: (this: HTMLModusWcRatingElement, ev: ModusWcRatingCustomEvent<HTMLModusWcRatingElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2198,8 +2107,7 @@ declare global {
         "inputFocus": FocusEvent;
     }
     /**
-     * A customizable select component used to pick a value from a list of options.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable select component used to pick a value from a list of options
      */
     interface HTMLModusWcSelectElement extends Components.ModusWcSelect, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcSelectElementEventMap>(type: K, listener: (this: HTMLModusWcSelectElement, ev: ModusWcSelectCustomEvent<HTMLModusWcSelectElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2216,8 +2124,7 @@ declare global {
         new (): HTMLModusWcSelectElement;
     };
     /**
-     * A customizable skeleton component used to create skeletons of various sizes and shapes.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable skeleton component used to create skeletons of various sizes and shapes
      */
     interface HTMLModusWcSkeletonElement extends Components.ModusWcSkeleton, HTMLStencilElement {
     }
@@ -2231,8 +2138,7 @@ declare global {
         "inputFocus": FocusEvent;
     }
     /**
-     * A customizable slider component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable slider component
      */
     interface HTMLModusWcSliderElement extends Components.ModusWcSlider, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcSliderElementEventMap>(type: K, listener: (this: HTMLModusWcSliderElement, ev: ModusWcSliderCustomEvent<HTMLModusWcSliderElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2250,7 +2156,6 @@ declare global {
     };
     /**
      * Used to show a list of steps in a process.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcStepperElement extends Components.ModusWcStepper, HTMLStencilElement {
     }
@@ -2264,8 +2169,7 @@ declare global {
         "inputFocus": FocusEvent;
     }
     /**
-     * A customizable checkbox component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable checkbox component
      */
     interface HTMLModusWcSwitchElement extends Components.ModusWcSwitch, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcSwitchElementEventMap>(type: K, listener: (this: HTMLModusWcSwitchElement, ev: ModusWcSwitchCustomEvent<HTMLModusWcSwitchElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2289,7 +2193,6 @@ declare global {
     }
     /**
      * A customizable table component used to show a list of data in a table format.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcTableElement extends Components.ModusWcTable, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcTableElementEventMap>(type: K, listener: (this: HTMLModusWcTableElement, ev: ModusWcTableCustomEvent<HTMLModusWcTableElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2313,7 +2216,6 @@ declare global {
     }
     /**
      * A customizable tabs component used to create groups of tabs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcTabsElement extends Components.ModusWcTabs, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcTabsElementEventMap>(type: K, listener: (this: HTMLModusWcTabsElement, ev: ModusWcTabsCustomEvent<HTMLModusWcTabsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2336,7 +2238,6 @@ declare global {
     }
     /**
      * A customizable input component used to create text inputs with types.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcTextInputElement extends Components.ModusWcTextInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcTextInputElementEventMap>(type: K, listener: (this: HTMLModusWcTextInputElement, ev: ModusWcTextInputCustomEvent<HTMLModusWcTextInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2359,7 +2260,6 @@ declare global {
     }
     /**
      * A customizable textarea component.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcTextareaElement extends Components.ModusWcTextarea, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcTextareaElementEventMap>(type: K, listener: (this: HTMLModusWcTextareaElement, ev: ModusWcTextareaCustomEvent<HTMLModusWcTextareaElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2387,7 +2287,6 @@ declare global {
     /**
      * A theme switcher component used to toggle the application theme and/or mode.
      * Allows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcThemeSwitcherElement extends Components.ModusWcThemeSwitcher, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcThemeSwitcherElementEventMap>(type: K, listener: (this: HTMLModusWcThemeSwitcherElement, ev: ModusWcThemeSwitcherCustomEvent<HTMLModusWcThemeSwitcherElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2410,7 +2309,6 @@ declare global {
     }
     /**
      * A customizable input component used to create time inputs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcTimeInputElement extends Components.ModusWcTimeInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcTimeInputElementEventMap>(type: K, listener: (this: HTMLModusWcTimeInputElement, ev: ModusWcTimeInputCustomEvent<HTMLModusWcTimeInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2429,7 +2327,6 @@ declare global {
     /**
      * A customizable toast component used to stack elements, positioned on the corner of a page.
      * The component supports a `<slot>` for injecting additional custom content inside the toast.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcToastElement extends Components.ModusWcToast, HTMLStencilElement {
     }
@@ -2439,7 +2336,6 @@ declare global {
     };
     /**
      * A customizable toolbar component used to organize content across the entire page.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcToolbarElement extends Components.ModusWcToolbar, HTMLStencilElement {
     }
@@ -2449,7 +2345,6 @@ declare global {
     };
     /**
      * A customizable tooltip component used to create tooltips with different content.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcTooltipElement extends Components.ModusWcTooltip, HTMLStencilElement {
     }
@@ -2459,7 +2354,6 @@ declare global {
     };
     /**
      * A customizable typography component used to render text with different sizes, variants, and weights.
-     * Adheres to WCAG 2.2 standards.
      */
     interface HTMLModusWcTypographyElement extends Components.ModusWcTypography, HTMLStencilElement {
     }
@@ -2479,7 +2373,6 @@ declare global {
         "modus-wc-checkbox": HTMLModusWcCheckboxElement;
         "modus-wc-chip": HTMLModusWcChipElement;
         "modus-wc-collapse": HTMLModusWcCollapseElement;
-        "modus-wc-date": HTMLModusWcDateElement;
         "modus-wc-divider": HTMLModusWcDividerElement;
         "modus-wc-icon": HTMLModusWcIconElement;
         "modus-wc-input-feedback": HTMLModusWcInputFeedbackElement;
@@ -2516,7 +2409,6 @@ declare namespace LocalJSX {
     /**
      * A customizable accordion component used for showing and hiding related groups of content.
      * The component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcAccordion {
         /**
@@ -2532,16 +2424,15 @@ declare namespace LocalJSX {
   }>) => void;
     }
     /**
-     * A customizable alert component used to inform the user about important events.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable alert component used to inform the user about important events
      */
     interface ModusWcAlert {
         /**
-          * The description of the alert. *
+          * The description of the alert.
          */
         "alertDescription"?: string;
         /**
-          * The title of the alert. *
+          * The title of the alert.
          */
         "alertTitle": string;
         /**
@@ -2553,7 +2444,7 @@ declare namespace LocalJSX {
          */
         "dismissible"?: boolean;
         /**
-          * The Modus icon to render. *
+          * The Modus icon to render.
          */
         "icon"?: string;
         /**
@@ -2571,7 +2462,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable autocomplete component used to create searchable text inputs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcAutocomplete {
         /**
@@ -2673,7 +2563,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable avatar component used to create avatars with different images.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcAvatar {
         /**
@@ -2700,7 +2589,6 @@ declare namespace LocalJSX {
     /**
      * A customizable badge component used to create badges with different sizes, types, and colors.
      * The component supports a `<slot>` for injecting content within the badge.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcBadge {
         /**
@@ -2728,7 +2616,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable breadcrumbs component used to help users navigate through a website.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcBreadcrumbs {
         /**
@@ -2750,8 +2637,7 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable button component used to create buttons with different sizes, variants, and types.
-     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button
      */
     interface ModusWcButton {
         /**
@@ -2796,8 +2682,7 @@ declare namespace LocalJSX {
         "variant"?: 'borderless' | 'filled' | 'outlined';
     }
     /**
-     * A customizable card component used to group and display content in a way that is easily readable.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable card component used to group and display content in a way that is easily readable
      */
     interface ModusWcCard {
         /**
@@ -2822,8 +2707,7 @@ declare namespace LocalJSX {
         "padding"?: 'normal' | 'compact';
     }
     /**
-     * A customizable checkbox component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable checkbox component
      */
     interface ModusWcCheckbox {
         /**
@@ -2880,8 +2764,7 @@ declare namespace LocalJSX {
         "value"?: boolean;
     }
     /**
-     * A customizable chip component used to display information in a compact area.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable chip component used to display information in a compact area
      */
     interface ModusWcChip {
         /**
@@ -2929,7 +2812,6 @@ declare namespace LocalJSX {
      * A customizable collapse component used for showing and hiding content.
      * The component supports a 'header' and 'content' `<slot>` for injecting custom HTML.
      * Do not set
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcCollapse {
         /**
@@ -3070,7 +2952,6 @@ declare namespace LocalJSX {
     /**
      * A customizable icon component used to render Modus icons.
      * <b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcIcon {
         /**
@@ -3093,7 +2974,6 @@ declare namespace LocalJSX {
     /**
      * A customizable feedback component used to provide additional context related to form input interactions.
      * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcInputFeedback {
         /**
@@ -3119,8 +2999,7 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable input label component.
-     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text
      */
     interface ModusWcInputLabel {
         /**
@@ -3149,8 +3028,7 @@ declare namespace LocalJSX {
         "subLabelText"?: string;
     }
     /**
-     * A customizable loader component used to indicate the loading of content.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable loader component used to indicate the loading of content
      */
     interface ModusWcLoader {
         /**
@@ -3172,8 +3050,7 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable menu component used to display a list of li elements vertically or horizontally.
-     * The component supports a `<slot>` for injecting custom li elements inside the ul.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a `<slot>` for injecting custom li elements inside the ul
      */
     interface ModusWcMenu {
         /**
@@ -3194,8 +3071,7 @@ declare namespace LocalJSX {
         "size"?: ModusSize;
     }
     /**
-     * A customizable menu item component used to display the item portion of a menu.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable menu item component used to display the item portion of a menu
      */
     interface ModusWcMenuItem {
         "bordered"?: boolean;
@@ -3242,8 +3118,7 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable modal component used to display content in a dialog.
-     * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML.
-     * Adheres to WCAG 2.2 standards.
+     * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML
      */
     interface ModusWcModal {
         /**
@@ -3278,8 +3153,7 @@ declare namespace LocalJSX {
     /**
      * A customizable navbar component used for top level navigation of all Trimble applications.
      * The component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.
-     * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML.
-     * Adheres to WCAG 2.2 standards.
+     * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML
      */
     interface ModusWcNavbar {
         /**
@@ -3388,8 +3262,7 @@ declare namespace LocalJSX {
         "visibility"?: INavbarVisibility;
     }
     /**
-     * A customizable input component used to create number inputs with types.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable input component used to create number inputs with types
      */
     interface ModusWcNumberInput {
         /**
@@ -3486,8 +3359,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * Pagination component to navigate through pages of content.
-     * Adheres to WCAG 2.2 standards.
+     * Pagination component to navigate through pages of content
      */
     interface ModusWcPagination {
         /**
@@ -3517,8 +3389,7 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable progress component used to show the progress of a task or show the passing of time.
-     * The radial variant supports slotting in custom HTML to be displayed within the progress circle.
-     * Adheres to WCAG 2.2 standards.
+     * The radial variant supports slotting in custom HTML to be displayed within the progress circle
      */
     interface ModusWcProgress {
         /**
@@ -3547,8 +3418,7 @@ declare namespace LocalJSX {
         "variant"?: 'default' | 'radial';
     }
     /**
-     * A customizable radio component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable radio component
      */
     interface ModusWcRadio {
         /**
@@ -3601,8 +3471,7 @@ declare namespace LocalJSX {
         "value"?: boolean;
     }
     /**
-     * A rating component that allows users to choose a rating from predefined options.
-     * Adheres to WCAG 2.2 standards.
+     * A rating component that allows users to choose a rating from predefined options
      */
     interface ModusWcRating {
         /**
@@ -3643,8 +3512,7 @@ declare namespace LocalJSX {
         "variant"?: ModusWcRatingVariant;
     }
     /**
-     * A customizable select component used to pick a value from a list of options.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable select component used to pick a value from a list of options
      */
     interface ModusWcSelect {
         /**
@@ -3709,8 +3577,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * A customizable skeleton component used to create skeletons of various sizes and shapes.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable skeleton component used to create skeletons of various sizes and shapes
      */
     interface ModusWcSkeleton {
         /**
@@ -3731,8 +3598,7 @@ declare namespace LocalJSX {
         "width"?: string;
     }
     /**
-     * A customizable slider component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable slider component
      */
     interface ModusWcSlider {
         /**
@@ -3798,7 +3664,6 @@ declare namespace LocalJSX {
     }
     /**
      * Used to show a list of steps in a process.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcStepper {
         /**
@@ -3815,8 +3680,7 @@ declare namespace LocalJSX {
         "steps"?: IStepperItem[];
     }
     /**
-     * A customizable checkbox component.
-     * Adheres to WCAG 2.2 standards.
+     * A customizable checkbox component
      */
     interface ModusWcSwitch {
         /**
@@ -3874,7 +3738,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable table component used to show a list of data in a table format.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTable {
         /**
@@ -3907,7 +3770,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable tabs component used to create groups of tabs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTabs {
         /**
@@ -3940,7 +3802,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable input component used to create text inputs with types.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTextInput {
         /**
@@ -4076,7 +3937,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable textarea component.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTextarea {
         /**
@@ -4172,7 +4032,6 @@ declare namespace LocalJSX {
     /**
      * A theme switcher component used to toggle the application theme and/or mode.
      * Allows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcThemeSwitcher {
         /**
@@ -4186,7 +4045,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable input component used to create time inputs.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTimeInput {
         /**
@@ -4281,7 +4139,6 @@ declare namespace LocalJSX {
     /**
      * A customizable toast component used to stack elements, positioned on the corner of a page.
      * The component supports a `<slot>` for injecting additional custom content inside the toast.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcToast {
         /**
@@ -4299,7 +4156,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable toolbar component used to organize content across the entire page.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcToolbar {
         /**
@@ -4309,7 +4165,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable tooltip component used to create tooltips with different content.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTooltip {
         /**
@@ -4339,7 +4194,6 @@ declare namespace LocalJSX {
     }
     /**
      * A customizable typography component used to render text with different sizes, variants, and weights.
-     * Adheres to WCAG 2.2 standards.
      */
     interface ModusWcTypography {
         /**
@@ -4371,7 +4225,6 @@ declare namespace LocalJSX {
         "modus-wc-checkbox": ModusWcCheckbox;
         "modus-wc-chip": ModusWcChip;
         "modus-wc-collapse": ModusWcCollapse;
-        "modus-wc-date": ModusWcDate;
         "modus-wc-divider": ModusWcDivider;
         "modus-wc-icon": ModusWcIcon;
         "modus-wc-input-feedback": ModusWcInputFeedback;
@@ -4411,222 +4264,177 @@ declare module "@stencil/core" {
             /**
              * A customizable accordion component used for showing and hiding related groups of content.
              * The component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-accordion": LocalJSX.ModusWcAccordion & JSXBase.HTMLAttributes<HTMLModusWcAccordionElement>;
             /**
-             * A customizable alert component used to inform the user about important events.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable alert component used to inform the user about important events
              */
             "modus-wc-alert": LocalJSX.ModusWcAlert & JSXBase.HTMLAttributes<HTMLModusWcAlertElement>;
             /**
              * A customizable autocomplete component used to create searchable text inputs.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-autocomplete": LocalJSX.ModusWcAutocomplete & JSXBase.HTMLAttributes<HTMLModusWcAutocompleteElement>;
             /**
              * A customizable avatar component used to create avatars with different images.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-avatar": LocalJSX.ModusWcAvatar & JSXBase.HTMLAttributes<HTMLModusWcAvatarElement>;
             /**
              * A customizable badge component used to create badges with different sizes, types, and colors.
              * The component supports a `<slot>` for injecting content within the badge.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-badge": LocalJSX.ModusWcBadge & JSXBase.HTMLAttributes<HTMLModusWcBadgeElement>;
             /**
              * A customizable breadcrumbs component used to help users navigate through a website.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-breadcrumbs": LocalJSX.ModusWcBreadcrumbs & JSXBase.HTMLAttributes<HTMLModusWcBreadcrumbsElement>;
             /**
              * A customizable button component used to create buttons with different sizes, variants, and types.
-             * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
-             * Adheres to WCAG 2.2 standards.
+             * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button
              */
             "modus-wc-button": LocalJSX.ModusWcButton & JSXBase.HTMLAttributes<HTMLModusWcButtonElement>;
             /**
-             * A customizable card component used to group and display content in a way that is easily readable.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable card component used to group and display content in a way that is easily readable
              */
             "modus-wc-card": LocalJSX.ModusWcCard & JSXBase.HTMLAttributes<HTMLModusWcCardElement>;
             /**
-             * A customizable checkbox component.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable checkbox component
              */
             "modus-wc-checkbox": LocalJSX.ModusWcCheckbox & JSXBase.HTMLAttributes<HTMLModusWcCheckboxElement>;
             /**
-             * A customizable chip component used to display information in a compact area.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable chip component used to display information in a compact area
              */
             "modus-wc-chip": LocalJSX.ModusWcChip & JSXBase.HTMLAttributes<HTMLModusWcChipElement>;
             /**
              * A customizable collapse component used for showing and hiding content.
              * The component supports a 'header' and 'content' `<slot>` for injecting custom HTML.
              * Do not set
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-collapse": LocalJSX.ModusWcCollapse & JSXBase.HTMLAttributes<HTMLModusWcCollapseElement>;
             /**
-             * A customizable date picker component used to create date inputs.
-             * Adheres to WCAG 2.2 standards.
-             */
-            "modus-wc-date": LocalJSX.ModusWcDate & JSXBase.HTMLAttributes<HTMLModusWcDateElement>;
-            /**
-             * A customizable divider component used to separate content horizontally or vertically.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable divider component used to separate content horizontally or vertically
              */
             "modus-wc-divider": LocalJSX.ModusWcDivider & JSXBase.HTMLAttributes<HTMLModusWcDividerElement>;
             /**
              * A customizable icon component used to render Modus icons.
              * <b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-icon": LocalJSX.ModusWcIcon & JSXBase.HTMLAttributes<HTMLModusWcIconElement>;
             /**
              * A customizable feedback component used to provide additional context related to form input interactions.
              * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-input-feedback": LocalJSX.ModusWcInputFeedback & JSXBase.HTMLAttributes<HTMLModusWcInputFeedbackElement>;
             /**
              * A customizable input label component.
-             * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
-             * Adheres to WCAG 2.2 standards.
+             * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text
              */
             "modus-wc-input-label": LocalJSX.ModusWcInputLabel & JSXBase.HTMLAttributes<HTMLModusWcInputLabelElement>;
             /**
-             * A customizable loader component used to indicate the loading of content.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable loader component used to indicate the loading of content
              */
             "modus-wc-loader": LocalJSX.ModusWcLoader & JSXBase.HTMLAttributes<HTMLModusWcLoaderElement>;
             /**
              * A customizable menu component used to display a list of li elements vertically or horizontally.
-             * The component supports a `<slot>` for injecting custom li elements inside the ul.
-             * Adheres to WCAG 2.2 standards.
+             * The component supports a `<slot>` for injecting custom li elements inside the ul
              */
             "modus-wc-menu": LocalJSX.ModusWcMenu & JSXBase.HTMLAttributes<HTMLModusWcMenuElement>;
             /**
-             * A customizable menu item component used to display the item portion of a menu.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable menu item component used to display the item portion of a menu
              */
             "modus-wc-menu-item": LocalJSX.ModusWcMenuItem & JSXBase.HTMLAttributes<HTMLModusWcMenuItemElement>;
             /**
              * A customizable modal component used to display content in a dialog.
-             * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML.
-             * Adheres to WCAG 2.2 standards.
+             * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML
              */
             "modus-wc-modal": LocalJSX.ModusWcModal & JSXBase.HTMLAttributes<HTMLModusWcModalElement>;
             /**
              * A customizable navbar component used for top level navigation of all Trimble applications.
              * The component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.
-             * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML.
-             * Adheres to WCAG 2.2 standards.
+             * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML
              */
             "modus-wc-navbar": LocalJSX.ModusWcNavbar & JSXBase.HTMLAttributes<HTMLModusWcNavbarElement>;
             /**
-             * A customizable input component used to create number inputs with types.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable input component used to create number inputs with types
              */
             "modus-wc-number-input": LocalJSX.ModusWcNumberInput & JSXBase.HTMLAttributes<HTMLModusWcNumberInputElement>;
             /**
-             * Pagination component to navigate through pages of content.
-             * Adheres to WCAG 2.2 standards.
+             * Pagination component to navigate through pages of content
              */
             "modus-wc-pagination": LocalJSX.ModusWcPagination & JSXBase.HTMLAttributes<HTMLModusWcPaginationElement>;
             /**
              * A customizable progress component used to show the progress of a task or show the passing of time.
-             * The radial variant supports slotting in custom HTML to be displayed within the progress circle.
-             * Adheres to WCAG 2.2 standards.
+             * The radial variant supports slotting in custom HTML to be displayed within the progress circle
              */
             "modus-wc-progress": LocalJSX.ModusWcProgress & JSXBase.HTMLAttributes<HTMLModusWcProgressElement>;
             /**
-             * A customizable radio component.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable radio component
              */
             "modus-wc-radio": LocalJSX.ModusWcRadio & JSXBase.HTMLAttributes<HTMLModusWcRadioElement>;
             /**
-             * A rating component that allows users to choose a rating from predefined options.
-             * Adheres to WCAG 2.2 standards.
+             * A rating component that allows users to choose a rating from predefined options
              */
             "modus-wc-rating": LocalJSX.ModusWcRating & JSXBase.HTMLAttributes<HTMLModusWcRatingElement>;
             /**
-             * A customizable select component used to pick a value from a list of options.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable select component used to pick a value from a list of options
              */
             "modus-wc-select": LocalJSX.ModusWcSelect & JSXBase.HTMLAttributes<HTMLModusWcSelectElement>;
             /**
-             * A customizable skeleton component used to create skeletons of various sizes and shapes.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable skeleton component used to create skeletons of various sizes and shapes
              */
             "modus-wc-skeleton": LocalJSX.ModusWcSkeleton & JSXBase.HTMLAttributes<HTMLModusWcSkeletonElement>;
             /**
-             * A customizable slider component.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable slider component
              */
             "modus-wc-slider": LocalJSX.ModusWcSlider & JSXBase.HTMLAttributes<HTMLModusWcSliderElement>;
             /**
              * Used to show a list of steps in a process.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-stepper": LocalJSX.ModusWcStepper & JSXBase.HTMLAttributes<HTMLModusWcStepperElement>;
             /**
-             * A customizable checkbox component.
-             * Adheres to WCAG 2.2 standards.
+             * A customizable checkbox component
              */
             "modus-wc-switch": LocalJSX.ModusWcSwitch & JSXBase.HTMLAttributes<HTMLModusWcSwitchElement>;
             /**
              * A customizable table component used to show a list of data in a table format.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-table": LocalJSX.ModusWcTable & JSXBase.HTMLAttributes<HTMLModusWcTableElement>;
             /**
              * A customizable tabs component used to create groups of tabs.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-tabs": LocalJSX.ModusWcTabs & JSXBase.HTMLAttributes<HTMLModusWcTabsElement>;
             /**
              * A customizable input component used to create text inputs with types.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-text-input": LocalJSX.ModusWcTextInput & JSXBase.HTMLAttributes<HTMLModusWcTextInputElement>;
             /**
              * A customizable textarea component.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-textarea": LocalJSX.ModusWcTextarea & JSXBase.HTMLAttributes<HTMLModusWcTextareaElement>;
             "modus-wc-theme-provider": LocalJSX.ModusWcThemeProvider & JSXBase.HTMLAttributes<HTMLModusWcThemeProviderElement>;
             /**
              * A theme switcher component used to toggle the application theme and/or mode.
              * Allows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-theme-switcher": LocalJSX.ModusWcThemeSwitcher & JSXBase.HTMLAttributes<HTMLModusWcThemeSwitcherElement>;
             /**
              * A customizable input component used to create time inputs.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-time-input": LocalJSX.ModusWcTimeInput & JSXBase.HTMLAttributes<HTMLModusWcTimeInputElement>;
             /**
              * A customizable toast component used to stack elements, positioned on the corner of a page.
              * The component supports a `<slot>` for injecting additional custom content inside the toast.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-toast": LocalJSX.ModusWcToast & JSXBase.HTMLAttributes<HTMLModusWcToastElement>;
             /**
              * A customizable toolbar component used to organize content across the entire page.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-toolbar": LocalJSX.ModusWcToolbar & JSXBase.HTMLAttributes<HTMLModusWcToolbarElement>;
             /**
              * A customizable tooltip component used to create tooltips with different content.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-tooltip": LocalJSX.ModusWcTooltip & JSXBase.HTMLAttributes<HTMLModusWcTooltipElement>;
             /**
              * A customizable typography component used to render text with different sizes, variants, and weights.
-             * Adheres to WCAG 2.2 standards.
              */
             "modus-wc-typography": LocalJSX.ModusWcTypography & JSXBase.HTMLAttributes<HTMLModusWcTypographyElement>;
         }

--- a/src/components/modus-wc-accordion/modus-wc-accordion.tsx
+++ b/src/components/modus-wc-accordion/modus-wc-accordion.tsx
@@ -13,8 +13,6 @@ import { Attributes, inheritAriaAttributes } from '../utils';
  * A customizable accordion component used for showing and hiding related groups of content.
  *
  * The component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-accordion',

--- a/src/components/modus-wc-accordion/readme.md
+++ b/src/components/modus-wc-accordion/readme.md
@@ -11,8 +11,6 @@ A customizable accordion component used for showing and hiding related groups of
 
 The component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                 | Type                  | Default |

--- a/src/components/modus-wc-alert/modus-wc-alert.tsx
+++ b/src/components/modus-wc-alert/modus-wc-alert.tsx
@@ -18,9 +18,7 @@ import { WarningSolidIcon } from '../../icons/warning-solid.icon';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable alert component used to inform the user about important events.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable alert component used to inform the user about important events
  */
 @Component({
   tag: 'modus-wc-alert',

--- a/src/components/modus-wc-alert/readme.md
+++ b/src/components/modus-wc-alert/readme.md
@@ -7,19 +7,17 @@
 
 ## Overview
 
-A customizable alert component used to inform the user about important events.
-
-Adheres to WCAG 2.2 standards.
+A customizable alert component used to inform the user about important events
 
 ## Properties
 
 | Property                  | Attribute           | Description                                         | Type                                                       | Default     |
 | ------------------------- | ------------------- | --------------------------------------------------- | ---------------------------------------------------------- | ----------- |
-| `alertDescription`        | `alert-description` | The description of the alert. *                     | `string \| undefined`                                      | `undefined` |
-| `alertTitle` _(required)_ | `alert-title`       | The title of the alert. *                           | `string`                                                   | `undefined` |
+| `alertDescription`        | `alert-description` | The description of the alert.                       | `string \| undefined`                                      | `undefined` |
+| `alertTitle` _(required)_ | `alert-title`       | The title of the alert.                             | `string`                                                   | `undefined` |
 | `customClass`             | `custom-class`      | Custom CSS class to apply to the outer div element. | `string \| undefined`                                      | `''`        |
 | `dismissible`             | `dismissible`       | Whether the alert has a dismiss button              | `boolean \| undefined`                                     | `false`     |
-| `icon`                    | `icon`              | The Modus icon to render. *                         | `string \| undefined`                                      | `undefined` |
+| `icon`                    | `icon`              | The Modus icon to render.                           | `string \| undefined`                                      | `undefined` |
 | `role`                    | `role`              | Role taken by the alert. Defaults to 'status'       | `"alert" \| "log" \| "marquee" \| "status" \| "timer"`     | `'status'`  |
 | `variant`                 | `variant`           | The variant of the alert.                           | `"error" \| "info" \| "success" \| "warning" \| undefined` | `'info'`    |
 

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -41,8 +41,6 @@ export interface IAutocompleteNoResults {
 
 /**
  * A customizable autocomplete component used to create searchable text inputs.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-autocomplete',

--- a/src/components/modus-wc-autocomplete/readme.md
+++ b/src/components/modus-wc-autocomplete/readme.md
@@ -9,8 +9,6 @@
 
 A customizable autocomplete component used to create searchable text inputs.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property        | Attribute         | Description                                                                                             | Type                                  | Default                                                                                                                              |

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -5,8 +5,6 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
  * A customizable avatar component used to create avatars with different images.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-avatar',

--- a/src/components/modus-wc-avatar/readme.md
+++ b/src/components/modus-wc-avatar/readme.md
@@ -9,8 +9,6 @@
 
 A customizable avatar component used to create avatars with different images.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property           | Attribute      | Description                                 | Type                                        | Default     |

--- a/src/components/modus-wc-badge/modus-wc-badge.tsx
+++ b/src/components/modus-wc-badge/modus-wc-badge.tsx
@@ -9,8 +9,6 @@ const ALERT_COLORS = ['success', 'warning', 'danger'];
  * A customizable badge component used to create badges with different sizes, types, and colors.
  *
  * The component supports a `<slot>` for injecting content within the badge.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-badge',

--- a/src/components/modus-wc-badge/readme.md
+++ b/src/components/modus-wc-badge/readme.md
@@ -11,8 +11,6 @@ A customizable badge component used to create badges with different sizes, types
 
 The component supports a `<slot>` for injecting content within the badge.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                    | Type                                                                                              | Default     |

--- a/src/components/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
+++ b/src/components/modus-wc-breadcrumbs/modus-wc-breadcrumbs.tsx
@@ -20,8 +20,6 @@ export interface IBreadcrumb {
 
 /**
  * A customizable breadcrumbs component used to help users navigate through a website.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-breadcrumbs',

--- a/src/components/modus-wc-breadcrumbs/readme.md
+++ b/src/components/modus-wc-breadcrumbs/readme.md
@@ -9,8 +9,6 @@
 
 A customizable breadcrumbs component used to help users navigate through a website.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                 | Type                                | Default |

--- a/src/components/modus-wc-button/modus-wc-button.tsx
+++ b/src/components/modus-wc-button/modus-wc-button.tsx
@@ -15,9 +15,7 @@ import { Attributes, inheritAriaAttributes, KEY } from '../utils';
 /**
  * A customizable button component used to create buttons with different sizes, variants, and types.
  *
- * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
- *
- * Adheres to WCAG 2.2 standards.
+ * The component supports a `<slot>` for injecting content within the button, similar to a native HTML button
  */
 @Component({
   tag: 'modus-wc-button',

--- a/src/components/modus-wc-button/readme.md
+++ b/src/components/modus-wc-button/readme.md
@@ -7,9 +7,7 @@
 
 A customizable button component used to create buttons with different sizes, variants, and types.
 
-The component supports a `<slot>` for injecting content within the button, similar to a native HTML button.
-
-Adheres to WCAG 2.2 standards.
+The component supports a `<slot>` for injecting content within the button, similar to a native HTML button
 
 ## Properties
 

--- a/src/components/modus-wc-card/modus-wc-card.tsx
+++ b/src/components/modus-wc-card/modus-wc-card.tsx
@@ -3,9 +3,7 @@ import { convertPropsToClasses } from './modus-wc-card.tailwind';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable card component used to group and display content in a way that is easily readable.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable card component used to group and display content in a way that is easily readable
  */
 @Component({
   tag: 'modus-wc-card',

--- a/src/components/modus-wc-card/readme.md
+++ b/src/components/modus-wc-card/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable card component used to group and display content in a way that is easily readable.
-
-Adheres to WCAG 2.2 standards.
+A customizable card component used to group and display content in a way that is easily readable
 
 ## Properties
 

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.tsx
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.tsx
@@ -12,9 +12,7 @@ import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable checkbox component.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable checkbox component
  */
 @Component({
   tag: 'modus-wc-checkbox',

--- a/src/components/modus-wc-checkbox/readme.md
+++ b/src/components/modus-wc-checkbox/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable checkbox component.
-
-Adheres to WCAG 2.2 standards.
+A customizable checkbox component
 
 ## Properties
 

--- a/src/components/modus-wc-chip/modus-wc-chip.tsx
+++ b/src/components/modus-wc-chip/modus-wc-chip.tsx
@@ -13,9 +13,7 @@ import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes, KEY } from '../utils';
 
 /**
- * A customizable chip component used to display information in a compact area.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable chip component used to display information in a compact area
  */
 @Component({
   tag: 'modus-wc-chip',

--- a/src/components/modus-wc-chip/readme.md
+++ b/src/components/modus-wc-chip/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable chip component used to display information in a compact area.
-
-Adheres to WCAG 2.2 standards.
+A customizable chip component used to display information in a compact area
 
 ## Properties
 

--- a/src/components/modus-wc-collapse/modus-wc-collapse.tsx
+++ b/src/components/modus-wc-collapse/modus-wc-collapse.tsx
@@ -41,8 +41,6 @@ export interface ICollapseOptions {
  *
  * The component supports a 'header' and 'content' `<slot>` for injecting custom HTML.
  * Do not set
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-collapse',

--- a/src/components/modus-wc-collapse/readme.md
+++ b/src/components/modus-wc-collapse/readme.md
@@ -12,8 +12,6 @@ A customizable collapse component used for showing and hiding content.
 The component supports a 'header' and 'content' `<slot>` for injecting custom HTML.
 Do not set
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                                                                                                           | Type                            | Default     |

--- a/src/components/modus-wc-divider/modus-wc-divider.tsx
+++ b/src/components/modus-wc-divider/modus-wc-divider.tsx
@@ -4,9 +4,7 @@ import { Orientation } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable divider component used to separate content horizontally or vertically.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable divider component used to separate content horizontally or vertically
  */
 @Component({
   tag: 'modus-wc-divider',

--- a/src/components/modus-wc-divider/readme.md
+++ b/src/components/modus-wc-divider/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable divider component used to separate content horizontally or vertically.
-
-Adheres to WCAG 2.2 standards.
+A customizable divider component used to separate content horizontally or vertically
 
 ## Properties
 

--- a/src/components/modus-wc-icon/modus-wc-icon.tsx
+++ b/src/components/modus-wc-icon/modus-wc-icon.tsx
@@ -6,8 +6,7 @@ import { Attributes, inheritAriaAttributes } from '../utils';
  * A customizable icon component used to render Modus icons.
  *
  * <b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
- *
- * Adheres to WCAG 2.2 standards.
+
  */
 @Component({
   tag: 'modus-wc-icon',

--- a/src/components/modus-wc-icon/readme.md
+++ b/src/components/modus-wc-icon/readme.md
@@ -11,8 +11,6 @@ A customizable icon component used to render Modus icons.
 
 <b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property            | Attribute      | Description                                                                                                              | Type                                        | Default     |

--- a/src/components/modus-wc-input-feedback/modus-wc-input-feedback.tsx
+++ b/src/components/modus-wc-input-feedback/modus-wc-input-feedback.tsx
@@ -12,8 +12,7 @@ export type IInputFeedbackLevel = 'error' | 'info' | 'success' | 'warning';
  * A customizable feedback component used to provide additional context related to form input interactions.
  *
  * <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
- *
- * Adheres to WCAG 2.2 standards.
+
  */
 @Component({
   tag: 'modus-wc-input-feedback',

--- a/src/components/modus-wc-input-feedback/readme.md
+++ b/src/components/modus-wc-input-feedback/readme.md
@@ -11,8 +11,6 @@ A customizable feedback component used to provide additional context related to 
 
 <b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property             | Attribute      | Description                                                   | Type                                          | Default     |
@@ -28,7 +26,6 @@ Adheres to WCAG 2.2 standards.
 
 ### Used by
 
- - [modus-wc-date](../modus-wc-date)
  - [modus-wc-number-input](../modus-wc-number-input)
  - [modus-wc-select](../modus-wc-select)
  - [modus-wc-text-input](../modus-wc-text-input)
@@ -43,7 +40,6 @@ Adheres to WCAG 2.2 standards.
 ```mermaid
 graph TD;
   modus-wc-input-feedback --> modus-wc-icon
-  modus-wc-date --> modus-wc-input-feedback
   modus-wc-number-input --> modus-wc-input-feedback
   modus-wc-select --> modus-wc-input-feedback
   modus-wc-text-input --> modus-wc-input-feedback

--- a/src/components/modus-wc-input-label/modus-wc-input-label.tsx
+++ b/src/components/modus-wc-input-label/modus-wc-input-label.tsx
@@ -5,9 +5,7 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 /**
  * A customizable input label component.
  *
- * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
- *
- * Adheres to WCAG 2.2 standards.
+ * The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text
  */
 @Component({
   tag: 'modus-wc-input-label',

--- a/src/components/modus-wc-input-label/readme.md
+++ b/src/components/modus-wc-input-label/readme.md
@@ -9,9 +9,7 @@
 
 A customizable input label component.
 
-The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.
-
-Adheres to WCAG 2.2 standards.
+The component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text
 
 ## Properties
 
@@ -31,7 +29,6 @@ Adheres to WCAG 2.2 standards.
 
  - [modus-wc-autocomplete](../modus-wc-autocomplete)
  - [modus-wc-checkbox](../modus-wc-checkbox)
- - [modus-wc-date](../modus-wc-date)
  - [modus-wc-number-input](../modus-wc-number-input)
  - [modus-wc-progress](../modus-wc-progress)
  - [modus-wc-radio](../modus-wc-radio)
@@ -47,7 +44,6 @@ Adheres to WCAG 2.2 standards.
 graph TD;
   modus-wc-autocomplete --> modus-wc-input-label
   modus-wc-checkbox --> modus-wc-input-label
-  modus-wc-date --> modus-wc-input-label
   modus-wc-number-input --> modus-wc-input-label
   modus-wc-progress --> modus-wc-input-label
   modus-wc-radio --> modus-wc-input-label

--- a/src/components/modus-wc-loader/modus-wc-loader.tsx
+++ b/src/components/modus-wc-loader/modus-wc-loader.tsx
@@ -22,9 +22,7 @@ export type LoaderColor =
   | 'error';
 
 /**
- * A customizable loader component used to indicate the loading of content.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable loader component used to indicate the loading of content
  */
 @Component({
   tag: 'modus-wc-loader',

--- a/src/components/modus-wc-loader/readme.md
+++ b/src/components/modus-wc-loader/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable loader component used to indicate the loading of content.
-
-Adheres to WCAG 2.2 standards.
+A customizable loader component used to indicate the loading of content
 
 ## Properties
 

--- a/src/components/modus-wc-menu-item/modus-wc-menu-item.tsx
+++ b/src/components/modus-wc-menu-item/modus-wc-menu-item.tsx
@@ -12,9 +12,7 @@ import { DaisySize, ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable menu item component used to display the item portion of a menu.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable menu item component used to display the item portion of a menu
  */
 @Component({
   tag: 'modus-wc-menu-item',

--- a/src/components/modus-wc-menu-item/readme.md
+++ b/src/components/modus-wc-menu-item/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable menu item component used to display the item portion of a menu.
-
-Adheres to WCAG 2.2 standards.
+A customizable menu item component used to display the item portion of a menu
 
 ## Properties
 

--- a/src/components/modus-wc-menu/modus-wc-menu.tsx
+++ b/src/components/modus-wc-menu/modus-wc-menu.tsx
@@ -6,9 +6,7 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 /**
  * A customizable menu component used to display a list of li elements vertically or horizontally.
  *
- * The component supports a `<slot>` for injecting custom li elements inside the ul.
- *
- * Adheres to WCAG 2.2 standards.
+ * The component supports a `<slot>` for injecting custom li elements inside the ul
  */
 @Component({
   tag: 'modus-wc-menu',

--- a/src/components/modus-wc-menu/readme.md
+++ b/src/components/modus-wc-menu/readme.md
@@ -9,9 +9,7 @@
 
 A customizable menu component used to display a list of li elements vertically or horizontally.
 
-The component supports a `<slot>` for injecting custom li elements inside the ul.
-
-Adheres to WCAG 2.2 standards.
+The component supports a `<slot>` for injecting custom li elements inside the ul
 
 ## Properties
 

--- a/src/components/modus-wc-modal/modus-wc-modal.tsx
+++ b/src/components/modus-wc-modal/modus-wc-modal.tsx
@@ -8,9 +8,7 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 /**
  * A customizable modal component used to display content in a dialog.
  *
- * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML.
- *
- * Adheres to WCAG 2.2 standards.
+ * The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML
  */
 @Component({
   tag: 'modus-wc-modal',

--- a/src/components/modus-wc-modal/readme.md
+++ b/src/components/modus-wc-modal/readme.md
@@ -9,9 +9,7 @@
 
 A customizable modal component used to display content in a dialog.
 
-The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML.
-
-Adheres to WCAG 2.2 standards.
+The component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML
 
 ## Properties
 

--- a/src/components/modus-wc-navbar/modus-wc-navbar.tsx
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.tsx
@@ -70,9 +70,7 @@ export interface INavbarUserCard {
  * A customizable navbar component used for top level navigation of all Trimble applications.
  *
  * The component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.
- * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML.
- *
- * Adheres to WCAG 2.2 standards.
+ * It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML
  */
 @Component({
   tag: 'modus-wc-navbar',

--- a/src/components/modus-wc-navbar/readme.md
+++ b/src/components/modus-wc-navbar/readme.md
@@ -10,9 +10,7 @@
 A customizable navbar component used for top level navigation of all Trimble applications.
 
 The component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.
-It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML.
-
-Adheres to WCAG 2.2 standards.
+It also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML
 
 ## Properties
 

--- a/src/components/modus-wc-number-input/modus-wc-number-input.tsx
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.tsx
@@ -12,9 +12,7 @@ import { IInputFeedbackProp, ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable input component used to create number inputs with types.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable input component used to create number inputs with types
  */
 @Component({
   tag: 'modus-wc-number-input',

--- a/src/components/modus-wc-number-input/readme.md
+++ b/src/components/modus-wc-number-input/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable input component used to create number inputs with types.
-
-Adheres to WCAG 2.2 standards.
+A customizable input component used to create number inputs with types
 
 ## Properties
 

--- a/src/components/modus-wc-pagination/modus-wc-pagination.tsx
+++ b/src/components/modus-wc-pagination/modus-wc-pagination.tsx
@@ -38,9 +38,7 @@ export interface IPageChange {
 }
 
 /**
- * Pagination component to navigate through pages of content.
- *
- * Adheres to WCAG 2.2 standards.
+ * Pagination component to navigate through pages of content
  */
 @Component({
   tag: 'modus-wc-pagination',

--- a/src/components/modus-wc-pagination/readme.md
+++ b/src/components/modus-wc-pagination/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-Pagination component to navigate through pages of content.
-
-Adheres to WCAG 2.2 standards.
+Pagination component to navigate through pages of content
 
 ## Properties
 

--- a/src/components/modus-wc-progress/modus-wc-progress.tsx
+++ b/src/components/modus-wc-progress/modus-wc-progress.tsx
@@ -5,9 +5,7 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 /**
  * A customizable progress component used to show the progress of a task or show the passing of time.
  *
- * The radial variant supports slotting in custom HTML to be displayed within the progress circle.
- *
- * Adheres to WCAG 2.2 standards.
+ * The radial variant supports slotting in custom HTML to be displayed within the progress circle
  */
 @Component({
   tag: 'modus-wc-progress',

--- a/src/components/modus-wc-progress/readme.md
+++ b/src/components/modus-wc-progress/readme.md
@@ -9,9 +9,7 @@
 
 A customizable progress component used to show the progress of a task or show the passing of time.
 
-The radial variant supports slotting in custom HTML to be displayed within the progress circle.
-
-Adheres to WCAG 2.2 standards.
+The radial variant supports slotting in custom HTML to be displayed within the progress circle
 
 ## Properties
 

--- a/src/components/modus-wc-radio/modus-wc-radio.tsx
+++ b/src/components/modus-wc-radio/modus-wc-radio.tsx
@@ -13,9 +13,7 @@ import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable radio component.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable radio component
  */
 @Component({
   tag: 'modus-wc-radio',

--- a/src/components/modus-wc-radio/readme.md
+++ b/src/components/modus-wc-radio/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable radio component.
-
-Adheres to WCAG 2.2 standards.
+A customizable radio component
 
 ## Properties
 

--- a/src/components/modus-wc-rating/modus-wc-rating.tsx
+++ b/src/components/modus-wc-rating/modus-wc-rating.tsx
@@ -21,9 +21,7 @@ export interface IRatingChange {
 export type ModusWcRatingVariant = 'heart' | 'smiley' | 'star' | 'thumb';
 
 /**
- * A rating component that allows users to choose a rating from predefined options.
- *
- * Adheres to WCAG 2.2 standards.
+ * A rating component that allows users to choose a rating from predefined options
  */
 @Component({
   tag: 'modus-wc-rating',

--- a/src/components/modus-wc-rating/readme.md
+++ b/src/components/modus-wc-rating/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A rating component that allows users to choose a rating from predefined options.
-
-Adheres to WCAG 2.2 standards.
+A rating component that allows users to choose a rating from predefined options
 
 ## Properties
 

--- a/src/components/modus-wc-select/modus-wc-select.tsx
+++ b/src/components/modus-wc-select/modus-wc-select.tsx
@@ -21,9 +21,7 @@ export interface ISelectOption {
 }
 
 /**
- * A customizable select component used to pick a value from a list of options.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable select component used to pick a value from a list of options
  */
 @Component({
   tag: 'modus-wc-select',

--- a/src/components/modus-wc-select/readme.md
+++ b/src/components/modus-wc-select/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable select component used to pick a value from a list of options.
-
-Adheres to WCAG 2.2 standards.
+A customizable select component used to pick a value from a list of options
 
 ## Properties
 

--- a/src/components/modus-wc-skeleton/modus-wc-skeleton.tsx
+++ b/src/components/modus-wc-skeleton/modus-wc-skeleton.tsx
@@ -3,9 +3,7 @@ import { convertPropsToClasses } from './modus-wc-skeleton.tailwind';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable skeleton component used to create skeletons of various sizes and shapes.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable skeleton component used to create skeletons of various sizes and shapes
  */
 @Component({
   tag: 'modus-wc-skeleton',

--- a/src/components/modus-wc-skeleton/readme.md
+++ b/src/components/modus-wc-skeleton/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable skeleton component used to create skeletons of various sizes and shapes.
-
-Adheres to WCAG 2.2 standards.
+A customizable skeleton component used to create skeletons of various sizes and shapes
 
 ## Properties
 

--- a/src/components/modus-wc-slider/modus-wc-slider.tsx
+++ b/src/components/modus-wc-slider/modus-wc-slider.tsx
@@ -12,9 +12,7 @@ import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable slider component.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable slider component
  */
 @Component({
   tag: 'modus-wc-slider',

--- a/src/components/modus-wc-slider/readme.md
+++ b/src/components/modus-wc-slider/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable slider component.
-
-Adheres to WCAG 2.2 standards.
+A customizable slider component
 
 ## Properties
 

--- a/src/components/modus-wc-stepper/modus-wc-stepper.tsx
+++ b/src/components/modus-wc-stepper/modus-wc-stepper.tsx
@@ -24,8 +24,6 @@ export interface IStepperItem {
 
 /**
  * Used to show a list of steps in a process.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-stepper',

--- a/src/components/modus-wc-stepper/readme.md
+++ b/src/components/modus-wc-stepper/readme.md
@@ -9,8 +9,6 @@
 
 Used to show a list of steps in a process.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                     | Type                                      | Default     |

--- a/src/components/modus-wc-switch/modus-wc-switch.tsx
+++ b/src/components/modus-wc-switch/modus-wc-switch.tsx
@@ -13,9 +13,7 @@ import { ModusSize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable checkbox component.
- *
- * Adheres to WCAG 2.2 standards.
+ * A customizable checkbox component
  */
 @Component({
   tag: 'modus-wc-switch',

--- a/src/components/modus-wc-switch/readme.md
+++ b/src/components/modus-wc-switch/readme.md
@@ -7,9 +7,7 @@
 
 ## Overview
 
-A customizable checkbox component.
-
-Adheres to WCAG 2.2 standards.
+A customizable checkbox component
 
 ## Properties
 

--- a/src/components/modus-wc-table/modus-wc-table.tsx
+++ b/src/components/modus-wc-table/modus-wc-table.tsx
@@ -30,8 +30,6 @@ export interface ITableColumn {
 
 /**
  * A customizable table component used to show a list of data in a table format.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-table',

--- a/src/components/modus-wc-table/readme.md
+++ b/src/components/modus-wc-table/readme.md
@@ -9,8 +9,6 @@
 
 A customizable table component used to show a list of data in a table format.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property               | Attribute      | Description                                                                        | Type                                      | Default         |

--- a/src/components/modus-wc-tabs/modus-wc-tabs.tsx
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.tsx
@@ -34,8 +34,6 @@ export interface ITab {
 
 /**
  * A customizable tabs component used to create groups of tabs.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-tabs',

--- a/src/components/modus-wc-tabs/readme.md
+++ b/src/components/modus-wc-tabs/readme.md
@@ -9,8 +9,6 @@
 
 A customizable tabs component used to create groups of tabs.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property         | Attribute          | Description                                 | Type                                                       | Default      |

--- a/src/components/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.tsx
@@ -20,8 +20,6 @@ import { Attributes, inheritAriaAttributes, inheritAttributes } from '../utils';
 
 /**
  * A customizable input component used to create text inputs with types.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-text-input',

--- a/src/components/modus-wc-text-input/readme.md
+++ b/src/components/modus-wc-text-input/readme.md
@@ -9,8 +9,6 @@
 
 A customizable input component used to create text inputs with types.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property         | Attribute          | Description                                                                                                                                                              | Type                                                                                                                                                  | Default        |

--- a/src/components/modus-wc-textarea/modus-wc-textarea.tsx
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.tsx
@@ -13,8 +13,6 @@ import { Attributes, inheritAriaAttributes, inheritAttributes } from '../utils';
 
 /**
  * A customizable textarea component.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-textarea',

--- a/src/components/modus-wc-textarea/readme.md
+++ b/src/components/modus-wc-textarea/readme.md
@@ -9,8 +9,6 @@
 
 A customizable textarea component.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property        | Attribute         | Description                                                                     | Type                                                                                   | Default     |

--- a/src/components/modus-wc-theme-switcher/modus-wc-theme-switcher.tsx
+++ b/src/components/modus-wc-theme-switcher/modus-wc-theme-switcher.tsx
@@ -18,8 +18,6 @@ import { Attributes, inheritAriaAttributes } from '../utils';
  * A theme switcher component used to toggle the application theme and/or mode.
  *
  * Allows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-theme-switcher',

--- a/src/components/modus-wc-theme-switcher/readme.md
+++ b/src/components/modus-wc-theme-switcher/readme.md
@@ -11,8 +11,6 @@ A theme switcher component used to toggle the application theme and/or mode.
 
 Allows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                              | Type                  | Default |

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tsx
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tsx
@@ -14,8 +14,6 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
  * A customizable input component used to create time inputs.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-time-input',

--- a/src/components/modus-wc-time-input/readme.md
+++ b/src/components/modus-wc-time-input/readme.md
@@ -9,8 +9,6 @@
 
 A customizable input component used to create time inputs.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property          | Attribute          | Description                                                                                                                                                                                                                                                                  | Type                                | Default     |

--- a/src/components/modus-wc-toast/modus-wc-toast.tsx
+++ b/src/components/modus-wc-toast/modus-wc-toast.tsx
@@ -17,8 +17,6 @@ export type ToastPosition =
  * A customizable toast component used to stack elements, positioned on the corner of a page.
  *
  * The component supports a `<slot>` for injecting additional custom content inside the toast.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-toast',

--- a/src/components/modus-wc-toast/readme.md
+++ b/src/components/modus-wc-toast/readme.md
@@ -11,8 +11,6 @@ A customizable toast component used to stack elements, positioned on the corner 
 
 The component supports a `<slot>` for injecting additional custom content inside the toast.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                        | Type                                                                                                                                                              | Default     |

--- a/src/components/modus-wc-toolbar/modus-wc-toolbar.tsx
+++ b/src/components/modus-wc-toolbar/modus-wc-toolbar.tsx
@@ -3,8 +3,6 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
  * A customizable toolbar component used to organize content across the entire page.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-toolbar',

--- a/src/components/modus-wc-toolbar/readme.md
+++ b/src/components/modus-wc-toolbar/readme.md
@@ -9,8 +9,6 @@
 
 A customizable toolbar component used to organize content across the entire page.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                 | Type                  | Default |

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
@@ -4,8 +4,6 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
  * A customizable tooltip component used to create tooltips with different content.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-tooltip',

--- a/src/components/modus-wc-tooltip/readme.md
+++ b/src/components/modus-wc-tooltip/readme.md
@@ -9,8 +9,6 @@
 
 A customizable tooltip component used to create tooltips with different content.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                                                                             | Type                                                            | Default     |

--- a/src/components/modus-wc-typography/modus-wc-typography.tsx
+++ b/src/components/modus-wc-typography/modus-wc-typography.tsx
@@ -17,8 +17,6 @@ export type TypographyWeight = 'light' | 'normal' | 'semibold' | 'bold';
 
 /**
  * A customizable typography component used to render text with different sizes, variants, and weights.
- *
- * Adheres to WCAG 2.2 standards.
  */
 @Component({
   tag: 'modus-wc-typography',

--- a/src/components/modus-wc-typography/readme.md
+++ b/src/components/modus-wc-typography/readme.md
@@ -9,8 +9,6 @@
 
 A customizable typography component used to render text with different sizes, variants, and weights.
 
-Adheres to WCAG 2.2 standards.
-
 ## Properties
 
 | Property      | Attribute      | Description                                          | Type                                                            | Default    |

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -8,7 +8,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable accordion component used for showing and hiding related groups of content.\r\n\r\nThe component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable accordion component used for showing and hiding related groups of content.\n\nThe component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.",
           "name": "ModusWcAccordion",
           "members": [
             {
@@ -41,7 +41,7 @@
               "kind": "field",
               "name": "expandedChange",
               "type": {
-                "text": "EventEmitter<{\r\n    expanded: boolean;\r\n    index: number;\r\n  }>"
+                "text": "EventEmitter<{\n    expanded: boolean;\n    index: number;\n  }>"
               },
               "description": "When a collapse expanded state is changed, this event outputs the relevant index and state"
             }
@@ -74,7 +74,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable alert component used to inform the user about important events.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable alert component used to inform the user about important events",
           "name": "ModusWcAlert",
           "members": [
             {
@@ -115,7 +115,7 @@
             {
               "name": "alert-description",
               "fieldName": "alertDescription",
-              "description": "The description of the alert. *",
+              "description": "The description of the alert.",
               "type": {
                 "text": "string"
               }
@@ -123,7 +123,7 @@
             {
               "name": "alert-title",
               "fieldName": "alertTitle",
-              "description": "The title of the alert. *",
+              "description": "The title of the alert.",
               "type": {
                 "text": "string"
               }
@@ -149,7 +149,7 @@
             {
               "name": "icon",
               "fieldName": "icon",
-              "description": "The Modus icon to render. *",
+              "description": "The Modus icon to render.",
               "type": {
                 "text": "string"
               }
@@ -211,7 +211,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable autocomplete component used to create searchable text inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable autocomplete component used to create searchable text inputs.",
           "name": "ModusWcAutocomplete",
           "members": [
             {
@@ -266,7 +266,7 @@
               "name": "debounce-ms",
               "fieldName": "debounceMs",
               "default": "300",
-              "description": "The debounce timeout in milliseconds.\r\nSet to 0 to disable debouncing.",
+              "description": "The debounce timeout in milliseconds.\nSet to 0 to disable debouncing.",
               "type": {
                 "text": "number"
               }
@@ -300,7 +300,7 @@
               "name": "items",
               "fieldName": "items",
               "default": "[]",
-              "description": "The items to display in the menu.\r\nCreating a new array of items will ensure proper component re-render.",
+              "description": "The items to display in the menu.\nCreating a new array of items will ensure proper component re-render.",
               "type": {
                 "text": "IAutocompleteItem[]"
               }
@@ -436,7 +436,7 @@
               "type": {
                 "text": "EventEmitter<Event>"
               },
-              "description": "Event emitted when the input value changes.\r\nThis event is debounced based on the debounceMs prop."
+              "description": "Event emitted when the input value changes.\nThis event is debounced based on the debounceMs prop."
             },
             {
               "kind": "field",
@@ -483,7 +483,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable avatar component used to create avatars with different images.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable avatar component used to create avatars with different images.",
           "name": "ModusWcAvatar",
           "members": [
             {
@@ -575,7 +575,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\r\n\r\nThe component supports a `<slot>` for injecting content within the badge.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\n\nThe component supports a `<slot>` for injecting content within the badge.",
           "name": "ModusWcBadge",
           "members": [
             {
@@ -598,7 +598,7 @@
               "default": "'primary'",
               "description": "The color variant of the badge.",
               "type": {
-                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'high-contrast'\r\n    | 'success'\r\n    | 'warning'\r\n    | 'danger'"
+                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'high-contrast'\n    | 'success'\n    | 'warning'\n    | 'danger'"
               }
             },
             {
@@ -659,7 +659,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable breadcrumbs component used to help users navigate through a website.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable breadcrumbs component used to help users navigate through a website.",
           "name": "ModusWcBreadcrumbs",
           "members": [
             {
@@ -742,7 +742,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\r\n\r\nThe component supports a `<slot>` for injecting content within the button, similar to a native HTML button.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\n\nThe component supports a `<slot>` for injecting content within the button, similar to a native HTML button",
           "name": "ModusWcButton",
           "members": [
             {
@@ -879,7 +879,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable card component used to group and display content in a way that is easily readable.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable card component used to group and display content in a way that is easily readable",
           "name": "ModusWcCard",
           "members": [
             {
@@ -972,7 +972,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable checkbox component.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable checkbox component",
           "name": "ModusWcCheckbox",
           "members": [
             {
@@ -1132,7 +1132,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable chip component used to display information in a compact area.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable chip component used to display information in a compact area",
           "name": "ModusWcChip",
           "members": [
             {
@@ -1267,7 +1267,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable collapse component used for showing and hiding content.\r\n\r\nThe component supports a 'header' and 'content' `<slot>` for injecting custom HTML.\r\nDo not set\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable collapse component used for showing and hiding content.\n\nThe component supports a 'header' and 'content' `<slot>` for injecting custom HTML.\nDo not set",
           "name": "ModusWcCollapse",
           "members": [
             {
@@ -1334,7 +1334,7 @@
             {
               "name": "options",
               "fieldName": "options",
-              "description": "Configuration options for rendering the pre-laid out collapse component.\r\nDo not set this prop if you intend to use the 'header' slot.",
+              "description": "Configuration options for rendering the pre-laid out collapse component.\nDo not set this prop if you intend to use the 'header' slot.",
               "type": {
                 "text": "ICollapseOptions"
               }
@@ -1375,203 +1375,11 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/modus-wc-date/modus-wc-date.tsx",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "A customizable date picker component used to create date inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
-          "name": "ModusWcDate",
-          "members": [
-            {
-              "kind": "field",
-              "name": "el",
-              "type": {
-                "text": "HTMLElement"
-              },
-              "description": "Reference to the host element"
-            },
-            {
-              "kind": "method",
-              "name": "render"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "bordered",
-              "fieldName": "bordered",
-              "default": "true",
-              "description": "Indicates that the input should have a border.",
-              "type": {
-                "text": "boolean"
-              }
-            },
-            {
-              "name": "custom-class",
-              "fieldName": "customClass",
-              "default": "''",
-              "description": "Custom CSS class to apply to the input.",
-              "type": {
-                "text": "string"
-              }
-            },
-            {
-              "name": "disabled",
-              "fieldName": "disabled",
-              "default": "false",
-              "description": "Whether the form control is disabled.",
-              "type": {
-                "text": "boolean"
-              }
-            },
-            {
-              "name": "feedback",
-              "fieldName": "feedback",
-              "description": "Feedback to render below the input.",
-              "type": {
-                "text": "IInputFeedbackProp"
-              }
-            },
-            {
-              "name": "input-id",
-              "fieldName": "inputId",
-              "description": "The ID of the input element.",
-              "type": {
-                "text": "string"
-              }
-            },
-            {
-              "name": "input-tab-index",
-              "fieldName": "inputTabIndex",
-              "description": "Determine the control's relative ordering for sequential focus navigation (typically with the Tab key).",
-              "type": {
-                "text": "number"
-              }
-            },
-            {
-              "name": "label",
-              "fieldName": "label",
-              "description": "The text to display within the label.",
-              "type": {
-                "text": "string"
-              }
-            },
-            {
-              "name": "max",
-              "fieldName": "max",
-              "description": "Maximum date value.",
-              "type": {
-                "text": "string"
-              }
-            },
-            {
-              "name": "min",
-              "fieldName": "min",
-              "description": "Minimum date value.",
-              "type": {
-                "text": "string"
-              }
-            },
-            {
-              "name": "name",
-              "fieldName": "name",
-              "description": "Name of the form control. Submitted with the form as part of a name/value pair.",
-              "type": {
-                "text": "string"
-              }
-            },
-            {
-              "name": "read-only",
-              "fieldName": "readOnly",
-              "default": "false",
-              "description": "Whether the value is editable.",
-              "type": {
-                "text": "boolean"
-              }
-            },
-            {
-              "name": "required",
-              "fieldName": "required",
-              "default": "false",
-              "description": "A value is required or must be checked for the form to be submittable.",
-              "type": {
-                "text": "boolean"
-              }
-            },
-            {
-              "name": "size",
-              "fieldName": "size",
-              "default": "'md'",
-              "description": "The size of the input.",
-              "type": {
-                "text": "ModusSize"
-              }
-            },
-            {
-              "name": "value",
-              "fieldName": "value",
-              "default": "''",
-              "description": "The value of the control (yyyy-mm-dd).",
-              "type": {
-                "text": "string"
-              }
-            }
-          ],
-          "tagName": "modus-wc-date",
-          "events": [
-            {
-              "kind": "field",
-              "name": "inputBlur",
-              "type": {
-                "text": "EventEmitter<FocusEvent>"
-              },
-              "description": "Event emitted when the input loses focus."
-            },
-            {
-              "kind": "field",
-              "name": "inputChange",
-              "type": {
-                "text": "EventEmitter<InputEvent>"
-              },
-              "description": "Event emitted when the input value changes."
-            },
-            {
-              "kind": "field",
-              "name": "inputFocus",
-              "type": {
-                "text": "EventEmitter<FocusEvent>"
-              },
-              "description": "Event emitted when the input gains focus."
-            }
-          ],
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "ModusWcDate",
-          "declaration": {
-            "name": "ModusWcDate",
-            "module": "src/components/modus-wc-date/modus-wc-date.tsx"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "modus-wc-date",
-          "declaration": {
-            "name": "ModusWcDate",
-            "module": "src/components/modus-wc-date/modus-wc-date.tsx"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/components/modus-wc-divider/modus-wc-divider.tsx",
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable divider component used to separate content horizontally or vertically.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable divider component used to separate content horizontally or vertically",
           "name": "ModusWcDivider",
           "members": [
             {
@@ -1594,7 +1402,7 @@
               "default": "'tertiary'",
               "description": "The color of the divider line.",
               "type": {
-                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'high-contrast'\r\n    | 'success'\r\n    | 'warning'\r\n    | 'danger'"
+                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'high-contrast'\n    | 'success'\n    | 'warning'\n    | 'danger'"
               }
             },
             {
@@ -1673,7 +1481,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable icon component used to render Modus icons.\r\n\r\n<b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable icon component used to render Modus icons.\n\n<b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
           "name": "ModusWcIcon",
           "members": [
             {
@@ -1756,7 +1564,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable feedback component used to provide additional context related to form input interactions.\r\n\r\n<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable feedback component used to provide additional context related to form input interactions.\n\n<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
           "name": "ModusWcInputFeedback",
           "members": [
             {
@@ -1848,7 +1656,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input label component.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input label component.\n\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text",
           "name": "ModusWcInputLabel",
           "members": [
             {
@@ -1947,7 +1755,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable loader component used to indicate the loading of content.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable loader component used to indicate the loading of content",
           "name": "ModusWcLoader",
           "members": [
             {
@@ -2031,7 +1839,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable menu item component used to display the item portion of a menu.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable menu item component used to display the item portion of a menu",
           "name": "ModusWcMenuItem",
           "members": [
             {
@@ -2171,7 +1979,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable menu component used to display a list of li elements vertically or horizontally.\r\n\r\nThe component supports a `<slot>` for injecting custom li elements inside the ul.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable menu component used to display a list of li elements vertically or horizontally.\n\nThe component supports a `<slot>` for injecting custom li elements inside the ul",
           "name": "ModusWcMenu",
           "members": [
             {
@@ -2254,7 +2062,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable modal component used to display content in a dialog.\r\n\r\nThe component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable modal component used to display content in a dialog.\n\nThe component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML",
           "name": "ModusWcModal",
           "members": [
             {
@@ -2275,7 +2083,7 @@
               "name": "backdrop",
               "fieldName": "backdrop",
               "default": "'default'",
-              "description": "The modal's backdrop.\r\nSpecify 'static' for a backdrop that doesn't close the modal when clicked outside the modal content.",
+              "description": "The modal's backdrop.\nSpecify 'static' for a backdrop that doesn't close the modal when clicked outside the modal content.",
               "type": {
                 "text": "'default' | 'static'"
               }
@@ -2364,7 +2172,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable navbar component used for top level navigation of all Trimble applications.\r\n\r\nThe component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.\r\nIt also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable navbar component used for top level navigation of all Trimble applications.\n\nThe component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.\nIt also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML",
           "name": "ModusWcNavbar",
           "members": [
             {
@@ -2643,7 +2451,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create number inputs with types.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create number inputs with types",
           "name": "ModusWcNumberInput",
           "members": [
             {
@@ -2724,7 +2532,7 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'numeric'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
                 "text": "'decimal' | 'none' | 'numeric'"
               }
@@ -2887,7 +2695,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "Pagination component to navigate through pages of content.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "Pagination component to navigate through pages of content",
           "name": "ModusWcPagination",
           "members": [
             {
@@ -2991,7 +2799,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable progress component used to show the progress of a task or show the passing of time.\r\n\r\nThe radial variant supports slotting in custom HTML to be displayed within the progress circle.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable progress component used to show the progress of a task or show the passing of time.\n\nThe radial variant supports slotting in custom HTML to be displayed within the progress circle",
           "name": "ModusWcProgress",
           "members": [
             {
@@ -3092,7 +2900,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable radio component.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable radio component",
           "name": "ModusWcRadio",
           "members": [
             {
@@ -3243,7 +3051,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A rating component that allows users to choose a rating from predefined options.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A rating component that allows users to choose a rating from predefined options",
           "name": "ModusWcRating",
           "members": [
             {
@@ -3370,7 +3178,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable select component used to pick a value from a list of options.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable select component used to pick a value from a list of options",
           "name": "ModusWcSelect",
           "members": [
             {
@@ -3546,7 +3354,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable skeleton component used to create skeletons of various sizes and shapes.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable skeleton component used to create skeletons of various sizes and shapes",
           "name": "ModusWcSkeleton",
           "members": [
             {
@@ -3630,7 +3438,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable slider component.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable slider component",
           "name": "ModusWcSlider",
           "members": [
             {
@@ -3805,7 +3613,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "Used to show a list of steps in a process.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "Used to show a list of steps in a process.",
           "name": "ModusWcStepper",
           "members": [
             {
@@ -3879,7 +3687,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable checkbox component.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable checkbox component",
           "name": "ModusWcSwitch",
           "members": [
             {
@@ -4045,7 +3853,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable table component used to show a list of data in a table format.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable table component used to show a list of data in a table format.",
           "name": "ModusWcTable",
           "members": [
             {
@@ -4112,7 +3920,7 @@
               "kind": "field",
               "name": "rowClick",
               "type": {
-                "text": "EventEmitter<{\r\n    row: Record<string, any>;\r\n    index: number;\r\n  }>"
+                "text": "EventEmitter<{\n    row: Record<string, any>;\n    index: number;\n  }>"
               },
               "description": "Emits when a row is clicked."
             }
@@ -4145,7 +3953,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable tabs component used to create groups of tabs.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable tabs component used to create groups of tabs.",
           "name": "ModusWcTabs",
           "members": [
             {
@@ -4211,7 +4019,7 @@
               "kind": "field",
               "name": "tabChange",
               "type": {
-                "text": "EventEmitter<{\r\n    previousTab: number;\r\n    newTab: number;\r\n  }>"
+                "text": "EventEmitter<{\n    previousTab: number;\n    newTab: number;\n  }>"
               },
               "description": "When a tab is switched to, this event outputs the relevant indices"
             }
@@ -4244,7 +4052,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create text inputs with types.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create text inputs with types.",
           "name": "ModusWcTextInput",
           "members": [
             {
@@ -4266,7 +4074,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
+                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
               }
             },
             {
@@ -4326,7 +4134,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
+                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
               }
             },
             {
@@ -4367,9 +4175,9 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'text'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
-                "text": "| 'decimal'\r\n    | 'email'\r\n    | 'none'\r\n    | 'numeric'\r\n    | 'search'\r\n    | 'tel'\r\n    | 'text'\r\n    | 'url'"
+                "text": "| 'decimal'\n    | 'email'\n    | 'none'\n    | 'numeric'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'url'"
               }
             },
             {
@@ -4530,7 +4338,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable textarea component.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable textarea component.",
           "name": "ModusWcTextarea",
           "members": [
             {
@@ -4587,7 +4395,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
+                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
               }
             },
             {
@@ -4747,7 +4555,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A theme switcher component used to toggle the application theme and/or mode.\r\n\r\nAllows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A theme switcher component used to toggle the application theme and/or mode.\n\nAllows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).",
           "name": "ModusWcThemeSwitcher",
           "members": [
             {
@@ -4816,7 +4624,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input component used to create time inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable input component used to create time inputs.",
           "name": "ModusWcTimeInput",
           "members": [
             {
@@ -4862,7 +4670,7 @@
             {
               "name": "datalist-id",
               "fieldName": "datalistId",
-              "description": "ID of a `<datalist>` element that contains pre-defined time options.\r\nThe value must be the ID of a `<datalist>` element in the same document.",
+              "description": "ID of a `<datalist>` element that contains pre-defined time options.\nThe value must be the ID of a `<datalist>` element in the same document.",
               "type": {
                 "text": "string"
               }
@@ -4963,7 +4771,7 @@
               "name": "show-seconds",
               "fieldName": "showSeconds",
               "default": "false",
-              "description": "Displays the time input format as `HH:mm:ss` if `true`.\r\nInternally sets the `step` to 1 second.\r\nIf a `step` value is provided, it will override this attribute.",
+              "description": "Displays the time input format as `HH:mm:ss` if `true`.\nInternally sets the `step` to 1 second.\nIf a `step` value is provided, it will override this attribute.",
               "type": {
                 "text": "boolean"
               }
@@ -4980,7 +4788,7 @@
             {
               "name": "step",
               "fieldName": "step",
-              "description": "Specifies the granularity that the `value` must adhere to.\r\nValue of step given in seconds. Default value is 60 seconds.\r\nOverrides the `seconds` attribute if both are provided.",
+              "description": "Specifies the granularity that the `value` must adhere to.\nValue of step given in seconds. Default value is 60 seconds.\nOverrides the `seconds` attribute if both are provided.",
               "type": {
                 "text": "number"
               }
@@ -4989,7 +4797,7 @@
               "name": "value",
               "fieldName": "value",
               "default": "''",
-              "description": "The value of the time input.\r\nAlways in 24-hour format that includes leading zeros:\r\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\r\nto be selected based on user's locale (or by the user agent).\r\nIf time includes seconds the format is always `HH:mm:ss`.",
+              "description": "The value of the time input.\nAlways in 24-hour format that includes leading zeros:\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\nto be selected based on user's locale (or by the user agent).\nIf time includes seconds the format is always `HH:mm:ss`.",
               "type": {
                 "text": "string"
               }
@@ -5050,7 +4858,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable toast component used to stack elements, positioned on the corner of a page.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the toast.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable toast component used to stack elements, positioned on the corner of a page.\n\nThe component supports a `<slot>` for injecting additional custom content inside the toast.",
           "name": "ModusWcToast",
           "members": [
             {
@@ -5145,7 +4953,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable toolbar component used to organize content across the entire page.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable toolbar component used to organize content across the entire page.",
           "name": "ModusWcToolbar",
           "members": [
             {
@@ -5202,7 +5010,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable tooltip component used to create tooltips with different content.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable tooltip component used to create tooltips with different content.",
           "name": "ModusWcTooltip",
           "members": [
             {
@@ -5302,7 +5110,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable typography component used to render text with different sizes, variants, and weights.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable typography component used to render text with different sizes, variants, and weights.",
           "name": "ModusWCTypography",
           "members": [
             {

--- a/src/stories/accessibility.mdx
+++ b/src/stories/accessibility.mdx
@@ -1,0 +1,32 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Documentation/Accessibility" />
+
+# Accessibility
+
+The Modus Web Components package is designed to be accessible by default. This means that the components are built with accessibility in mind and are tested to ensure they meet the [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/).
+
+Features:
+
+- Meet [minimum contrast requirements (Level AA)](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html).
+- Keyboard navigable where applicable.
+- Screen reader accessible.
+- Supports the [prefers-reduced-motion media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) to minimize the amount of non-essential motion.
+
+Found an accessibility issue? Please [report it at GitHub](https://github.com/trimble-oss/modus-web-components/issues/new?assignees=&labels=accessibility&template=accessibility-issue-report.md&title=).
+
+## For contributors
+
+The Storybook site has an Accessibility tab that can be used to test the components for accessibility issues. If you are contributing to the Modus Web Components package please ensure that your changes do not introduce accessibility issues. If there are any violations please address them before submitting your changes. If you are unsure, please reach out to the team for guidance.
+
+## Useful tools for testing your sites
+
+### Browser extensions
+
+- [axe DevTools](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
+- [Lighthouse](https://chromewebstore.google.com/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk)
+- [Microsoft Accessibility Insights](https://accessibilityinsights.io/downloads/)
+
+## Further Reading
+
+You can find more information on accessibility on the [Modus website](https://modus.trimble.com/foundations/accessibility/).


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Docs: remove repetitive 'Adheres to WCAG 2.2 standards'
Aside from being repetitive, it's also untrue for many components.
Instead this should be covered in the accessibility section.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #
