### PR TITLE
Icon: Support both filled and outlined icons in modus web components

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,10 +2,20 @@
   href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=fallback"
   rel="stylesheet"
 />
-<link rel="stylesheet" href="../src/styles/modus-icons.css" />
 <script>
   // Determine if we're running locally or deployed
   const isLocal = window.location.hostname.includes('localhost');
+
+  //modus-icons.css
+  const iconsCssPath = isLocal
+    ? '../src/styles/modus-icons.css'
+    : 'public/modus-icons.css';
+  const iconsLink = document.createElement('link');
+  iconsLink.rel = 'stylesheet';
+  iconsLink.href = iconsCssPath;
+  document.head.appendChild(iconsLink);
+
+  // Add output.css with conditional path
   const cssPath = isLocal ? '../src/styles/output.css' : 'public/output.css';
   const link = document.createElement('link');
   link.rel = 'stylesheet';

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,17 +5,6 @@
 <script>
   // Determine if we're running locally or deployed
   const isLocal = window.location.hostname.includes('localhost');
-
-  //modus-icons.css
-  const iconsCssPath = isLocal
-    ? '../src/styles/modus-icons.css'
-    : 'public/modus-icons.css';
-  const iconsLink = document.createElement('link');
-  iconsLink.rel = 'stylesheet';
-  iconsLink.href = iconsCssPath;
-  document.head.appendChild(iconsLink);
-
-  // Add output.css with conditional path
   const cssPath = isLocal ? '../src/styles/output.css' : 'public/output.css';
   const link = document.createElement('link');
   link.rel = 'stylesheet';

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -2,10 +2,7 @@
   href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700&display=fallback"
   rel="stylesheet"
 />
-<link
-  rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1.16.0/dist/modus-outlined/fonts/modus-icons.css"
-/>
+<link rel="stylesheet" href="../src/styles/modus-icons.css" />
 <script>
   // Determine if we're running locally or deployed
   const isLocal = window.location.hostname.includes('localhost');

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -7,6 +7,7 @@ import { createElement } from 'react';
 import { defineCustomElements } from '../dist/loader';
 import customElements from '../src/custom-elements.json';
 import a11yConfig from './a11yConfig';
+import '../src/styles/modus-icons.css';
 
 defineCustomElements();
 setCustomElementsManifest(customElements);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -643,7 +643,7 @@ export namespace Components {
         /**
           * The icon variant, can be "outlined" or "solid".
          */
-        "variant"?: 'outlined' | 'solid' | 'default';
+        "variant"?: 'outlined' | 'solid';
     }
     /**
      * A customizable feedback component used to provide additional context related to form input interactions.
@@ -3370,7 +3370,7 @@ declare namespace LocalJSX {
         /**
           * The icon variant, can be "outlined" or "solid".
          */
-        "variant"?: 'outlined' | 'solid' | 'default';
+        "variant"?: 'outlined' | 'solid';
     }
     /**
      * A customizable feedback component used to provide additional context related to form input interactions.

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -640,6 +640,10 @@ export namespace Components {
           * The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon.
          */
         "size"?: DaisySize;
+        /**
+          * The icon variant, can be "outlined" or "solid".
+         */
+        "variant"?: 'outlined' | 'solid' | 'default';
     }
     /**
      * A customizable feedback component used to provide additional context related to form input interactions.
@@ -3363,6 +3367,10 @@ declare namespace LocalJSX {
           * The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon.
          */
         "size"?: DaisySize;
