### PR TITLE
feat: add dropdown menu component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-alpha.1",
       "license": "MIT",
       "dependencies": {
+        "@floating-ui/dom": "^1.7.1",
         "@tanstack/table-core": "^8.21.3"
       },
       "devDependencies": {
@@ -1388,6 +1389,31 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
+      "integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
+      "integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.1",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@github/catalyst": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
     "test:update-snapshot": "stencil test --spec --update-snapshot",
     "test:watch": "stencil test --spec --watchAll"
   },
+  "dependencies": {
+    "@floating-ui/dom": "^1.7.1",
+    "@tanstack/table-core": "^8.21.3"
+  },
   "devDependencies": {
     "@eslint/js": "^9.26.0",
     "@stencil/angular-output-target": "^0.10.2",
@@ -288,8 +292,5 @@
   "volta": {
     "node": "18.20.5"
   },
-  "customElements": "src/custom-elements.json",
-  "dependencies": {
-    "@tanstack/table-core": "^8.21.3"
-  }
+  "customElements": "src/custom-elements.json"
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -6,7 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { IAutocompleteItem, IAutocompleteNoResults } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
-import { AutocompleteTypes, DaisySize, Density, IInputFeedbackProp, ModusSize, Orientation, TextFieldTypes } from "./components/types";
+import { AutocompleteTypes, DaisySize, Density, IInputFeedbackProp, ModusSize, Orientation, PopoverPlacement, TextFieldTypes } from "./components/types";
 import { IBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 import { ICollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
 import { IInputFeedbackLevel } from "./components/modus-wc-input-feedback/modus-wc-input-feedback";
@@ -23,7 +23,7 @@ import { IThemeConfig } from "./providers/theme/theme.types";
 import { ToastPosition } from "./components/modus-wc-toast/modus-wc-toast";
 import { TypographyVariant, TypographyWeight } from "./components/modus-wc-typography/modus-wc-typography";
 export { IAutocompleteItem, IAutocompleteNoResults } from "./components/modus-wc-autocomplete/modus-wc-autocomplete";
-export { AutocompleteTypes, DaisySize, Density, IInputFeedbackProp, ModusSize, Orientation, TextFieldTypes } from "./components/types";
+export { AutocompleteTypes, DaisySize, Density, IInputFeedbackProp, ModusSize, Orientation, PopoverPlacement, TextFieldTypes } from "./components/types";
 export { IBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 export { ICollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
 export { IInputFeedbackLevel } from "./components/modus-wc-input-feedback/modus-wc-input-feedback";
@@ -510,6 +510,55 @@ export namespace Components {
           * Whether the divider is responsive or not.
          */
         "responsive"?: boolean;
+    }
+    /**
+     * A customizable dropdown menu component used to render a button and toggleable menu.
+     */
+    interface ModusWcDropdownMenu {
+        /**
+          * The color variant of the button.
+         */
+        "buttonColor"?: | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'warning'
+    | 'danger';
+        /**
+          * The size of the button.
+         */
+        "buttonSize"?: DaisySize;
+        /**
+          * The variant of the button.
+         */
+        "buttonVariant"?: 'borderless' | 'filled' | 'outlined';
+        /**
+          * Custom CSS class to apply to the host element.
+         */
+        "customClass"?: string;
+        /**
+          * If true, the button will be disabled.
+         */
+        "disabled"?: boolean;
+        /**
+          * Indicates that the menu should have a border.
+         */
+        "menuBordered"?: boolean;
+        /**
+          * Distance between the button and menu in pixels.
+         */
+        "menuOffset"?: number;
+        /**
+          * The placement of the menu relative to the button.
+         */
+        "menuPlacement"?: PopoverPlacement;
+        /**
+          * The size of the menu.
+         */
+        "menuSize"?: ModusSize;
+        /**
+          * Indicates that the menu is visible.
+         */
+        "menuVisible": boolean;
     }
     /**
      * A customizable icon component used to render Modus icons.
@@ -1692,6 +1741,10 @@ export interface ModusWcDateCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusWcDateElement;
 }
+export interface ModusWcDropdownMenuCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLModusWcDropdownMenuElement;
+}
 export interface ModusWcMenuCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLModusWcMenuElement;
@@ -1990,6 +2043,26 @@ declare global {
     var HTMLModusWcDividerElement: {
         prototype: HTMLModusWcDividerElement;
         new (): HTMLModusWcDividerElement;
+    };
+    interface HTMLModusWcDropdownMenuElementEventMap {
+        "menuVisibilityChange": { isVisible: boolean };
+    }
+    /**
+     * A customizable dropdown menu component used to render a button and toggleable menu.
+     */
+    interface HTMLModusWcDropdownMenuElement extends Components.ModusWcDropdownMenu, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLModusWcDropdownMenuElementEventMap>(type: K, listener: (this: HTMLModusWcDropdownMenuElement, ev: ModusWcDropdownMenuCustomEvent<HTMLModusWcDropdownMenuElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLModusWcDropdownMenuElementEventMap>(type: K, listener: (this: HTMLModusWcDropdownMenuElement, ev: ModusWcDropdownMenuCustomEvent<HTMLModusWcDropdownMenuElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLModusWcDropdownMenuElement: {
+        prototype: HTMLModusWcDropdownMenuElement;
+        new (): HTMLModusWcDropdownMenuElement;
     };
     /**
      * A customizable icon component used to render Modus icons.
@@ -2507,6 +2580,7 @@ declare global {
         "modus-wc-collapse": HTMLModusWcCollapseElement;
         "modus-wc-date": HTMLModusWcDateElement;
         "modus-wc-divider": HTMLModusWcDividerElement;
+        "modus-wc-dropdown-menu": HTMLModusWcDropdownMenuElement;
         "modus-wc-icon": HTMLModusWcIconElement;
         "modus-wc-input-feedback": HTMLModusWcInputFeedbackElement;
         "modus-wc-input-label": HTMLModusWcInputLabelElement;
@@ -3085,6 +3159,59 @@ declare namespace LocalJSX {
           * Whether the divider is responsive or not.
          */
         "responsive"?: boolean;
+    }
+    /**
+     * A customizable dropdown menu component used to render a button and toggleable menu.
+     */
+    interface ModusWcDropdownMenu {
+        /**
+          * The color variant of the button.
+         */
+        "buttonColor"?: | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'warning'
+    | 'danger';
+        /**
+          * The size of the button.
+         */
+        "buttonSize"?: DaisySize;
+        /**
+          * The variant of the button.
+         */
+        "buttonVariant"?: 'borderless' | 'filled' | 'outlined';
+        /**
+          * Custom CSS class to apply to the host element.
+         */
+        "customClass"?: string;
+        /**
+          * If true, the button will be disabled.
+         */
+        "disabled"?: boolean;
+        /**
+          * Indicates that the menu should have a border.
+         */
+        "menuBordered"?: boolean;
+        /**
+          * Distance between the button and menu in pixels.
+         */
+        "menuOffset"?: number;
+        /**
+          * The placement of the menu relative to the button.
+         */
+        "menuPlacement"?: PopoverPlacement;
+        /**
+          * The size of the menu.
+         */
+        "menuSize"?: ModusSize;
+        /**
+          * Indicates that the menu is visible.
+         */
+        "menuVisible"?: boolean;
+        /**
+          * Event emitted when the menuVisible prop changes.
+         */
+        "onMenuVisibilityChange"?: (event: ModusWcDropdownMenuCustomEvent<{ isVisible: boolean }>) => void;
     }
     /**
      * A customizable icon component used to render Modus icons.
@@ -4465,6 +4592,7 @@ declare namespace LocalJSX {
         "modus-wc-collapse": ModusWcCollapse;
         "modus-wc-date": ModusWcDate;
         "modus-wc-divider": ModusWcDivider;
+        "modus-wc-dropdown-menu": ModusWcDropdownMenu;
         "modus-wc-icon": ModusWcIcon;
         "modus-wc-input-feedback": ModusWcInputFeedback;
         "modus-wc-input-label": ModusWcInputLabel;
@@ -4559,6 +4687,10 @@ declare module "@stencil/core" {
              * A customizable divider component used to separate content horizontally or vertically
              */
             "modus-wc-divider": LocalJSX.ModusWcDivider & JSXBase.HTMLAttributes<HTMLModusWcDividerElement>;
+            /**
+             * A customizable dropdown menu component used to render a button and toggleable menu.
+             */
+            "modus-wc-dropdown-menu": LocalJSX.ModusWcDropdownMenu & JSXBase.HTMLAttributes<HTMLModusWcDropdownMenuElement>;
             /**
              * A customizable icon component used to render Modus icons.
              * <b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>

--- a/src/components/modus-wc-button/readme.md
+++ b/src/components/modus-wc-button/readme.md
@@ -36,6 +36,7 @@ The component supports a `<slot>` for injecting content within the button, simil
 ### Used by
 
  - [modus-wc-alert](../modus-wc-alert)
+ - [modus-wc-dropdown-menu](../modus-wc-dropdown-menu)
  - [modus-wc-modal](../modus-wc-modal)
  - [modus-wc-navbar](../modus-wc-navbar)
 
@@ -43,6 +44,7 @@ The component supports a `<slot>` for injecting content within the button, simil
 ```mermaid
 graph TD;
   modus-wc-alert --> modus-wc-button
+  modus-wc-dropdown-menu --> modus-wc-button
   modus-wc-modal --> modus-wc-button
   modus-wc-navbar --> modus-wc-button
   style modus-wc-button fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/components/modus-wc-dropdown-menu/__snapshots__/modus-wc-dropdown-menu.spec.ts.snap
+++ b/src/components/modus-wc-dropdown-menu/__snapshots__/modus-wc-dropdown-menu.spec.ts.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modus-wc-dropdown-menu should render with custom props 1`] = `
+<modus-wc-dropdown-menu button-size="sm" button-variant="borderless" class="modus-wc-dropdown-menu test-class" custom-class="test-class" disabled="{true}" menu-bordered="{false}" menu-offset="0" menu-placement="right" menu-size="sm" menu-visible="{true}">
+  <!---->
+  <modus-wc-button>
+    <!---->
+    <button aria-expanded="true" aria-haspopup="true" class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-disabled modus-wc-btn-primary modus-wc-btn-sm" disabled="" tabindex="-1" type="button">
+      <div slot="button">
+        Button
+      </div>
+    </button>
+  </modus-wc-button>
+  <div class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: visible; opacity: 1; pointer-events: auto;">
+    <modus-wc-menu>
+      <!---->
+      <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-sm modus-wc-w-full" role="menu">
+      </ul>
+    </modus-wc-menu>
+  </div>
+</modus-wc-dropdown-menu>
+`;
+
+exports[`modus-wc-dropdown-menu should render with default props 1`] = `
+<modus-wc-dropdown-menu class="modus-wc-dropdown-menu">
+  <!---->
+  <modus-wc-button>
+    <!---->
+    <button aria-expanded="false" aria-haspopup="true" class="modus-wc-btn modus-wc-btn-filled modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
+      <div slot="button">
+        Button
+      </div>
+    </button>
+  </modus-wc-button>
+  <div aria-hidden="" class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: hidden; opacity: 0; pointer-events: none;">
+    <modus-wc-menu>
+      <!---->
+      <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-md modus-wc-w-full" role="menu">
+      </ul>
+    </modus-wc-menu>
+  </div>
+</modus-wc-dropdown-menu>
+`;
+
+exports[`modus-wc-dropdown-menu should render with menu items 1`] = `
+<modus-wc-dropdown-menu class="modus-wc-dropdown-menu" menu-visible="{true}">
+  <!---->
+  <modus-wc-button>
+    <!---->
+    <button aria-expanded="true" aria-haspopup="true" class="modus-wc-btn modus-wc-btn-filled modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
+      <div slot="button">
+        Button
+      </div>
+    </button>
+  </modus-wc-button>
+  <div class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: visible; opacity: 1; pointer-events: auto;">
+    <modus-wc-menu>
+      <!---->
+      <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-md modus-wc-w-full" role="menu">
+        <div slot="menu">
+          <modus-wc-menu-item label="Item One" value="1">
+            <modus-wc-menu-item label="Item Two" value="2">
+              <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
+                <button type="button">
+                  <div class="modus-wc-menu-item-content">
+                    <div class="modus-wc-menu-item-labels">
+                      <div>
+                        Item Two
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              </li>
+            </modus-wc-menu-item>
+            <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
+              <button type="button">
+                <div class="modus-wc-menu-item-content">
+                  <div class="modus-wc-menu-item-labels">
+                    <div>
+                      Item One
+                    </div>
+                  </div>
+                </div>
+              </button>
+            </li>
+          </modus-wc-menu-item>
+        </div>
+      </ul>
+    </modus-wc-menu>
+  </div>
+</modus-wc-dropdown-menu>
+`;

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.scss
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.scss
@@ -1,0 +1,13 @@
+/**
+* This component uses Tailwind CSS and DaisyUI.
+* Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
+*/
+
+modus-wc-dropdown-menu.modus-wc-dropdown-menu {
+  .menu-wrapper {
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: max-content;
+  }
+}

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.spec.ts
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.spec.ts
@@ -1,0 +1,128 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ModusWcDropdownMenu } from './modus-wc-dropdown-menu';
+import { ModusWcButton } from '../modus-wc-button/modus-wc-button';
+import { ModusWcMenu } from '../modus-wc-menu/modus-wc-menu';
+import { ModusWcMenuItem } from '../modus-wc-menu-item/modus-wc-menu-item';
+
+describe('modus-wc-dropdown-menu', () => {
+  it('should render with default props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcDropdownMenu, ModusWcButton, ModusWcMenu],
+      html: `<modus-wc-dropdown-menu>
+                <div slot="button">Button</div>
+             </modus-wc-dropdown-menu>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with custom props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcDropdownMenu, ModusWcButton, ModusWcMenu],
+      html: `<modus-wc-dropdown-menu
+                button-size="sm"
+                button-variant="borderless"
+                custom-class="test-class"
+                disabled={true}
+                menu-bordered={false}
+                menu-offset="0"
+                menu-placement="right"
+                menu-size="sm"
+                menu-visible={true}
+             >
+                <div slot="button">Button</div>
+             </modus-wc-dropdown-menu>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with menu items', async () => {
+    const page = await newSpecPage({
+      components: [
+        ModusWcDropdownMenu,
+        ModusWcButton,
+        ModusWcMenu,
+        ModusWcMenuItem,
+      ],
+      html: `<modus-wc-dropdown-menu menu-visible={true}>
+                <div slot="button">Button</div>
+                <div slot="menu">
+                  <modus-wc-menu-item label="Item One" value="1" />
+                  <modus-wc-menu-item label="Item Two" value="2" />
+                </div>
+             </modus-wc-dropdown-menu>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should open menu and close it when click outside', async () => {
+    const page = await newSpecPage({
+      components: [
+        ModusWcDropdownMenu,
+        ModusWcButton,
+        ModusWcMenu,
+        ModusWcMenuItem,
+      ],
+      html: `<modus-wc-dropdown-menu>
+                <div slot="button">Button</div>
+                <div slot="menu">
+                  <modus-wc-menu-item label="Item One" value="1" />
+                  <modus-wc-menu-item label="Item Two" value="2" />
+                </div>
+             </modus-wc-dropdown-menu>`,
+    });
+
+    // Open the menu
+    const button = page.root!.querySelector('button');
+    expect(button?.textContent).toBe('Button');
+    button?.click();
+
+    await page.waitForChanges();
+
+    expect(page.root!.menuVisible).toBe(true);
+
+    // Click outside component to close it
+    document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    await page.waitForChanges();
+
+    // Verify menu is now hidden
+    expect(page.root!.menuVisible).toBe(false);
+  });
+
+  it('should close the menu when escape key is pressed', async () => {
+    const page = await newSpecPage({
+      components: [
+        ModusWcDropdownMenu,
+        ModusWcButton,
+        ModusWcMenu,
+        ModusWcMenuItem,
+      ],
+      html: `<modus-wc-dropdown-menu>
+                <div slot="button">Button</div>
+                <div slot="menu">
+                  <modus-wc-menu-item label="Item One" value="1" />
+                  <modus-wc-menu-item label="Item Two" value="2" />
+                </div>
+             </modus-wc-dropdown-menu>`,
+    });
+
+    // Open the menu
+    const button = page.root!.querySelector('button');
+    expect(button?.textContent).toBe('Button');
+    button?.click();
+
+    await page.waitForChanges();
+
+    expect(page.root!.menuVisible).toBe(true);
+
+    // Press escape key to close menu
+    page.root!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+    );
+
+    await page.waitForChanges();
+
+    // Verify menu is now hidden
+    expect(page.root!.menuVisible).toBe(false);
+  });
+});

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.stories.ts
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.stories.ts
@@ -1,0 +1,152 @@
+import { withActions } from '@storybook/addon-actions/decorator';
+import { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { DaisySize, ModusSize, PopoverPlacement } from '../types';
+
+interface DropdownMenuArgs {
+  'button-color'?: 'primary' | 'secondary' | 'tertiary' | 'warning' | 'danger';
+  'button-size'?: DaisySize;
+  'button-variant'?: 'borderless' | 'filled' | 'outlined';
+  'custom-class'?: string;
+  disabled?: boolean;
+  'menu-bordered'?: boolean;
+  'menu-offset'?: number;
+  'menu-placement'?: PopoverPlacement;
+  'menu-size'?: ModusSize;
+  'menu-visible': boolean;
+}
+
+const meta: Meta<DropdownMenuArgs> = {
+  title: 'Components/Dropdown Menu',
+  component: 'modus-wc-dropdown-menu',
+  args: {
+    'button-color': 'primary',
+    'button-size': 'md',
+    'button-variant': 'filled',
+    disabled: false,
+    'menu-bordered': true,
+    'menu-offset': 14,
+    'menu-placement': 'bottom-start',
+    'menu-size': 'md',
+    'menu-visible': false,
+  },
+  argTypes: {
+    'button-color': {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'tertiary', 'warning', 'danger'],
+    },
+    'button-size': {
+      control: { type: 'select' },
+      options: ['xs', 'sm', 'md', 'lg'],
+    },
+    'button-variant': {
+      control: { type: 'select' },
+      options: ['borderless', 'filled', 'outlined'],
+    },
+    'menu-placement': {
+      control: { type: 'select' },
+      options: [
+        'top',
+        'top-start',
+        'top-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'left',
+        'left-start',
+        'left-end',
+        'right',
+        'right-start',
+        'right-end',
+      ],
+    },
+    'menu-size': {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['menuVisibilityChange'],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<DropdownMenuArgs>;
+
+const Template: Story = {
+  render: (args) => {
+    let selectedValue = '';
+
+    const handleItemSelect = (event: CustomEvent) => {
+      selectedValue = event.detail.value;
+      const displayElement = document.querySelector('#selected-value');
+      if (displayElement) {
+        displayElement.textContent = selectedValue;
+      }
+
+      // Close the dropdown menu when an item is selected
+      const dropdownMenu = event.target as HTMLElement;
+      const dropdownMenuElement = dropdownMenu.closest(
+        'modus-wc-dropdown-menu'
+      );
+      if (dropdownMenuElement) {
+        dropdownMenuElement.menuVisible = false;
+      }
+    };
+
+    // prettier-ignore
+    return html`
+<style>
+  div#story--components-dropdown-menu--default--primary-inner {
+    height: 120px;
+  }
+
+  [slot="button"] {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .value {
+    font-size: 14px;
+    padding-top: 12px;
+  }
+</style>
+
+<modus-wc-dropdown-menu
+  button-color=${ifDefined(args['button-color'])}
+  button-size=${ifDefined(args['button-size'])}
+  button-variant=${ifDefined(args['button-variant'])}
+  custom-class=${ifDefined(args['custom-class'])}
+  ?disabled=${args.disabled}
+  ?menu-bordered=${args['menu-bordered']}
+  menu-offset=${ifDefined(args['menu-offset'])}
+  menu-placement=${ifDefined(args['menu-placement'])}
+  menu-size=${ifDefined(args['menu-size'])}
+  ?menu-visible=${args['menu-visible']}
+>
+  <div slot="button">
+    Button
+    <modus-wc-icon name="expand_more" size="sm" />
+  </div>
+  <div slot="menu">
+    <modus-wc-menu-item label="Item One" value="1" @itemSelect=${handleItemSelect}></modus-wc-menu-item>
+    <modus-wc-menu-item label="Item Two" value="2" @itemSelect=${handleItemSelect} /></modus-wc-menu-item>
+    <modus-wc-menu-item label="Item Three" value="3" @itemSelect=${handleItemSelect} /></modus-wc-menu-item>
+  </div>
+</modus-wc-dropdown-menu>
+
+<div class="value">
+  Selected Value:
+  <span id="selected-value"></span>
+</div>
+    `;
+  },
+};
+
+export const Default: Story = { ...Template };

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.stories.ts
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.stories.ts
@@ -104,7 +104,9 @@ const Template: Story = {
 <style>
   /* Storybook styling */
   div#story--components-dropdown-menu--default--primary-inner {
-    height: 120px;
+    display: flex;
+    align-items: center;
+    height: 240px;
   }
 
   [slot="button"] {

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.stories.ts
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.stories.ts
@@ -102,6 +102,7 @@ const Template: Story = {
     // prettier-ignore
     return html`
 <style>
+  /* Storybook styling */
   div#story--components-dropdown-menu--default--primary-inner {
     height: 120px;
   }
@@ -117,6 +118,28 @@ const Template: Story = {
     padding-top: 12px;
   }
 </style>
+
+<script>
+  let selectedValue = '';
+
+  const handleItemSelect = (event: CustomEvent) => {
+    // Update the "Selected Value" label
+    selectedValue = event.detail.value;
+    const displayElement = document.querySelector('#selected-value');
+    if (displayElement) {
+      displayElement.textContent = selectedValue;
+    }
+
+    // Close the dropdown menu when an item is selected
+    const dropdownMenu = event.target as HTMLElement;
+    const dropdownMenuElement = dropdownMenu.closest(
+      'modus-wc-dropdown-menu'
+    );
+    if (dropdownMenuElement) {
+      dropdownMenuElement.menuVisible = false;
+    }
+  };
+</script>
 
 <modus-wc-dropdown-menu
   button-color=${ifDefined(args['button-color'])}
@@ -134,6 +157,7 @@ const Template: Story = {
     Button
     <modus-wc-icon name="expand_more" size="sm" />
   </div>
+
   <div slot="menu">
     <modus-wc-menu-item label="Item One" value="1" @itemSelect=${handleItemSelect}></modus-wc-menu-item>
     <modus-wc-menu-item label="Item Two" value="2" @itemSelect=${handleItemSelect} /></modus-wc-menu-item>

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
@@ -1,0 +1,170 @@
+import { computePosition, flip, offset, shift } from '@floating-ui/dom';
+import {
+  Component,
+  Element,
+  EventEmitter,
+  h,
+  Host,
+  Listen,
+  Prop,
+  State,
+  Event as StencilEvent,
+  Watch,
+} from '@stencil/core';
+import { DaisySize, ModusSize, PopoverPlacement } from '../types';
+import { Attributes, inheritAriaAttributes } from '../utils';
+
+/**
+ * A customizable dropdown menu component used to render a button and toggleable menu.
+ */
+@Component({
+  tag: 'modus-wc-dropdown-menu',
+  styleUrl: 'modus-wc-dropdown-menu.scss',
+  shadow: false,
+})
+export class ModusWcDropdownMenu {
+  private buttonRef?: HTMLElement;
+  private inheritedAttributes: Attributes = {};
+  private menuRef?: HTMLElement;
+
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
+  /** The color variant of the button. */
+  @Prop() buttonColor?:
+    | 'primary'
+    | 'secondary'
+    | 'tertiary'
+    | 'warning'
+    | 'danger' = 'primary';
+
+  /** The size of the button. */
+  @Prop() buttonSize?: DaisySize = 'md';
+
+  /** The variant of the button. */
+  @Prop() buttonVariant?: 'borderless' | 'filled' | 'outlined' = 'filled';
+
+  /** Custom CSS class to apply to the host element. */
+  @Prop() customClass?: string = '';
+
+  /** If true, the button will be disabled. */
+  @Prop() disabled?: boolean = false;
+
+  /** Indicates that the menu should have a border. */
+  @Prop() menuBordered?: boolean = true;
+
+  /** Distance between the button and menu in pixels. */
+  @Prop() menuOffset?: number = 10;
+
+  /** The placement of the menu relative to the button. */
+  @Prop() menuPlacement?: PopoverPlacement = 'bottom-start';
+
+  /** The size of the menu. */
+  @Prop() menuSize?: ModusSize = 'md';
+
+  /** Indicates that the menu is visible. */
+  @Prop({ mutable: true }) menuVisible: boolean = false;
+
+  /** Event emitted when the menuVisible prop changes. */
+  @StencilEvent() menuVisibilityChange!: EventEmitter<{ isVisible: boolean }>;
+
+  @State() private menuPosition = { x: 0, y: 0 };
+
+  @Listen('click', { target: 'document' })
+  handleDocumentClick(event: Event) {
+    // Close the menu when the user clicks outside the component
+    if (!this.el.contains(event.target as Node) && this.menuVisible) {
+      this.menuVisible = false;
+      this.menuVisibilityChange.emit({ isVisible: false });
+    }
+  }
+
+  @Listen('keydown')
+  handleKeyDown(event: KeyboardEvent) {
+    // Close the menu when the user clicks escape
+    if (event.key === 'Escape' && this.menuVisible) {
+      this.menuVisible = false;
+      this.menuVisibilityChange.emit({ isVisible: false });
+    }
+  }
+
+  @Watch('menuVisible')
+  async onMenuVisibilityChange(newValue: boolean) {
+    if (newValue) {
+      await this.updateMenuPosition();
+    }
+  }
+
+  componentDidLoad() {
+    this.buttonRef = this.el.querySelector('modus-wc-button') as HTMLElement;
+  }
+
+  componentWillLoad() {
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
+  }
+
+  private getClasses(): string {
+    const classList: string[] = ['modus-wc-dropdown-menu'];
+
+    // The order CSS classes are added matters to CSS specificity
+    if (this.customClass) classList.push(this.customClass);
+
+    return classList.join(' ');
+  }
+
+  private handleButtonClick = () => {
+    const newVisibility = !this.menuVisible;
+    this.menuVisible = newVisibility;
+    this.menuVisibilityChange.emit({ isVisible: newVisibility });
+  };
+
+  private updateMenuPosition = async () => {
+    if (!this.buttonRef || !this.menuRef) return;
+
+    const { x, y } = await computePosition(this.buttonRef, this.menuRef, {
+      placement: this.menuPlacement,
+      middleware: [offset(this.menuOffset), flip(), shift({ padding: 8 })],
+    });
+
+    this.menuPosition = { x, y };
+  };
+
+  render() {
+    return (
+      <Host class={this.getClasses()} {...this.inheritedAttributes}>
+        <modus-wc-button
+          aria-expanded={this.menuVisible.toString()}
+          aria-haspopup="true"
+          color={this.buttonColor}
+          disabled={this.disabled}
+          onButtonClick={this.handleButtonClick}
+          size={this.buttonSize}
+          variant={this.buttonVariant}
+        >
+          <slot name="button" />
+        </modus-wc-button>
+
+        <div
+          aria-hidden={!this.menuVisible}
+          class="menu-wrapper"
+          ref={(el) => (this.menuRef = el)}
+          style={{
+            // Positioning
+            position: 'absolute',
+            top: `${this.menuPosition.y}px`,
+            left: `${this.menuPosition.x}px`,
+            zIndex: '1000',
+            // Visibility
+            visibility: this.menuVisible ? 'visible' : 'hidden',
+            opacity: this.menuVisible ? '1' : '0',
+            pointerEvents: this.menuVisible ? 'auto' : 'none',
+          }}
+        >
+          <modus-wc-menu bordered={this.menuBordered} size={this.menuSize}>
+            <slot name="menu" />
+          </modus-wc-menu>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
@@ -119,6 +119,7 @@ export class ModusWcDropdownMenu {
   };
 
   private updateMenuPosition = async () => {
+    // istanbul ignore next
     if (!this.buttonRef || !this.menuRef) return;
 
     const { x, y } = await computePosition(this.buttonRef, this.menuRef, {

--- a/src/components/modus-wc-dropdown-menu/readme.md
+++ b/src/components/modus-wc-dropdown-menu/readme.md
@@ -1,0 +1,52 @@
+# modus-wc-dropdown-menu
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+A customizable dropdown menu component used to render a button and toggleable menu.
+
+## Properties
+
+| Property        | Attribute        | Description                                       | Type                                                                                                                                                                              | Default          |
+| --------------- | ---------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `buttonColor`   | `button-color`   | The color variant of the button.                  | `"danger" \| "primary" \| "secondary" \| "tertiary" \| "warning" \| undefined`                                                                                                    | `'primary'`      |
+| `buttonSize`    | `button-size`    | The size of the button.                           | `"lg" \| "md" \| "sm" \| "xs" \| undefined`                                                                                                                                       | `'md'`           |
+| `buttonVariant` | `button-variant` | The variant of the button.                        | `"borderless" \| "filled" \| "outlined" \| undefined`                                                                                                                             | `'filled'`       |
+| `customClass`   | `custom-class`   | Custom CSS class to apply to the host element.    | `string \| undefined`                                                                                                                                                             | `''`             |
+| `disabled`      | `disabled`       | If true, the button will be disabled.             | `boolean \| undefined`                                                                                                                                                            | `false`          |
+| `menuBordered`  | `menu-bordered`  | Indicates that the menu should have a border.     | `boolean \| undefined`                                                                                                                                                            | `true`           |
+| `menuOffset`    | `menu-offset`    | Distance between the button and menu in pixels.   | `number \| undefined`                                                                                                                                                             | `10`             |
+| `menuPlacement` | `menu-placement` | The placement of the menu relative to the button. | `"bottom" \| "bottom-end" \| "bottom-start" \| "left" \| "left-end" \| "left-start" \| "right" \| "right-end" \| "right-start" \| "top" \| "top-end" \| "top-start" \| undefined` | `'bottom-start'` |
+| `menuSize`      | `menu-size`      | The size of the menu.                             | `"lg" \| "md" \| "sm" \| undefined`                                                                                                                                               | `'md'`           |
+| `menuVisible`   | `menu-visible`   | Indicates that the menu is visible.               | `boolean`                                                                                                                                                                         | `false`          |
+
+
+## Events
+
+| Event                  | Description                                      | Type                                   |
+| ---------------------- | ------------------------------------------------ | -------------------------------------- |
+| `menuVisibilityChange` | Event emitted when the menuVisible prop changes. | `CustomEvent<{ isVisible: boolean; }>` |
+
+
+## Dependencies
+
+### Depends on
+
+- [modus-wc-button](../modus-wc-button)
+- [modus-wc-menu](../modus-wc-menu)
+
+### Graph
+```mermaid
+graph TD;
+  modus-wc-dropdown-menu --> modus-wc-button
+  modus-wc-dropdown-menu --> modus-wc-menu
+  style modus-wc-dropdown-menu fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/modus-wc-menu/modus-wc-menu.scss
+++ b/src/components/modus-wc-menu/modus-wc-menu.scss
@@ -17,12 +17,14 @@ modus-wc-menu .modus-wc-menu {
   }
 }
 
-[data-theme='modus-classic-light'] modus-wc-menu .modus-wc-menu {
+[data-theme='modus-classic-light'] modus-wc-menu .modus-wc-menu,
+[data-theme='modus-modern-light'] modus-wc-menu .modus-wc-menu {
   background-color: var(--modus-wc-color-white);
   border-color: var(--modus-wc-color-gray-0);
 }
 
-[data-theme='modus-classic-dark'] modus-wc-menu .modus-wc-menu {
+[data-theme='modus-classic-dark'] modus-wc-menu .modus-wc-menu,
+[data-theme='modus-modern-dark'] modus-wc-menu .modus-wc-menu {
   background-color: var(--modus-wc-color-black);
   border-color: var(--modus-wc-color-gray-8);
 }

--- a/src/components/modus-wc-menu/readme.md
+++ b/src/components/modus-wc-menu/readme.md
@@ -33,12 +33,14 @@ The component supports a `<slot>` for injecting custom li elements inside the ul
 ### Used by
 
  - [modus-wc-autocomplete](../modus-wc-autocomplete)
+ - [modus-wc-dropdown-menu](../modus-wc-dropdown-menu)
  - [modus-wc-navbar](../modus-wc-navbar)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-autocomplete --> modus-wc-menu
+  modus-wc-dropdown-menu --> modus-wc-menu
   modus-wc-navbar --> modus-wc-menu
   style modus-wc-menu fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -87,3 +87,17 @@ export interface IInputFeedbackProp {
   level: IInputFeedbackLevel;
   message?: string;
 }
+
+export type PopoverPlacement =
+  | 'top'
+  | 'top-start'
+  | 'top-end'
+  | 'bottom'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left'
+  | 'left-start'
+  | 'left-end'
+  | 'right'
+  | 'right-start'
+  | 'right-end';

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1678,6 +1678,189 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A customizable dropdown menu component used to render a button and toggleable menu.",
+          "name": "ModusWcDropdownMenu",
+          "members": [
+            {
+              "kind": "field",
+              "name": "el",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "description": "Reference to the host element"
+            },
+            {
+              "kind": "method",
+              "name": "handleDocumentClick",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handleKeyDown",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "onMenuVisibilityChange",
+              "parameters": [
+                {
+                  "name": "newValue",
+                  "type": {
+                    "text": "boolean"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "button-color",
+              "fieldName": "buttonColor",
+              "default": "'primary'",
+              "description": "The color variant of the button.",
+              "type": {
+                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'warning'\r\n    | 'danger'"
+              }
+            },
+            {
+              "name": "button-size",
+              "fieldName": "buttonSize",
+              "default": "'md'",
+              "description": "The size of the button.",
+              "type": {
+                "text": "DaisySize"
+              }
+            },
+            {
+              "name": "button-variant",
+              "fieldName": "buttonVariant",
+              "default": "'filled'",
+              "description": "The variant of the button.",
+              "type": {
+                "text": "'borderless' | 'filled' | 'outlined'"
+              }
+            },
+            {
+              "name": "custom-class",
+              "fieldName": "customClass",
+              "default": "''",
+              "description": "Custom CSS class to apply to the host element.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "disabled",
+              "fieldName": "disabled",
+              "default": "false",
+              "description": "If true, the button will be disabled.",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "name": "menu-bordered",
+              "fieldName": "menuBordered",
+              "default": "true",
+              "description": "Indicates that the menu should have a border.",
+              "type": {
+                "text": "boolean"
+              }
+            },
+            {
+              "name": "menu-offset",
+              "fieldName": "menuOffset",
+              "default": "10",
+              "description": "Distance between the button and menu in pixels.",
+              "type": {
+                "text": "number"
+              }
+            },
+            {
+              "name": "menu-placement",
+              "fieldName": "menuPlacement",
+              "default": "'bottom-start'",
+              "description": "The placement of the menu relative to the button.",
+              "type": {
+                "text": "PopoverPlacement"
+              }
+            },
+            {
+              "name": "menu-size",
+              "fieldName": "menuSize",
+              "default": "'md'",
+              "description": "The size of the menu.",
+              "type": {
+                "text": "ModusSize"
+              }
+            },
+            {
+              "name": "menu-visible",
+              "fieldName": "menuVisible",
+              "default": "false",
+              "description": "Indicates that the menu is visible.",
+              "type": {
+                "text": "boolean"
+              }
+            }
+          ],
+          "tagName": "modus-wc-dropdown-menu",
+          "events": [
+            {
+              "kind": "field",
+              "name": "menuVisibilityChange",
+              "type": {
+                "text": "EventEmitter<{ isVisible: boolean }>"
+              },
+              "description": "Event emitted when the menuVisible prop changes."
+            }
+          ],
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ModusWcDropdownMenu",
+          "declaration": {
+            "name": "ModusWcDropdownMenu",
+            "module": "src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "modus-wc-dropdown-menu",
+          "declaration": {
+            "name": "ModusWcDropdownMenu",
+            "module": "src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/modus-wc-icon/modus-wc-icon.tsx",
       "declarations": [
         {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds a new component `ModusWcDropdownMenu`. It is a combination of the existing Modus button, menu, and menu item components. The menu is toggled by clicking the button. It is closed when clicking outside of the component. It can also be toggled externally via the `menuVisible` prop.

The component uses the floating UI (formerly popper) library for dynamic placement of the menu in relation to the button.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Tests added, 100% coverage

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #431 
