### PR TITLE
fixes a color var typo in global.css

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -97,7 +97,7 @@ modus-wc-date {
   --modus-wc-color-base-page: #000;
   --modus-wc-color-base-100: var(--modus-wc-color-trimble-gray);
   --modus-wc-color-base-200: var(--modus-wc-color-gray-8);
-  --modus-wc-color-base-300: var(--modus-wc-color-9);
+  --modus-wc-color-base-300: var(--modus-wc-color-gray-9);
   --modus-wc-color-base-content: var(--modus-wc-color-gray-1);
   --modus-wc-color-info: var(--modus-wc-color-trimble-blue);
   --modus-wc-color-success: var(--modus-wc-color-green);


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Fixes a typo, there is no such color as `--modus-wc-color-9`.
However, there is `--modus-wc-color-gray-9`.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other


### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

N/A