+        /**
+          * The icon variant, can be "outlined" or "solid".
+         */
+        "variant"?: 'outlined' | 'solid' | 'default';
     }
     /**
      * A customizable feedback component used to provide additional context related to form input interactions.

--- a/src/components/modus-wc-icon/__snapshots__/modus-wc-icon.spec.ts.snap
+++ b/src/components/modus-wc-icon/__snapshots__/modus-wc-icon.spec.ts.snap
@@ -12,8 +12,20 @@ exports[`modus-wc-icon should render with default props 1`] = `
 </modus-wc-icon>
 `;
 
+exports[`modus-wc-icon should render with outlined variant 1`] = `
+<modus-wc-icon class="modus-wc-flex modus-wc-items-center" variant="outlined">
+  <i aria-hidden="true" aria-label="Outlined icon" class="modus-icons-outlined modus-wc-icon modus-wc-icon--md" tabindex="-1"></i>
+</modus-wc-icon>
+`;
+
 exports[`modus-wc-icon should render with size prop lg 1`] = `
 <modus-wc-icon class="modus-wc-flex modus-wc-items-center" size="lg">
   <i aria-hidden="true" aria-label="Custom icon" class="modus-icons modus-wc-icon modus-wc-icon--lg" tabindex="-1"></i>
+</modus-wc-icon>
+`;
+
+exports[`modus-wc-icon should render with solid variant 1`] = `
+<modus-wc-icon class="modus-wc-flex modus-wc-items-center" variant="solid">
+  <i aria-hidden="true" aria-label="Solid icon" class="modus-icons-solid modus-wc-icon modus-wc-icon--md" tabindex="-1"></i>
 </modus-wc-icon>
 `;

--- a/src/components/modus-wc-icon/modus-wc-icon.scss
+++ b/src/components/modus-wc-icon/modus-wc-icon.scss
@@ -1,4 +1,6 @@
-modus-wc-icon .modus-icons {
+modus-wc-icon .modus-icons,
+modus-wc-icon .modus-icons-outlined,
+modus-wc-icon .modus-icons-solid {
   &.modus-wc-icon--xs {
     font-size: 1rem;
   }

--- a/src/components/modus-wc-icon/modus-wc-icon.spec.ts
+++ b/src/components/modus-wc-icon/modus-wc-icon.spec.ts
@@ -25,4 +25,20 @@ describe('modus-wc-icon', () => {
     });
     expect(page.root).toMatchSnapshot();
   });
+
+  it('should render with outlined variant', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcIcon],
+      html: '<modus-wc-icon aria-label="Outlined icon" variant="outlined"></modus-wc-icon>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with solid variant', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcIcon],
+      html: '<modus-wc-icon aria-label="Solid icon" variant="solid"></modus-wc-icon>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
 });

--- a/src/components/modus-wc-icon/modus-wc-icon.stories.ts
+++ b/src/components/modus-wc-icon/modus-wc-icon.stories.ts
@@ -46,7 +46,7 @@ const Template: Story = {
   ?decorative="${args.decorative}"
   name="${args.name}"
   size="${args.size}"
-  variant="${args.variant}"
+  variant="${ifDefined(args.variant)}"
 >
 </modus-wc-icon>
     `;

--- a/src/components/modus-wc-icon/modus-wc-icon.stories.ts
+++ b/src/components/modus-wc-icon/modus-wc-icon.stories.ts
@@ -46,7 +46,7 @@ const Template: Story = {
   ?decorative="${args.decorative}"
   name="${args.name}"
   size="${args.size}"
-  ?variant="${args.variant}"
+  variant="${args.variant}"
 >
 </modus-wc-icon>
     `;

--- a/src/components/modus-wc-icon/modus-wc-icon.stories.ts
+++ b/src/components/modus-wc-icon/modus-wc-icon.stories.ts
@@ -8,7 +8,7 @@ interface IconArgs {
   decorative: boolean;
   name: string;
   size: DaisySize;
-  variant: 'outlined' | 'solid' | 'default';
+  variant?: 'outlined' | 'solid';
 }
 
 const meta: Meta<IconArgs> = {
@@ -19,7 +19,6 @@ const meta: Meta<IconArgs> = {
     decorative: false,
     name: 'alert',
     size: 'md',
-    variant: 'default',
   },
   argTypes: {
     size: {
@@ -28,7 +27,7 @@ const meta: Meta<IconArgs> = {
     },
     variant: {
       control: { type: 'select' },
-      options: ['default', 'outlined', 'solid'],
+      options: ['outlined', 'solid'],
     },
   },
 };
@@ -47,7 +46,7 @@ const Template: Story = {
   ?decorative="${args.decorative}"
   name="${args.name}"
   size="${args.size}"
-  variant="${args.variant}"
+  ?variant="${args.variant}"
 >
 </modus-wc-icon>
     `;

--- a/src/components/modus-wc-icon/modus-wc-icon.stories.ts
+++ b/src/components/modus-wc-icon/modus-wc-icon.stories.ts
@@ -8,6 +8,7 @@ interface IconArgs {
   decorative: boolean;
   name: string;
   size: DaisySize;
+  variant: 'outlined' | 'solid' | 'default';
 }
 
 const meta: Meta<IconArgs> = {
@@ -18,11 +19,16 @@ const meta: Meta<IconArgs> = {
     decorative: false,
     name: 'alert',
     size: 'md',
+    variant: 'default',
   },
   argTypes: {
     size: {
       control: { type: 'select' },
       options: ['xs', 'sm', 'md', 'lg'],
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['default', 'outlined', 'solid'],
     },
   },
 };
@@ -41,6 +47,7 @@ const Template: Story = {
   ?decorative="${args.decorative}"
   name="${args.name}"
   size="${args.size}"
+  variant="${args.variant}"
 >
 </modus-wc-icon>
     `;

--- a/src/components/modus-wc-icon/modus-wc-icon.tsx
+++ b/src/components/modus-wc-icon/modus-wc-icon.tsx
@@ -32,7 +32,7 @@ export class ModusWcIcon {
   @Prop() size?: DaisySize = 'md';
 
   /** The icon variant, can be "outlined" or "solid". */
