### PR TITLE
Menu Item: Accepts Icons via slot(modus-wc-icon)

### DIFF
--- a/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
+++ b/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
@@ -247,6 +247,7 @@ exports[`modus-wc-autocomplete should render with custom props 1`] = `
     <!---->
     <ul aria-label="Autocomplete menu" aria-orientation="vertical" class="modus-wc-menu modus-wc-menu-lg modus-wc-w-full" role="menu">
       <modus-wc-menu-item>
+        <!---->
         <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
           <button type="button">
             <div class="modus-wc-menu-item-content">
@@ -260,6 +261,7 @@ exports[`modus-wc-autocomplete should render with custom props 1`] = `
         </li>
       </modus-wc-menu-item>
       <modus-wc-menu-item>
+        <!---->
         <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
           <button type="button">
             <div class="modus-wc-menu-item-content">
@@ -273,6 +275,7 @@ exports[`modus-wc-autocomplete should render with custom props 1`] = `
         </li>
       </modus-wc-menu-item>
       <modus-wc-menu-item>
+        <!---->
         <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
           <button type="button">
             <div class="modus-wc-menu-item-content">

--- a/src/components/modus-wc-dropdown-menu/__snapshots__/modus-wc-dropdown-menu.spec.ts.snap
+++ b/src/components/modus-wc-dropdown-menu/__snapshots__/modus-wc-dropdown-menu.spec.ts.snap
@@ -59,7 +59,9 @@ exports[`modus-wc-dropdown-menu should render with menu items 1`] = `
       <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-md modus-wc-w-full" role="menu">
         <div slot="menu">
           <modus-wc-menu-item label="Item One" value="1">
-            <modus-wc-menu-item label="Item Two" value="2">
+            <!---->
+            <modus-wc-menu-item hidden="" label="Item Two" value="2">
+              <!---->
               <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
                 <button type="button">
                   <div class="modus-wc-menu-item-content">

