### PR TITLE
fix: navbar buttons visible in safari

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -55,11 +55,11 @@ export namespace Components {
      */
     interface ModusWcAlert {
         /**
-          * The description of the alert. *
+          * The description of the alert.
          */
         "alertDescription"?: string;
         /**
-          * The title of the alert. *
+          * The title of the alert.
          */
         "alertTitle": string;
         /**
@@ -71,7 +71,7 @@ export namespace Components {
          */
         "dismissible"?: boolean;
         /**
-          * The Modus icon to render. *
+          * The Modus icon to render.
          */
         "icon"?: string;
         /**
@@ -2537,11 +2537,11 @@ declare namespace LocalJSX {
      */
     interface ModusWcAlert {
         /**
-          * The description of the alert. *
+          * The description of the alert.
          */
         "alertDescription"?: string;
         /**
-          * The title of the alert. *
+          * The title of the alert.
          */
         "alertTitle": string;
         /**
@@ -2553,7 +2553,7 @@ declare namespace LocalJSX {
          */
         "dismissible"?: boolean;
         /**
-          * The Modus icon to render. *
+          * The Modus icon to render.
          */
         "icon"?: string;
         /**

--- a/src/components/modus-wc-alert/readme.md
+++ b/src/components/modus-wc-alert/readme.md
@@ -15,11 +15,11 @@ Adheres to WCAG 2.2 standards.
 
 | Property                  | Attribute           | Description                                         | Type                                                       | Default     |
 | ------------------------- | ------------------- | --------------------------------------------------- | ---------------------------------------------------------- | ----------- |
-| `alertDescription`        | `alert-description` | The description of the alert. *                     | `string \| undefined`                                      | `undefined` |
-| `alertTitle` _(required)_ | `alert-title`       | The title of the alert. *                           | `string`                                                   | `undefined` |
+| `alertDescription`        | `alert-description` | The description of the alert.                       | `string \| undefined`                                      | `undefined` |
+| `alertTitle` _(required)_ | `alert-title`       | The title of the alert.                             | `string`                                                   | `undefined` |
 | `customClass`             | `custom-class`      | Custom CSS class to apply to the outer div element. | `string \| undefined`                                      | `''`        |
 | `dismissible`             | `dismissible`       | Whether the alert has a dismiss button              | `boolean \| undefined`                                     | `false`     |
-| `icon`                    | `icon`              | The Modus icon to render. *                         | `string \| undefined`                                      | `undefined` |
+| `icon`                    | `icon`              | The Modus icon to render.                           | `string \| undefined`                                      | `undefined` |
 | `role`                    | `role`              | Role taken by the alert. Defaults to 'status'       | `"alert" \| "log" \| "marquee" \| "status" \| "timer"`     | `'status'`  |
 | `variant`                 | `variant`           | The variant of the alert.                           | `"error" \| "info" \| "success" \| "warning" \| undefined` | `'info'`    |
 

--- a/src/components/modus-wc-navbar/modus-wc-navbar.scss
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.scss
@@ -6,6 +6,10 @@ modus-wc-navbar .modus-wc-navbar {
   // Common button styles
   modus-wc-button {
     display: inline-flex;
+
+    svg {
+      height: 32px;
+    }
   }
 
   .modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -115,7 +115,7 @@
             {
               "name": "alert-description",
               "fieldName": "alertDescription",
-              "description": "The description of the alert. *",
+              "description": "The description of the alert.",
               "type": {
                 "text": "string"
               }
@@ -123,7 +123,7 @@
             {
               "name": "alert-title",
               "fieldName": "alertTitle",
-              "description": "The title of the alert. *",
+              "description": "The title of the alert.",
               "type": {
                 "text": "string"
               }
@@ -149,7 +149,7 @@
             {
               "name": "icon",
               "fieldName": "icon",
-              "description": "The Modus icon to render. *",
+              "description": "The Modus icon to render.",
               "type": {
                 "text": "string"
               }


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR sets the SVG height so that it is visible in Safari, looks fine in other browsers also.

Contains auto doc changes from another dev.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Manual

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #391 