-  @Prop() variant?: 'outlined' | 'solid' | 'default' = 'default';
+  @Prop() variant?: 'outlined' | 'solid';
 
   componentWillLoad() {
     if (!this.decorative && !this.el.ariaLabel) {

--- a/src/components/modus-wc-icon/modus-wc-icon.tsx
+++ b/src/components/modus-wc-icon/modus-wc-icon.tsx
@@ -31,6 +31,9 @@ export class ModusWcIcon {
   /** The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon. */
   @Prop() size?: DaisySize = 'md';
 
+  /** The icon variant, can be "outlined" or "solid". */
+  @Prop() variant?: 'outlined' | 'solid' | 'default' = 'default';
+
   componentWillLoad() {
     if (!this.decorative && !this.el.ariaLabel) {
       this.el.ariaLabel = `${this.name} icon`;
@@ -40,10 +43,24 @@ export class ModusWcIcon {
   }
 
   private getClasses(): string {
-    const classList = ['modus-wc-icon modus-icons'];
+    let classList: string[] = [];
 
-    // The order CSS classes are added matters to CSS specificity
+    // Add base class
+    classList.push('modus-wc-icon');
+
+    // Add icon font class based on variant
+    if (this.variant === 'outlined') {
+      classList.push('modus-icons-outlined');
+    } else if (this.variant === 'solid') {
+      classList.push('modus-icons-solid');
+    } else {
+      classList.push('modus-icons');
+    }
+
+    // Add size class - this is common for all variants
     classList.push(`modus-wc-icon--${this.size}`);
+
+    // Add custom class if provided
     if (this.customClass) classList.push(this.customClass);
 
     return classList.join(' ');

--- a/src/components/modus-wc-icon/readme.md
+++ b/src/components/modus-wc-icon/readme.md
@@ -13,12 +13,13 @@ A customizable icon component used to render Modus icons.
 
 ## Properties
 
-| Property            | Attribute      | Description                                                                                                              | Type                                        | Default     |
-| ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- | ----------- |
-| `customClass`       | `custom-class` | Custom CSS class to apply to the i element.                                                                              | `string \| undefined`                       | `''`        |
-| `decorative`        | `decorative`   | Indicates that the icon is decorative. When true, sets aria-hidden to hide the icon from screen readers.                 | `boolean \| undefined`                      | `true`      |
-| `name` _(required)_ | `name`         | The icon name, should match the CSS class in the icon font.                                                              | `string`                                    | `undefined` |
-| `size`              | `size`         | The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon. | `"lg" \| "md" \| "sm" \| "xs" \| undefined` | `'md'`      |
+| Property            | Attribute      | Description                                                                                                              | Type                                              | Default     |
+| ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | ----------- |
+| `customClass`       | `custom-class` | Custom CSS class to apply to the i element.                                                                              | `string \| undefined`                             | `''`        |
+| `decorative`        | `decorative`   | Indicates that the icon is decorative. When true, sets aria-hidden to hide the icon from screen readers.                 | `boolean \| undefined`                            | `true`      |
+| `name` _(required)_ | `name`         | The icon name, should match the CSS class in the icon font.                                                              | `string`                                          | `undefined` |
+| `size`              | `size`         | The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon. | `"lg" \| "md" \| "sm" \| "xs" \| undefined`       | `'md'`      |
+| `variant`           | `variant`      | The icon variant, can be "outlined" or "solid".                                                                          | `"default" \| "outlined" \| "solid" \| undefined` | `'default'` |
 
 
 ## Dependencies

--- a/src/components/modus-wc-icon/readme.md
+++ b/src/components/modus-wc-icon/readme.md
@@ -13,13 +13,13 @@ A customizable icon component used to render Modus icons.
 
 ## Properties
 
-| Property            | Attribute      | Description                                                                                                              | Type                                              | Default     |
-| ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- | ----------- |
-| `customClass`       | `custom-class` | Custom CSS class to apply to the i element.                                                                              | `string \| undefined`                             | `''`        |
-| `decorative`        | `decorative`   | Indicates that the icon is decorative. When true, sets aria-hidden to hide the icon from screen readers.                 | `boolean \| undefined`                            | `true`      |
-| `name` _(required)_ | `name`         | The icon name, should match the CSS class in the icon font.                                                              | `string`                                          | `undefined` |
-| `size`              | `size`         | The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon. | `"lg" \| "md" \| "sm" \| "xs" \| undefined`       | `'md'`      |
-| `variant`           | `variant`      | The icon variant, can be "outlined" or "solid".                                                                          | `"default" \| "outlined" \| "solid" \| undefined` | `'default'` |
+| Property            | Attribute      | Description                                                                                                              | Type                                        | Default     |
+| ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------- | ----------- |
+| `customClass`       | `custom-class` | Custom CSS class to apply to the i element.                                                                              | `string \| undefined`                       | `''`        |
+| `decorative`        | `decorative`   | Indicates that the icon is decorative. When true, sets aria-hidden to hide the icon from screen readers.                 | `boolean \| undefined`                      | `true`      |
+| `name` _(required)_ | `name`         | The icon name, should match the CSS class in the icon font.                                                              | `string`                                    | `undefined` |
+| `size`              | `size`         | The icon size, can be "sm", "md", "lg" (a custom size can be specified in CSS). This adjusts the font size for the icon. | `"lg" \| "md" \| "sm" \| "xs" \| undefined` | `'md'`      |
+| `variant`           | `variant`      | The icon variant, can be "outlined" or "solid".                                                                          | `"outlined" \| "solid" \| undefined`        | `undefined` |
 
 
 ## Dependencies

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -8,7 +8,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable accordion component used for showing and hiding related groups of content.\n\nThe component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.",
+          "description": "A customizable accordion component used for showing and hiding related groups of content.\r\n\r\nThe component supports a `<slot>` for injecting `<modus-wc-collapse>` elements. See [Collapse](/docs/components-collapse--docs) docs for additional info.",
           "name": "ModusWcAccordion",
           "members": [
             {
@@ -41,7 +41,7 @@
               "kind": "field",
               "name": "expandedChange",
               "type": {
-                "text": "EventEmitter<{\n    expanded: boolean;\n    index: number;\n  }>"
+                "text": "EventEmitter<{\r\n    expanded: boolean;\r\n    index: number;\r\n  }>"
               },
               "description": "When a collapse expanded state is changed, this event outputs the relevant index and state"
             }
@@ -280,7 +280,7 @@
             {
               "name": "props",
               "type": {
-                "text": "{\n  bordered?: boolean;\n  disabled?: boolean;\n  readOnly?: boolean;\n  size?: ModusSize;\n}"
+                "text": "{\r\n  bordered?: boolean;\r\n  disabled?: boolean;\r\n  readOnly?: boolean;\r\n  size?: ModusSize;\r\n}"
               }
             }
           ]
@@ -332,7 +332,7 @@
             {
               "name": "params",
               "type": {
-                "text": "{\n  initialNavigation: boolean;\n  visibleItems: IAutocompleteItem[];\n  onUpdateFocus: (value: string) => void;\n  onSetInitialNavigation: (value: boolean) => void;\n}"
+                "text": "{\r\n  initialNavigation: boolean;\r\n  visibleItems: IAutocompleteItem[];\r\n  onUpdateFocus: (value: string) => void;\r\n  onSetInitialNavigation: (value: boolean) => void;\r\n}"
               }
             }
           ]
@@ -355,7 +355,7 @@
             {
               "name": "params",
               "type": {
-                "text": "{\n    multiSelect?: boolean;\n    selectionOrder: string[];\n    items?: IAutocompleteItem[];\n    onChipRemove: (item: IAutocompleteItem) => void;\n  }"
+                "text": "{\r\n    multiSelect?: boolean;\r\n    selectionOrder: string[];\r\n    items?: IAutocompleteItem[];\r\n    onChipRemove: (item: IAutocompleteItem) => void;\r\n  }"
               }
             }
           ]
@@ -365,7 +365,7 @@
           "name": "processChipRemoval",
           "return": {
             "type": {
-              "text": "{\n  updatedItems: IAutocompleteItem[] | undefined;\n  updatedSelectionOrder: string[];\n}"
+              "text": "{\r\n  updatedItems: IAutocompleteItem[] | undefined;\r\n  updatedSelectionOrder: string[];\r\n}"
             }
           },
           "parameters": [
@@ -378,7 +378,7 @@
             {
               "name": "params",
               "type": {
-                "text": "{\n    disabled?: boolean;\n    readOnly?: boolean;\n    items?: IAutocompleteItem[];\n    selectionOrder: string[];\n  }"
+                "text": "{\r\n    disabled?: boolean;\r\n    readOnly?: boolean;\r\n    items?: IAutocompleteItem[];\r\n    selectionOrder: string[];\r\n  }"
               }
             }
           ]
@@ -388,7 +388,7 @@
           "name": "processInputChange",
           "return": {
             "type": {
-              "text": "{\n  inputValue: string;\n  shouldShowMenu: boolean;\n  updatedItems: IAutocompleteItem[] | undefined;\n  shouldResetNavigation: boolean;\n}"
+              "text": "{\r\n  inputValue: string;\r\n  shouldShowMenu: boolean;\r\n  updatedItems: IAutocompleteItem[] | undefined;\r\n  shouldResetNavigation: boolean;\r\n}"
             }
           },
           "parameters": [
@@ -401,7 +401,7 @@
             {
               "name": "params",
               "type": {
-                "text": "{\n    disabled?: boolean;\n    readOnly?: boolean;\n    customInputChange?: (value: string) => void;\n    showMenuOnFocus?: boolean;\n    minChars: number;\n    items?: IAutocompleteItem[];\n    multiSelect?: boolean;\n    debounceMs?: number;\n  }"
+                "text": "{\r\n    disabled?: boolean;\r\n    readOnly?: boolean;\r\n    customInputChange?: (value: string) => void;\r\n    showMenuOnFocus?: boolean;\r\n    minChars: number;\r\n    items?: IAutocompleteItem[];\r\n    multiSelect?: boolean;\r\n    debounceMs?: number;\r\n  }"
               }
             }
           ]
@@ -411,7 +411,7 @@
           "name": "processItemSelection",
           "return": {
             "type": {
-              "text": "{\n  updatedItems: IAutocompleteItem[] | undefined;\n  updatedValue: string | undefined;\n  updatedSelectionOrder: string[];\n  shouldExpandChips: boolean;\n  shouldCloseMenu: boolean;\n}"
+              "text": "{\r\n  updatedItems: IAutocompleteItem[] | undefined;\r\n  updatedValue: string | undefined;\r\n  updatedSelectionOrder: string[];\r\n  shouldExpandChips: boolean;\r\n  shouldCloseMenu: boolean;\r\n}"
             }
           },
           "parameters": [
@@ -424,7 +424,7 @@
             {
               "name": "params",
               "type": {
-                "text": "{\n    disabled?: boolean;\n    readOnly?: boolean;\n    items?: IAutocompleteItem[];\n    multiSelect?: boolean;\n    leaveMenuOpen?: boolean;\n    selectionOrder: string[];\n    maxChips?: number;\n    customItemSelect?: (item: IAutocompleteItem) => void;\n  }"
+                "text": "{\r\n    disabled?: boolean;\r\n    readOnly?: boolean;\r\n    items?: IAutocompleteItem[];\r\n    multiSelect?: boolean;\r\n    leaveMenuOpen?: boolean;\r\n    selectionOrder: string[];\r\n    maxChips?: number;\r\n    customItemSelect?: (item: IAutocompleteItem) => void;\r\n  }"
               }
             }
           ]
@@ -447,7 +447,7 @@
             {
               "name": "params",
               "type": {
-                "text": "{\n    disabled?: boolean;\n    readOnly?: boolean;\n    customKeyDown?: (event: KeyboardEvent) => void;\n  }"
+                "text": "{\r\n    disabled?: boolean;\r\n    readOnly?: boolean;\r\n    customKeyDown?: (event: KeyboardEvent) => void;\r\n  }"
               }
             }
           ]
@@ -952,7 +952,7 @@
               "name": "debounce-ms",
               "fieldName": "debounceMs",
               "default": "300",
-              "description": "The debounce timeout in milliseconds.\nSet to 0 to disable debouncing.",
+              "description": "The debounce timeout in milliseconds.\r\nSet to 0 to disable debouncing.",
               "type": {
                 "text": "number"
               }
@@ -1004,7 +1004,7 @@
               "name": "items",
               "fieldName": "items",
               "default": "[]",
-              "description": "The items to display in the menu.\nCreating a new array of items will ensure proper component re-render.",
+              "description": "The items to display in the menu.\r\nCreating a new array of items will ensure proper component re-render.",
               "type": {
                 "text": "IAutocompleteItem[]"
               }
@@ -1175,7 +1175,7 @@
               "type": {
                 "text": "EventEmitter<Event>"
               },
-              "description": "Event emitted when the input value changes.\nThis event is debounced based on the debounceMs prop."
+              "description": "Event emitted when the input value changes.\r\nThis event is debounced based on the debounceMs prop."
             },
             {
               "kind": "field",
@@ -1314,7 +1314,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\n\nThe component supports a `<slot>` for injecting content within the badge.",
+          "description": "A customizable badge component used to create badges with different sizes, types, and colors.\r\n\r\nThe component supports a `<slot>` for injecting content within the badge.",
           "name": "ModusWcBadge",
           "members": [
             {
@@ -1337,7 +1337,7 @@
               "default": "'primary'",
               "description": "The color variant of the badge.",
               "type": {
-                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'high-contrast'\n    | 'success'\n    | 'warning'\n    | 'danger'"
+                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'high-contrast'\r\n    | 'success'\r\n    | 'warning'\r\n    | 'danger'"
               }
             },
             {
@@ -1481,7 +1481,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\n\nThe component supports a `<slot>` for injecting content within the button, similar to a native HTML button",
+          "description": "A customizable button component used to create buttons with different sizes, variants, and types.\r\n\r\nThe component supports a `<slot>` for injecting content within the button, similar to a native HTML button",
           "name": "ModusWcButton",
           "members": [
             {
@@ -2006,7 +2006,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable collapse component used for showing and hiding content.\n\nThe component supports a 'header' and 'content' `<slot>` for injecting custom HTML.\nDo not set",
+          "description": "A customizable collapse component used for showing and hiding content.\r\n\r\nThe component supports a 'header' and 'content' `<slot>` for injecting custom HTML.\r\nDo not set",
           "name": "ModusWcCollapse",
           "members": [
             {
@@ -2073,7 +2073,7 @@
             {
               "name": "options",
               "fieldName": "options",
-              "description": "Configuration options for rendering the pre-laid out collapse component.\nDo not set this prop if you intend to use the 'header' slot.",
+              "description": "Configuration options for rendering the pre-laid out collapse component.\r\nDo not set this prop if you intend to use the 'header' slot.",
               "type": {
                 "text": "ICollapseOptions"
               }
@@ -2118,7 +2118,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable date picker component used to create date inputs.\n\nAdheres to WCAG 2.2 standards.",
+          "description": "A customizable date picker component used to create date inputs.\r\n\r\nAdheres to WCAG 2.2 standards.",
           "name": "ModusWcDate",
           "members": [
             {
@@ -2333,7 +2333,7 @@
               "default": "'tertiary'",
               "description": "The color of the divider line.",
               "type": {
-                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'high-contrast'\n    | 'success'\n    | 'warning'\n    | 'danger'"
+                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'high-contrast'\r\n    | 'success'\r\n    | 'warning'\r\n    | 'danger'"
               }
             },
             {
@@ -2442,7 +2442,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable dropdown menu component used to render a button and toggleable menu.\n\nThe component supports a 'button' and 'menu' `<slot>` for injecting custom HTML content.",
+          "description": "A customizable dropdown menu component used to render a button and toggleable menu.\r\n\r\nThe component supports a 'button' and 'menu' `<slot>` for injecting custom HTML content.",
           "name": "ModusWcDropdownMenu",
           "members": [
             {
@@ -2509,7 +2509,7 @@
               "default": "'primary'",
               "description": "The color variant of the button.",
               "type": {
-                "text": "| 'primary'\n    | 'secondary'\n    | 'tertiary'\n    | 'warning'\n    | 'danger'"
+                "text": "| 'primary'\r\n    | 'secondary'\r\n    | 'tertiary'\r\n    | 'warning'\r\n    | 'danger'"
               }
             },
             {
@@ -2633,7 +2633,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable icon component used to render Modus icons.\n\n<b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
+          "description": "A customizable icon component used to render Modus icons.\r\n\r\n<b>This component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
           "name": "ModusWcIcon",
           "members": [
             {
@@ -2684,6 +2684,15 @@
               "type": {
                 "text": "DaisySize"
               }
+            },
+            {
+              "name": "variant",
+              "fieldName": "variant",
+              "default": "'default'",
+              "description": "The icon variant, can be \"outlined\" or \"solid\".",
+              "type": {
+                "text": "'outlined' | 'solid' | 'default'"
+              }
             }
           ],
           "tagName": "modus-wc-icon",
@@ -2716,7 +2725,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable feedback component used to provide additional context related to form input interactions.\n\n<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
+          "description": "A customizable feedback component used to provide additional context related to form input interactions.\r\n\r\n<b>To use a custom icon, this component requires Modus icons to be installed in the host application. See [Modus Icon Usage](/docs/documentation-modus-icon-usage--docs) for steps.</b>",
           "name": "ModusWcInputFeedback",
           "members": [
             {
@@ -2808,7 +2817,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable input label component.\n\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text",
+          "description": "A customizable input label component.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the label, such as icons or formatted text",
           "name": "ModusWcInputLabel",
           "members": [
             {
@@ -3131,7 +3140,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable menu component used to display a list of li elements vertically or horizontally.\n\nThe component supports a `<slot>` for injecting custom li elements inside the ul",
+          "description": "A customizable menu component used to display a list of li elements vertically or horizontally.\r\n\r\nThe component supports a `<slot>` for injecting custom li elements inside the ul",
           "name": "ModusWcMenu",
           "members": [
             {
@@ -3223,7 +3232,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable modal component used to display content in a dialog.\n\nThe component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML",
+          "description": "A customizable modal component used to display content in a dialog.\r\n\r\nThe component supports a 'header', 'content', and 'footer' <slot> for injecting custom HTML",
           "name": "ModusWcModal",
           "members": [
             {
@@ -3244,7 +3253,7 @@
               "name": "backdrop",
               "fieldName": "backdrop",
               "default": "'default'",
-              "description": "The modal's backdrop.\nSpecify 'static' for a backdrop that doesn't close the modal when clicked outside the modal content.",
+              "description": "The modal's backdrop.\r\nSpecify 'static' for a backdrop that doesn't close the modal when clicked outside the modal content.",
               "type": {
                 "text": "'default' | 'static'"
               }
@@ -3333,7 +3342,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable navbar component used for top level navigation of all Trimble applications.\n\nThe component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.\nIt also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML",
+          "description": "A customizable navbar component used for top level navigation of all Trimble applications.\r\n\r\nThe component supports a 'main-menu', 'notifications', and 'apps' `<slot>` for injecting custom HTML menus.\r\nIt also supports a 'start', 'center', and 'end' `<slot>` for injecting additional custom HTML",
           "name": "ModusWcNavbar",
           "members": [
             {
@@ -3975,7 +3984,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable progress component used to show the progress of a task or show the passing of time.\n\nThe radial variant supports slotting in custom HTML to be displayed within the progress circle",
+          "description": "A customizable progress component used to show the progress of a task or show the passing of time.\r\n\r\nThe radial variant supports slotting in custom HTML to be displayed within the progress circle",
           "name": "ModusWcProgress",
           "members": [
             {
@@ -4076,7 +4085,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable radio button component used to create radio inputs.",
+          "description": "A customizable radio button component.",
           "name": "ModusWcRadio",
           "members": [
             {
@@ -4354,7 +4363,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable select component used to create selects with different options.",
+          "description": "A customizable select component used to pick a value from a list of options",
           "name": "ModusWcSelect",
           "members": [
             {
@@ -5408,7 +5417,7 @@
               "kind": "field",
               "name": "cellEditCommit",
               "type": {
-                "text": "EventEmitter<{\n    rowIndex: number;\n    colId: string;\n    newValue: unknown;\n    updatedRow: Record<string, unknown>;\n  }>"
+                "text": "EventEmitter<{\r\n    rowIndex: number;\r\n    colId: string;\r\n    newValue: unknown;\r\n    updatedRow: Record<string, unknown>;\r\n  }>"
               },
               "description": "Emits when cell editing is committed with the new value."
             },
@@ -5416,7 +5425,7 @@
               "kind": "field",
               "name": "cellEditStart",
               "type": {
-                "text": "EventEmitter<{\n    rowIndex: number;\n    colId: string;\n  }>"
+                "text": "EventEmitter<{\r\n    rowIndex: number;\r\n    colId: string;\r\n  }>"
               },
               "description": "Emits when cell editing starts."
             },
@@ -5432,7 +5441,7 @@
               "kind": "field",
               "name": "rowClick",
               "type": {
-                "text": "EventEmitter<{\n    row: Record<string, unknown>;\n    index: number;\n  }>"
+                "text": "EventEmitter<{\r\n    row: Record<string, unknown>;\r\n    index: number;\r\n  }>"
               },
               "description": "Emits when a row is clicked."
             },
@@ -5440,7 +5449,7 @@
               "kind": "field",
               "name": "rowSelectionChange",
               "type": {
-                "text": "EventEmitter<{\n    selectedRows: Record<string, unknown>[];\n    selectedRowIds: string[];\n  }>"
+                "text": "EventEmitter<{\r\n    selectedRows: Record<string, unknown>[];\r\n    selectedRowIds: string[];\r\n  }>"
               },
               "description": "Emits when row selection changes with the selected rows and their IDs."
             },
@@ -5547,7 +5556,7 @@
               "kind": "field",
               "name": "tabChange",
               "type": {
-                "text": "EventEmitter<{\n    previousTab: number;\n    newTab: number;\n  }>"
+                "text": "EventEmitter<{\r\n    previousTab: number;\r\n    newTab: number;\r\n  }>"
               },
               "description": "When a tab is switched to, this event outputs the relevant indices"
             }
@@ -5602,7 +5611,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
+                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
               }
             },
             {
@@ -5662,7 +5671,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
+                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
               }
             },
             {
@@ -5914,7 +5923,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
+                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
               }
             },
             {
@@ -6074,7 +6083,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A theme switcher component used to toggle the application theme and/or mode.\n\nAllows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).",
+          "description": "A theme switcher component used to toggle the application theme and/or mode.\r\n\r\nAllows consumers to set the initial theme (Modus Classic, Modus Modern, etc.) and end-users to toggle modes (Light, Dark).",
           "name": "ModusWcThemeSwitcher",
           "members": [
             {
@@ -6189,7 +6198,7 @@
             {
               "name": "datalist-id",
               "fieldName": "datalistId",
-              "description": "ID of a `<datalist>` element that contains pre-defined time options.\nThe value must be the ID of a `<datalist>` element in the same document.",
+              "description": "ID of a `<datalist>` element that contains pre-defined time options.\r\nThe value must be the ID of a `<datalist>` element in the same document.",
               "type": {
                 "text": "string"
               }
@@ -6290,7 +6299,7 @@
               "name": "show-seconds",
               "fieldName": "showSeconds",
               "default": "false",
-              "description": "Displays the time input format as `HH:mm:ss` if `true`.\nInternally sets the `step` to 1 second.\nIf a `step` value is provided, it will override this attribute.",
+              "description": "Displays the time input format as `HH:mm:ss` if `true`.\r\nInternally sets the `step` to 1 second.\r\nIf a `step` value is provided, it will override this attribute.",
               "type": {
                 "text": "boolean"
               }
@@ -6307,7 +6316,7 @@
             {
               "name": "step",
               "fieldName": "step",
-              "description": "Specifies the granularity that the `value` must adhere to.\nValue of step given in seconds. Default value is 60 seconds.\nOverrides the `seconds` attribute if both are provided.",
+              "description": "Specifies the granularity that the `value` must adhere to.\r\nValue of step given in seconds. Default value is 60 seconds.\r\nOverrides the `seconds` attribute if both are provided.",
               "type": {
                 "text": "number"
               }
@@ -6316,7 +6325,7 @@
               "name": "value",
               "fieldName": "value",
               "default": "''",
-              "description": "The value of the time input.\nAlways in 24-hour format that includes leading zeros:\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\nto be selected based on user's locale (or by the user agent).\nIf time includes seconds the format is always `HH:mm:ss`.",
+              "description": "The value of the time input.\r\nAlways in 24-hour format that includes leading zeros:\r\n`HH:mm` or `HH:mm:ss`, regardless of input format which is likely\r\nto be selected based on user's locale (or by the user agent).\r\nIf time includes seconds the format is always `HH:mm:ss`.",
               "type": {
                 "text": "string"
               }
@@ -6377,7 +6386,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable toast component used to stack elements, positioned on the corner of a page.\n\nThe component supports a `<slot>` for injecting additional custom content inside the toast.",
+          "description": "A customizable toast component used to stack elements, positioned on the corner of a page.\r\n\r\nThe component supports a `<slot>` for injecting additional custom content inside the toast.",
           "name": "ModusWcToast",
           "members": [
             {
@@ -6529,7 +6538,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable tooltip component used to create tooltips with different content.\n\nThe tooltip can be dismissed by pressing the Escape key.",
+          "description": "A customizable tooltip component used to create tooltips with different content.\r\n\r\nThe tooltip can be dismissed by pressing the Escape key when hovering over it.\r\nWhen forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.",
           "name": "ModusWcTooltip",
           "members": [
             {
@@ -6558,30 +6567,12 @@
               ]
             },
             {
-              "kind": "field",
-              "name": "escapeDismissed",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Track if tooltip was dismissed with Escape key"
-            },
-            {
               "kind": "method",
               "name": "handleMouseEnter"
             },
             {
               "kind": "method",
               "name": "handleMouseLeave"
-            },
-            {
-              "kind": "field",
-              "name": "isVisible",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Track if tooltip is currently visible"
             },
             {
               "kind": "method",

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -6545,7 +6545,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable tooltip component used to create tooltips with different content.\n\nThe tooltip can be dismissed by pressing the Escape key when hovering over it.\nWhen forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.",
+          "description": "A customizable tooltip component used to create tooltips with different content.\r\n\r\nThe tooltip can be dismissed by pressing the Escape key when hovering over it.\r\nWhen forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.",
           "name": "ModusWcTooltip",
           "members": [
             {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -2688,10 +2688,9 @@
             {
               "name": "variant",
               "fieldName": "variant",
-              "default": "'default'",
               "description": "The icon variant, can be \"outlined\" or \"solid\".",
               "type": {
-                "text": "'outlined' | 'solid' | 'default'"
+                "text": "'outlined' | 'solid'"
               }
             }
           ],

--- a/src/stories/modus-icon-usage.mdx
+++ b/src/stories/modus-icon-usage.mdx
@@ -6,7 +6,7 @@ import { Meta } from '@storybook/blocks';
 
 Modus Web Components require Modus Icons.
 
-Starting from v0.0.0-beta.3, the Web Components package supports both outlined and solid icon variants through a single CSS file.
+Starting from v0.0.0-beta.5, the Web Components package supports both outlined and solid icon variants through a single CSS file.
 
 ## 1. Installation
 
@@ -174,19 +174,19 @@ Once the stylesheet is loaded, you can use icons in any framework:
 ### React
 
 ```tsx
-import { ModusWcIcon as ModusIcon } from '@trimble-oss/moduswebcomponents-react';
+import { ModusWcIcon } from '@trimble-oss/moduswebcomponents-react';
 
 export function IconExamples() {
   return (
     <div>
       {/* Outlined */}
-      <ModusIcon name="alert" variant="outlined" />
+      <ModusWcIcon name="alert" variant="outlined" />
 
       {/* Solid */}
-      <ModusIcon name="alert" variant="solid" />
+      <ModusWcIcon name="alert" variant="solid" />
 
       {/* Accessible icon */}
-      <ModusIcon
+      <ModusWcIcon
         name="accessibility_circle"
         variant="solid"
         decorative={false}
@@ -194,7 +194,7 @@ export function IconExamples() {
       />
 
       {/* Custom styling */}
-      <ModusIcon
+      <ModusWcIcon
         name="add_bold"
         variant="outlined"
         decorative

--- a/src/stories/modus-icon-usage.mdx
+++ b/src/stories/modus-icon-usage.mdx
@@ -10,6 +10,8 @@ Starting from v0.0.0-beta.3, the Web Components package supports both outlined a
 
 ## 1. Installation
 
+### Option A: Online Usage (CDN)
+
 Create a file at:
 
 ```
@@ -72,3 +74,139 @@ Then include it in your app:
   <link rel="stylesheet" href="/modus-web-components/modus-icons.css" />
 </head>
 ```
+
+### Option B: Offline Usage
+
+For applications requiring offline capability, follow these steps:
+
+1. Install the Modus Icons package:
+
+```bash
+npm install @trimble-oss/modus-icons
+```
+
+2. Download the font files:
+
+```
+node_modules/@trimble-oss/modus-icons/dist/modus-outlined/fonts/modus-icons.woff2
+node_modules/@trimble-oss/modus-icons/dist/modus-solid/fonts/modus-icons.woff2
+```
+
+3. Create this directory structure in your project:
+
+```
+public/
+  └── modus-web-components/
+      ├── fonts/
+      │   ├── modus-icons-outlined.woff2  (renamed from modus-outlined/fonts/modus-icons.woff2)
+      │   └── modus-icons-solid.woff2     (renamed from modus-solid/fonts/modus-icons.woff2)
+      └── modus-icons.css
+```
+
+4. Create a modified `modus-icons.css` file that references the local font files:
+
+```css
+@font-face {
+  font-family: 'modus-icons';
+  src: url('./fonts/modus-icons-outlined.woff2') format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'modus-icons-outlined';
+  src: url('./fonts/modus-icons-outlined.woff2') format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'modus-icons-solid';
+  src: url('./fonts/modus-icons-solid.woff2') format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+.modus-icons-outlined {
+  font-family: 'modus-icons-outlined';
+  font-style: normal;
+  font-weight: normal;
+}
+
+.modus-icons-solid {
+  font-family: 'modus-icons-solid';
+  font-style: normal;
+  font-weight: normal;
+}
+
+.modus-icons {
+  font-family: 'modus-icons';
+  font-style: normal;
+  font-weight: normal;
+}
+```
+
+5. Include the CSS file in your HTML just as in the online version:
+
+```html
+<head>
+  <link rel="stylesheet" href="/modus-web-components/modus-icons.css" />
+</head>
+```
+
+## 2. Usage in Components
+
+Once the stylesheet is loaded, you can use icons in any framework:
+
+### Web Components
+
+```html
+<!-- Outlined icon (default) -->
+<modus-wc-icon name="alert" variant="outlined"></modus-wc-icon>
+
+<!-- Solid icon -->
+<modus-wc-icon name="alert" variant="solid"></modus-wc-icon>
+```
+
+### React
+
+```tsx
+import { ModusWcIcon as ModusIcon } from "@trimble-oss/moduswebcomponents-react";
+
+export function IconExamples() {
+  return (
+    <div>
+      {/* Outlined */}
+      <ModusIcon name="alert" variant="outlined" />
+
+      {/* Solid */}
+      <ModusIcon name="alert" variant="solid" />
+
+      {/* Accessible icon */}
+      <ModusIcon
+        name="accessibility_circle"
+        variant="solid"
+        decorative={false}
+        aria-label="Accessibility features"
+      />
+
+      {/* Custom styling */}
+      <ModusIcon
+        name="add_bold"
+        variant="outlined"
+        decorative
+        style={{ color: "var(--modus-wc-color-trimble-blue)" }}
+      />
+    </div>
+  );
+}
+```
+
+### Angular, Vue, etc.
+
+Follow the same approach — just make sure to include the global CSS file once in your application.
+
+

--- a/src/stories/modus-icon-usage.mdx
+++ b/src/stories/modus-icon-usage.mdx
@@ -8,12 +8,18 @@ Several components require [Modus icons](https://modus-icons.trimble.com) to be 
 icons, add the following html to your application.
 
 <b>
-  Modus (font) icons currently only supports the usage of one icon set
-  (outlined, filled, transportation) per application. If you require multiple
-  sets, reach out to [Modus
-  Design](https://mail.google.com/chat/u/0/#chat/space/AAAAexugR1k) and comment
-  on this [GitHub Issue](https://github.com/trimble-oss/modus-icons/issues/363).
+  Starting from version 0.0.0-beta.3, Modus Web Components now includes the CSS for
+  both outlined and solid icon variants. You can use either set by importing the
+  `modus-icons.css` file.
 </b>
+
+```html
+<head>
+  <link rel="stylesheet" href="path-to-your-assets/modus-icons.css" />
+</head>
+```
+
+You can also still use the CDN approach:
 
 ```html
 <head>
@@ -40,14 +46,26 @@ For applications requiring offline capability or improved performance, you can b
 npm install @trimble-oss/modus-icons
 ```
 
-### 2. Copy the required font files and styles to your application:
+### 2. Use the pre-bundled Modus Icons CSS file:
+
+If you're using Modus Web Components, you can directly import the bundled CSS file:
+
+```html
+<link rel="stylesheet" href="/path-to-modus-web-components/modus-icons.css" />
+```
+
+This file includes both outlined and solid variants, which you can use with these classes:
+
+- `.modus-icons-outlined` - For outlined icons
+- `.modus-icons-solid` - For solid icons
+- `.modus-icons` - For default style (depends on which specific icon file was loaded last)
+
+### 3. Or copy the required font files and styles manually:
 
 - From `node_modules/@trimble-oss/modus-icons/dist/modus-outlined/fonts/`, copy:
   - `modus-icons.css`
   - Font files (.woff, .woff2, etc.)
 - Place them in a publicly accessible directory (e.g., /public/fonts/).
-
-### 3. Reference the local stylesheet in your application:
 
 ```html
 <head>

--- a/src/stories/modus-icon-usage.mdx
+++ b/src/stories/modus-icon-usage.mdx
@@ -8,9 +8,9 @@ Several components require [Modus icons](https://modus-icons.trimble.com) to be 
 icons, add the following html to your application.
 
 <b>
-  Starting from version 0.0.0-beta.3, Modus Web Components now includes the CSS for
-  both outlined and solid icon variants. You can use either set by importing the
-  `modus-icons.css` file.
+  Starting from version 0.0.0-beta.3, Modus Web Components now includes the CSS
+  for both outlined and solid icon variants. You can use either set by importing
+  the `modus-icons.css` file.
 </b>
 
 ```html

--- a/src/stories/modus-icon-usage.mdx
+++ b/src/stories/modus-icon-usage.mdx
@@ -4,83 +4,71 @@ import { Meta } from '@storybook/blocks';
 
 # Modus Icon Usage
 
-Several components require [Modus icons](https://modus-icons.trimble.com) to be installed in the host application. To install
-icons, add the following html to your application.
+Modus Web Components require Modus Icons.
 
-<b>
-  Starting from version 0.0.0-beta.3, Modus Web Components now includes the CSS
-  for both outlined and solid icon variants. You can use either set by importing
-  the `modus-icons.css` file.
-</b>
+Starting from v0.0.0-beta.3, the Web Components package supports both outlined and solid icon variants through a single CSS file.
+
+## 1. Installation
+
+Create a file at:
+
+```
+/public/modus-web-components/modus-icons.css
+```
+
+with the following contents:
+
+```css
+@font-face {
+  font-family: 'modus-icons';
+  src: url('https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1/dist/modus-outlined/fonts/modus-icons.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'modus-icons-outlined';
+  src: url('https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1/dist/modus-outlined/fonts/modus-icons.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'modus-icons-solid';
+  src: url('https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1/dist/modus-solid/fonts/modus-icons.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+.modus-icons-outlined {
+  font-family: 'modus-icons-outlined';
+  font-style: normal;
+  font-weight: normal;
+}
+
+.modus-icons-solid {
+  font-family: 'modus-icons-solid';
+  font-style: normal;
+  font-weight: normal;
+}
+
+.modus-icons {
+  font-family: 'modus-icons';
+  font-style: normal;
+  font-weight: normal;
+}
+```
+
+Then include it in your app:
 
 ```html
 <head>
-  <link rel="stylesheet" href="path-to-your-assets/modus-icons.css" />
+  <link rel="stylesheet" href="/modus-web-components/modus-icons.css" />
 </head>
 ```
-
-You can also still use the CDN approach:
-
-```html
-<head>
-  <link
-    rel="preload"
-    href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@latest/dist/modus-outlined/fonts/modus-icons.css"
-    as="style"
-    crossorigin="anonymous"
-  />
-  <link
-    rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@latest/dist/modus-outlined/fonts/modus-icons.css"
-  />
-</head>
-```
-
-## Offline usage
-
-For applications requiring offline capability or improved performance, you can bundle Modus icons directly with your app.
-
-### 1. Install the `@trimble-oss/modus-icons` package:
-
-```bash
-npm install @trimble-oss/modus-icons
-```
-
-### 2. Use the pre-bundled Modus Icons CSS file:
-
-If you're using Modus Web Components, you can directly import the bundled CSS file:
-
-```html
-<link rel="stylesheet" href="/path-to-modus-web-components/modus-icons.css" />
-```
-
-This file includes both outlined and solid variants, which you can use with these classes:
-
-- `.modus-icons-outlined` - For outlined icons
-- `.modus-icons-solid` - For solid icons
-- `.modus-icons` - For default style (depends on which specific icon file was loaded last)
-
-### 3. Or copy the required font files and styles manually:
-
-- From `node_modules/@trimble-oss/modus-icons/dist/modus-outlined/fonts/`, copy:
-  - `modus-icons.css`
-  - Font files (.woff, .woff2, etc.)
-- Place them in a publicly accessible directory (e.g., /public/fonts/).
-
-```html
-<head>
-  <link
-    rel="preload"
-    href="/path-to-your-local-modus-icons-font.woff2"
-    as="font"
-    type="font/woff2"
-    crossorigin="anonymous"
-  />
-  <link rel="stylesheet" href="/path-to-your-local-modus-icons.css" />
-</head>
-```
-
----
-
-Need help? Check out our [GitHub repository](https://github.com/trimble-oss/modus-web-components)
-or [raise an issue](https://github.com/trimble-oss/modus-web-components/issues).

--- a/src/stories/modus-icon-usage.mdx
+++ b/src/stories/modus-icon-usage.mdx
@@ -174,7 +174,7 @@ Once the stylesheet is loaded, you can use icons in any framework:
 ### React
 
 ```tsx
-import { ModusWcIcon as ModusIcon } from "@trimble-oss/moduswebcomponents-react";
+import { ModusWcIcon as ModusIcon } from '@trimble-oss/moduswebcomponents-react';
 
 export function IconExamples() {
   return (
@@ -198,7 +198,7 @@ export function IconExamples() {
         name="add_bold"
         variant="outlined"
         decorative
-        style={{ color: "var(--modus-wc-color-trimble-blue)" }}
+        style={{ color: 'var(--modus-wc-color-trimble-blue)' }}
       />
     </div>
   );
@@ -208,5 +208,3 @@ export function IconExamples() {
 ### Angular, Vue, etc.
 
 Follow the same approach — just make sure to include the global CSS file once in your application.
-
-

--- a/src/styles/modus-icons.css
+++ b/src/styles/modus-icons.css
@@ -1,0 +1,44 @@
+@font-face {
+  font-family: 'modus-icons';
+  src: url('https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1/dist/modus-outlined/fonts/modus-icons.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'modus-icons-outlined';
+  src: url('https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1/dist/modus-outlined/fonts/modus-icons.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'modus-icons-solid';
+  src: url('https://cdn.jsdelivr.net/npm/@trimble-oss/modus-icons@1/dist/modus-solid/fonts/modus-icons.woff2')
+    format('woff2');
+  font-style: normal;
+  font-weight: normal;
+  font-display: swap;
+}
+
+.modus-icons-outlined {
+  font-family: 'modus-icons-outlined';
+  font-style: normal;
+  font-weight: normal;
+}
+
+.modus-icons-solid {
+  font-family: 'modus-icons-solid';
+  font-style: normal;
+  font-weight: normal;
+}
+
+.modus-icons {
+  font-family: 'modus-icons';
+  font-style: normal;
+  font-weight: normal;
+}

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -42,6 +42,7 @@ export const config: Config = {
       copy: [
         // This is scoped to /src
         { src: './styles/output.css', dest: 'dist/modus-wc-styles.css' },
+        { src: './styles/modus-icons.css', dest: 'dist/modus-icons.css' },
         { src: '../README.md', dest: 'dist/README.md' },
         { src: '../LICENSE', dest: 'dist/LICENSE' },
         { src: '../package.json', dest: 'dist/package.json' },


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Add a support to use outlined and solid icons at same time

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #533 