--- a/src/components/modus-wc-menu-item/__snapshots__/modus-wc-menu-item.spec.ts.snap
+++ b/src/components/modus-wc-menu-item/__snapshots__/modus-wc-menu-item.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`modus-wc-menu-item renders with default props 1`] = `
 <modus-wc-menu-item label="Test label" value="Test value">
+  <!---->
   <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
     <button type="button">
       <div class="modus-wc-menu-item-content">
@@ -16,16 +17,34 @@ exports[`modus-wc-menu-item renders with default props 1`] = `
 </modus-wc-menu-item>
 `;
 
-exports[`modus-wc-menu-item should render with custom props 1`] = `
-<modus-wc-menu-item bordered="true" custom-class="test-class" disabled="true" label="Test label" selected="true" size="lg" start-icon="check" sub-label="Test sub-label" value="Test value">
-  <li aria-current="" aria-disabled="" class="modus-wc-menu-item modus-wc-menu-item-bordered modus-wc-menu-item-disabled modus-wc-menu-item-lg modus-wc-menu-item-selected test-class" role="menuitem">
-    <button disabled="" type="button">
+exports[`modus-wc-menu-item should render with a start-icon slot 1`] = `
+<modus-wc-menu-item label="Test label" value="Test value">
+  <!---->
+  <li class="modus-wc-menu-item modus-wc-menu-item-md" role="menuitem">
+    <button type="button">
       <div class="modus-wc-menu-item-content">
-        <modus-wc-icon class="modus-wc-flex modus-wc-items-center">
-          <i aria-hidden="true" class="modus-icons modus-wc-icon modus-wc-icon--md modus-wc-menu-item-start-icon" tabindex="-1">
+        <modus-wc-icon class="modus-wc-flex modus-wc-items-center" name="check" slot="start-icon">
+          <i aria-hidden="true" class="modus-icons modus-wc-icon modus-wc-icon--md" tabindex="-1">
             check
           </i>
         </modus-wc-icon>
+        <div class="modus-wc-menu-item-labels">
+          <div>
+            Test label
+          </div>
+        </div>
+      </div>
+    </button>
+  </li>
+</modus-wc-menu-item>
+`;
+
+exports[`modus-wc-menu-item should render with custom props 1`] = `
+<modus-wc-menu-item bordered="true" custom-class="test-class" disabled="true" label="Test label" selected="true" size="lg" sub-label="Test sub-label" value="Test value">
+  <!---->
+  <li aria-current="" aria-disabled="" class="modus-wc-menu-item modus-wc-menu-item-bordered modus-wc-menu-item-disabled modus-wc-menu-item-lg modus-wc-menu-item-selected test-class" role="menuitem">
+    <button disabled="" type="button">
+      <div class="modus-wc-menu-item-content">
         <div class="modus-wc-menu-item-labels">
           <div>
             Test label
@@ -49,6 +68,7 @@ exports[`modus-wc-menu-item should render with custom props 1`] = `
 
 exports[`modus-wc-menu-item should render with size lg 1`] = `
 <modus-wc-menu-item label="Test label" selected="true" size="lg" value="Test value">
+  <!---->
   <li aria-current="" class="modus-wc-menu-item modus-wc-menu-item-lg modus-wc-menu-item-selected" role="menuitem">
     <button type="button">
       <div class="modus-wc-menu-item-content">
@@ -68,6 +88,7 @@ exports[`modus-wc-menu-item should render with size lg 1`] = `
 
 exports[`modus-wc-menu-item should render with size md 1`] = `
 <modus-wc-menu-item label="Test label" selected="true" size="md" value="Test value">
+  <!---->
   <li aria-current="" class="modus-wc-menu-item modus-wc-menu-item-md modus-wc-menu-item-selected" role="menuitem">
     <button type="button">
       <div class="modus-wc-menu-item-content">
@@ -87,6 +108,7 @@ exports[`modus-wc-menu-item should render with size md 1`] = `
 
 exports[`modus-wc-menu-item should render with size sm 1`] = `
 <modus-wc-menu-item label="Test label" selected="true" size="sm" value="Test value">
+  <!---->
   <li aria-current="" class="modus-wc-menu-item modus-wc-menu-item-selected modus-wc-menu-item-sm" role="menuitem">
     <button type="button">
       <div class="modus-wc-menu-item-content">

--- a/src/components/modus-wc-menu-item/modus-wc-menu-item.scss
+++ b/src/components/modus-wc-menu-item/modus-wc-menu-item.scss
@@ -14,7 +14,7 @@ modus-wc-menu-item .modus-wc-menu-item {
       display: flex;
       width: 100%;
 
-      .modus-wc-menu-item-start-icon {
+       [slot='start-icon'] {
         padding-inline-end: var(--modus-wc-spacing-lg);
       }
 

--- a/src/components/modus-wc-menu-item/modus-wc-menu-item.scss
+++ b/src/components/modus-wc-menu-item/modus-wc-menu-item.scss
@@ -14,7 +14,7 @@ modus-wc-menu-item .modus-wc-menu-item {
       display: flex;
       width: 100%;
 
-       [slot='start-icon'] {
+      [slot='start-icon'] {
         padding-inline-end: var(--modus-wc-spacing-lg);
       }
 

--- a/src/components/modus-wc-menu-item/modus-wc-menu-item.spec.ts
+++ b/src/components/modus-wc-menu-item/modus-wc-menu-item.spec.ts
@@ -19,12 +19,21 @@ describe('modus-wc-menu-item', () => {
               custom-class="test-class" 
               disabled="true" 
               label="Test label" 
-              start-icon="check" 
               selected="true" 
               size="lg" 
               sub-label="Test sub-label" 
               value="Test value"
             ></modus-wc-menu-item>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with a start-icon slot', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcMenuItem, ModusWcIcon],
+      html: `<modus-wc-menu-item label="Test label" value="Test value">
+              <modus-wc-icon slot="start-icon" name="check"></modus-wc-icon>
+            </modus-wc-menu-item>`,
     });
     expect(page.root).toMatchSnapshot();
   });

--- a/src/components/modus-wc-menu-item/modus-wc-menu-item.stories.ts
+++ b/src/components/modus-wc-menu-item/modus-wc-menu-item.stories.ts
@@ -9,7 +9,6 @@ interface MenuItemArgs {
   'custom-class'?: string;
   disabled?: boolean;
   label: string;
-  'start-icon'?: string;
   selected?: boolean;
   size?: ModusSize;
   'sub-label'?: string;
@@ -52,7 +51,6 @@ const Template: Story = {
     custom-class=${ifDefined(args['custom-class'])}
     ?disabled=${args.disabled}
     label=${args.label}
-    start-icon=${ifDefined(args['start-icon'])}
     ?selected=${args.selected}
     size=${args.size}
     sub-label=${ifDefined(args['sub-label'])}
@@ -64,3 +62,29 @@ const Template: Story = {
 };
 
 export const Default: Story = { ...Template };
+
+export const WithIcon: Story = {
+  render: (args) => {
+    // prettier-ignore
+    return html`
+<modus-wc-menu>
+  <modus-wc-menu-item
+    ?bordered=${args.bordered}
+    custom-class=${ifDefined(args['custom-class'])}
+    ?disabled=${args.disabled}
+    label=${args.label}
+    ?selected=${args.selected}
+    size=${args.size}
+    sub-label=${ifDefined(args['sub-label'])}
+    value=${args.value}
+  >
+    <modus-wc-icon
+      slot="start-icon"
+      name="alert"
+      size="sm"
+    ></modus-wc-icon>
+  </modus-wc-menu-item>
+</modus-wc-menu>
+    `;
+  },
+};

--- a/src/components/modus-wc-menu-item/modus-wc-menu-item.tsx
+++ b/src/components/modus-wc-menu-item/modus-wc-menu-item.tsx
@@ -113,14 +113,7 @@ export class ModusWcMenuItem {
             type="button"
           >
             <div class="modus-wc-menu-item-content">
-              {this.startIcon && (
-                <modus-wc-icon
-                  customClass="modus-wc-menu-item-start-icon"
-                  decorative={true}
-                  name={this.startIcon}
-                  size={this.getIconSize()}
-                />
-              )}
+              <slot name="start-icon"></slot>
               <div class="modus-wc-menu-item-labels">
                 <div>{this.label}</div>
                 {this.subLabel && (

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -8,7 +8,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable accordion component used for showing and hiding related groups of content.\r\n\r\nThe component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.",
+          "description": "A customizable accordion component used for showing and hiding related groups of content.\n\nThe component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.",
           "name": "ModusWcAccordion",
           "members": [
             {
@@ -41,7 +41,7 @@
               "kind": "field",
               "name": "expandedChange",
               "type": {
-                "text": "EventEmitter<{\r\n    expanded: boolean;\r\n    index: number;\r\n  }>"
+                "text": "EventEmitter<{\n    expanded: boolean;\n    index: number;\n  }>"
               },
               "description": "When a collapse expanded state is changed, this event outputs the relevant index and state"
             }
@@ -266,7 +266,7 @@
               "name": "debounce-ms",
               "fieldName": "debounceMs",
               "default": "300",
-              "description": "The debounce timeout in milliseconds.\r\nSet to 0 to disable debouncing.",
+              "description": "The debounce timeout in milliseconds.\nSet to 0 to disable debouncing.",
               "type": {
                 "text": "number"
               }
@@ -318,7 +318,7 @@
               "name": "items",
               "fieldName": "items",
               "default": "[]",
-              "description": "The items to display in the menu.\r\nCreating a new array of items will ensure proper component re-render.",
+              "description": "The items to display in the menu.\nCreating a new array of items will ensure proper component re-render.",
               "type": {
                 "text": "IAutocompleteItem[]"
               }
@@ -463,7 +463,7 @@
               "type": {
                 "text": "EventEmitter<Event>"
               },
-              "description": "Event emitted when the input value changes.\r\nThis event is debounced based on the debounceMs prop."
+              "description": "Event emitted when the input value changes.\nThis event is debounced based on the debounceMs prop."
             },
             {
               "kind": "field",
@@ -602,7 +602,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\r\n\r\nThe component supports a `<slot>` for injecting content within the badge.",
+          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\n\nThe component supports a `<slot>` for injecting content within the badge.",
           "name": "ModusWcBadge",
           "members": [
             {
@@ -625,7 +625,7 @@
               "default": "'primary'",
               "description": "The color variant of the badge.",
               "type": {
-                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'high-contrast'\r\n    | 'success'\r\n    | 'warning'\r\n    | 'danger'"
+                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'high-contrast'\n    | 'success'\n    | 'warning'\n    | 'danger'"
               }
             },
             {
@@ -769,7 +769,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\r\n\r\nThe component supports a `<slot>` for injecting content within the button, similar to a native HTML button",
+          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\n\nThe component supports a `<slot>` for injecting content within the button, similar to a native HTML button",
           "name": "ModusWcButton",
           "members": [
             {
@@ -1294,7 +1294,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable collapse component used for showing and hiding content.\r\n\r\nThe component supports a 'header' and 'content' `<slot>` for injecting custom HTML.\r\nDo not set",
+          "description": "A customizable collapse component used for showing and hiding content.\n\nThe component supports a 'header' and 'content' `<slot>` for injecting custom HTML.\nDo not set",
           "name": "ModusWcCollapse",
           "members": [
             {
@@ -1361,7 +1361,7 @@
             {
               "name": "options",
               "fieldName": "options",
-              "description": "Configuration options for rendering the pre-laid out collapse component.\r\nDo not set this prop if you intend to use the 'header' slot.",
+              "description": "Configuration options for rendering the pre-laid out collapse component.\nDo not set this prop if you intend to use the 'header' slot.",
               "type": {
                 "text": "ICollapseOptions"
               }
@@ -1406,7 +1406,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable date picker component used to create date inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable date picker component used to create date inputs.\n\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcDate",
           "members": [
             {
@@ -1621,7 +1621,7 @@
               "default": "'tertiary'",
               "description": "The color of the divider line.",
               "type": {
-                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'high-contrast'\r\n    | 'success'\r\n    | 'warning'\r\n    | 'danger'"
+                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'high-contrast'\n    | 'success'\n    | 'warning'\n    | 'danger'"
               }
             },
             {
@@ -1700,7 +1700,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable dropdown menu component used to render a button and toggleable menu.\r\n\r\nThe component supports a 'button' and 'menu' `<slot>` for injecting custom HTML content.",
+          "description": "A customizable dropdown menu component used to render a button and toggleable menu.\n\nThe component supports a 'button' and 'menu' `<slot>` for injecting custom HTML content.",
           "name": "ModusWcDropdownMenu",
           "members": [
             {
@@ -1759,7 +1759,7 @@
               "default": "'primary'",
               "description": "The color variant of the button.",
               "type": {
-                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'warning'\r\n    | 'danger'"
+                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'warning'\n    | 'danger'"
               }
             },
             {
@@ -1883,7 +1883,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable icon component used to render Modus icons.\r\n\r\n<b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
+          "description": "A customizable icon component used to render Modus icons.\n\n<b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
           "name": "ModusWcIcon",
           "members": [
             {
@@ -1966,7 +1966,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable feedback component used to provide additional context related to form input interactions.\r\n\r\n<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
+          "description": "A customizable feedback component used to provide additional context related to form input interactions.\n\n<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
           "name": "ModusWcInputFeedback",
           "members": [
             {
@@ -2058,7 +2058,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input label component.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text",
+          "description": "A customizable input label component.\n\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text",
           "name": "ModusWcInputLabel",
           "members": [
             {
@@ -2381,7 +2381,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable menu component used to display a list of li elements vertically or horizontally.\r\n\r\nThe component supports a `<slot>` for injecting custom li elements inside the ul",
+          "description": "A customizable menu component used to display a list of li elements vertically or horizontally.\n\nThe component supports a `<slot>` for injecting custom li elements inside the ul",
           "name": "ModusWcMenu",
           "members": [
             {
@@ -2473,7 +2473,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable modal component used to display content in a dialog.\r\n\r\nThe component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML",
+          "description": "A customizable modal component used to display content in a dialog.\n\nThe component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML",
           "name": "ModusWcModal",
           "members": [
             {
@@ -2494,7 +2494,7 @@
               "name": "backdrop",
               "fieldName": "backdrop",
               "default": "'default'",
-              "description": "The modal's backdrop.\r\nSpecify 'static' for a backdrop that doesn't close the modal when clicked outside the modal content.",
+              "description": "The modal's backdrop.\nSpecify 'static' for a backdrop that doesn't close the modal when clicked outside the modal content.",
               "type": {
                 "text": "'default' | 'static'"
               }
@@ -2583,7 +2583,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable navbar component used for top level navigation of all Trimble applications.\r\n\r\nThe component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.\r\nIt also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML",
+          "description": "A customizable navbar component used for top level navigation of all Trimble applications.\n\nThe component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.\nIt also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML",
           "name": "ModusWcNavbar",
           "members": [
             {
@@ -2951,7 +2951,7 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'numeric'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
                 "text": "'decimal' | 'none' | 'numeric'"
               }
@@ -3234,7 +3234,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable progress component used to show the progress of a task or show the passing of time.\r\n\r\nThe radial variant supports slotting in custom HTML to be displayed within the progress circle",
+          "description": "A customizable progress component used to show the progress of a task or show the passing of time.\n\nThe radial variant supports slotting in custom HTML to be displayed within the progress circle",
           "name": "ModusWcProgress",
           "members": [
             {
@@ -4618,7 +4618,7 @@
               "kind": "field",
               "name": "cellEditCommit",
               "type": {
-                "text": "EventEmitter<{\r\n    rowIndex: number;\r\n    colId: string;\r\n    newValue: unknown;\r\n    updatedRow: Record<string, unknown>;\r\n  }>"
+                "text": "EventEmitter<{\n    rowIndex: number;\n    colId: string;\n    newValue: unknown;\n    updatedRow: Record<string, unknown>;\n  }>"
               },
               "description": "Emits when cell editing is committed with the new value."
             },
@@ -4626,7 +4626,7 @@
               "kind": "field",
               "name": "cellEditStart",
               "type": {
-                "text": "EventEmitter<{\r\n    rowIndex: number;\r\n    colId: string;\r\n  }>"
+                "text": "EventEmitter<{\n    rowIndex: number;\n    colId: string;\n  }>"
               },
               "description": "Emits when cell editing starts."
             },
@@ -4642,7 +4642,7 @@
               "kind": "field",
               "name": "rowClick",
               "type": {
-                "text": "EventEmitter<{\r\n    row: Record<string, unknown>;\r\n    index: number;\r\n  }>"
+                "text": "EventEmitter<{\n    row: Record<string, unknown>;\n    index: number;\n  }>"
               },
               "description": "Emits when a row is clicked."
             },
@@ -4650,7 +4650,7 @@
               "kind": "field",
               "name": "rowSelectionChange",
               "type": {
-                "text": "EventEmitter<{\r\n    selectedRows: Record<string, unknown>[];\r\n    selectedRowIds: string[];\r\n  }>"
+                "text": "EventEmitter<{\n    selectedRows: Record<string, unknown>[];\n    selectedRowIds: string[];\n  }>"
               },
               "description": "Emits when row selection changes with the selected rows and their IDs."
             },
@@ -4757,7 +4757,7 @@
               "kind": "field",
               "name": "tabChange",
               "type": {
-                "text": "EventEmitter<{\r\n    previousTab: number;\r\n    newTab: number;\r\n  }>"
+                "text": "EventEmitter<{\n    previousTab: number;\n    newTab: number;\n  }>"
               },
               "description": "When a tab is switched to, this event outputs the relevant indices"
             }
@@ -4812,7 +4812,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
+                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
               }
             },
             {
@@ -4872,7 +4872,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
+                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
               }
             },
             {
@@ -4913,9 +4913,9 @@
               "name": "input-mode",
               "fieldName": "inputMode",
               "default": "'text'",
-              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\r\nThis allows a browser to display an appropriate virtual keyboard.",
+              "description": "Hints at the type of data that might be entered by the user while editing the element or its contents.\nThis allows a browser to display an appropriate virtual keyboard.",
               "type": {
-                "text": "| 'decimal'\r\n    | 'email'\r\n    | 'none'\r\n    | 'numeric'\r\n    | 'search'\r\n    | 'tel'\r\n    | 'text'\r\n    | 'url'"
+                "text": "| 'decimal'\n    | 'email'\n    | 'none'\n    | 'numeric'\n    | 'search'\n    | 'tel'\n    | 'text'\n    | 'url'"
               }
             },
             {
@@ -5133,7 +5133,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
+                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
               }
             },
             {
@@ -5293,7 +5293,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A theme switcher component used to toggle the application theme and/or mode.\r\n\r\nAllows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).",
+          "description": "A theme switcher component used to toggle the application theme and/or mode.\n\nAllows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).",
           "name": "ModusWcThemeSwitcher",
           "members": [
             {
@@ -5408,7 +5408,7 @@
             {
               "name": "datalist-id",
               "fieldName": "datalistId",
-              "description": "ID of a `<datalist>` element that contains pre-defined time options.\r\nThe value must be the ID of a `<datalist>` element in the same document.",
+              "description": "ID of a `<datalist>` element that contains pre-defined time options.\nThe value must be the ID of a `<datalist>` element in the same document.",
               "type": {
                 "text": "string"
               }
@@ -5509,7 +5509,7 @@
               "name": "show-seconds",
               "fieldName": "showSeconds",
               "default": "false",
-              "description": "Displays the time input format as `HH:mm:ss` if `true`.\r\nInternally sets the `step` to 1 second.\r\nIf a `step` value is provided, it will override this attribute.",
+              "description": "Displays the time input format as `HH:mm:ss` if `true`.\nInternally sets the `step` to 1 second.\nIf a `step` value is provided, it will override this attribute.",
               "type": {
                 "text": "boolean"
               }
@@ -5526,7 +5526,7 @@
             {
               "name": "step",
               "fieldName": "step",
-              "description": "Specifies the granularity that the `value` must adhere to.\r\nValue of step given in seconds. Default value is 60 seconds.\r\nOverrides the `seconds` attribute if both are provided.",
+              "description": "Specifies the granularity that the `value` must adhere to.\nValue of step given in seconds. Default value is 60 seconds.\nOverrides the `seconds` attribute if both are provided.",
               "type": {
                 "text": "number"
               }
@@ -5535,7 +5535,7 @@
               "name": "value",
               "fieldName": "value",
               "default": "''",
-              "description": "The value of the time input.\r\nAlways in 24-hour format that includes leading zeros:\r\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\r\nto be selected based on user's locale (or by the user agent).\r\nIf time includes seconds the format is always `HH:mm:ss`.",
+              "description": "The value of the time input.\nAlways in 24-hour format that includes leading zeros:\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\nto be selected based on user's locale (or by the user agent).\nIf time includes seconds the format is always `HH:mm:ss`.",
               "type": {
                 "text": "string"
               }
@@ -5596,7 +5596,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable toast component used to stack elements, positioned on the corner of a page.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the toast.",
+          "description": "A customizable toast component used to stack elements, positioned on the corner of a page.\n\nThe component supports a `<slot>` for injecting additional custom content inside the toast.",
           "name": "ModusWcToast",
           "members": [
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- The modus-wc-menu-item component was refactored to use a start-icon slot instead of a prop to allow icons more than the modus icon library.


### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [x] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #406
