### PR TITLE
Typography: fix weight is not applied on header variants

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -20,7 +20,7 @@ import { SortingState } from "@tanstack/table-core";
 import { ITab } from "./components/modus-wc-tabs/modus-wc-tabs";
 import { IThemeConfig } from "./providers/theme/theme.types";
 import { ToastPosition } from "./components/modus-wc-toast/modus-wc-toast";
-import { TypographySize, TypographyVariant, TypographyWeight } from "./components/modus-wc-typography/modus-wc-typography";
+import { TypographyHierarchy, TypographySize, TypographyWeight } from "./components/modus-wc-typography/modus-wc-typography";
 export { AutocompleteTypes, DaisySize, Density, IAutocompleteItem, IAutocompleteNoResults, IInputFeedbackProp, ModusSize, Orientation, PopoverPlacement, TextFieldTypes } from "./components/types";
 export { IBreadcrumb } from "./components/modus-wc-breadcrumbs/modus-wc-breadcrumbs";
 export { ICollapseOptions } from "./components/modus-wc-collapse/modus-wc-collapse";
@@ -36,7 +36,7 @@ export { SortingState } from "@tanstack/table-core";
 export { ITab } from "./components/modus-wc-tabs/modus-wc-tabs";
 export { IThemeConfig } from "./providers/theme/theme.types";
 export { ToastPosition } from "./components/modus-wc-toast/modus-wc-toast";
-export { TypographySize, TypographyVariant, TypographyWeight } from "./components/modus-wc-typography/modus-wc-typography";
+export { TypographyHierarchy, TypographySize, TypographyWeight } from "./components/modus-wc-typography/modus-wc-typography";
 export namespace Components {
     /**
      * A customizable accordion component used for showing and hiding related groups of content.
@@ -1754,13 +1754,13 @@ export namespace Components {
          */
         "customClass"?: string;
         /**
+          * The hierarchy of the typography component.
+         */
+        "hierarchy": TypographyHierarchy;
+        /**
           * The size of the font.
          */
         "size"?: TypographySize;
-        /**
-          * The variant of the typography component.
-         */
-        "variant": TypographyVariant;
         /**
           * The weight of the text.
          */
@@ -4751,13 +4751,13 @@ declare namespace LocalJSX {
          */
         "customClass"?: string;
         /**
+          * The hierarchy of the typography component.
+         */
+        "hierarchy"?: TypographyHierarchy;
+        /**
           * The size of the font.
          */
         "size"?: TypographySize;
-        /**
-          * The variant of the typography component.
-         */
-        "variant"?: TypographyVariant;
         /**
           * The weight of the text.
          */

--- a/src/components/modus-wc-typography/__snapshots__/modus-wc-typography.spec.ts.snap
+++ b/src/components/modus-wc-typography/__snapshots__/modus-wc-typography.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modus-wc-typography should render headings 1`] = `
 <modus-wc-typography variant="h1">
   <!---->
-  <h1 class="modus-wc-typography">
+  <h1 class="modus-wc-text-md modus-wc-typography modus-wc-typography-weight-normal">
     Test content
   </h1>
 </modus-wc-typography>

--- a/src/components/modus-wc-typography/__snapshots__/modus-wc-typography.spec.ts.snap
+++ b/src/components/modus-wc-typography/__snapshots__/modus-wc-typography.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-typography should render headings 1`] = `
-<modus-wc-typography variant="h1">
+<modus-wc-typography hierarchy="h1">
   <!---->
   <h1 class="modus-wc-text-md modus-wc-typography modus-wc-typography-weight-normal">
     Test content
@@ -10,7 +10,7 @@ exports[`modus-wc-typography should render headings 1`] = `
 `;
 
 exports[`modus-wc-typography should render with custom props 1`] = `
-<modus-wc-typography custom-class="test-class" size="sm" variant="body" weight="bold">
+<modus-wc-typography custom-class="test-class" hierarchy="body" size="sm" weight="bold">
   <!---->
   <body class="modus-wc-text-sm modus-wc-typography modus-wc-typography-weight-bold test-class">
     Test content

--- a/src/components/modus-wc-typography/modus-wc-typography.scss
+++ b/src/components/modus-wc-typography/modus-wc-typography.scss
@@ -4,42 +4,42 @@
 */
 
 modus-wc-typography {
-  h1.modus-wc-typography {
+  h1.modus-wc-typography:not(.modus-wc-typography-override) {
     font-size: var(--modus-wc-font-size-3xl);
     font-weight: var(--modus-wc-font-weight-normal);
     letter-spacing: 0.5px;
     line-height: 36px;
   }
 
-  h2.modus-wc-typography {
+  h2.modus-wc-typography:not(.modus-wc-typography-override) {
     font-size: var(--modus-wc-font-size-2xl);
     font-weight: var(--modus-wc-font-weight-normal);
     letter-spacing: 0.15px;
     line-height: 30px;
   }
 
-  h3.modus-wc-typography {
+  h3.modus-wc-typography:not(.modus-wc-typography-override) {
     font-size: var(--modus-wc-font-size-xl);
     font-weight: var(--modus-wc-font-weight-semibold);
     letter-spacing: 0.15px;
     line-height: 27px;
   }
 
-  h4.modus-wc-typography {
+  h4.modus-wc-typography:not(.modus-wc-typography-override) {
     font-size: var(--modus-wc-font-size-lg);
     font-weight: var(--modus-wc-font-weight-semibold);
     letter-spacing: 0.15px;
     line-height: 24px;
   }
 
-  h5.modus-wc-typography {
+  h5.modus-wc-typography:not(.modus-wc-typography-override) {
     font-size: var(--modus-wc-font-size-md);
     font-weight: var(--modus-wc-font-weight-bold);
     letter-spacing: 0.45px;
     line-height: 24px;
   }
 
-  h6.modus-wc-typography {
+  h6.modus-wc-typography:not(.modus-wc-typography-override) {
     font-size: var(--modus-wc-font-size-sm);
     font-weight: var(--modus-wc-font-weight-bold);
     letter-spacing: 0.45px;
@@ -61,4 +61,36 @@ modus-wc-typography {
   .modus-wc-typography-weight-bold {
     font-weight: var(--modus-wc-font-weight-bold);
   }
+
+
+  // Text size classes
+  .modus-wc-text-xs {
+    font-size: var(--modus-wc-font-size-xs);
+  }
+
+  .modus-wc-text-sm {
+    font-size: var(--modus-wc-font-size-sm);
+  }
+
+  .modus-wc-text-md {
+    font-size: var(--modus-wc-font-size-md);
+  }
+
+  .modus-wc-text-lg {
+    font-size: var(--modus-wc-font-size-lg);
+  }
+
+  .modus-wc-text-xl {
+    font-size: var(--modus-wc-font-size-xl);
+  }
+
+  .modus-wc-text-2xl {
+    font-size: var(--modus-wc-font-size-2xl);
+  }
+
+  .modus-wc-text-3xl {
+    font-size: var(--modus-wc-font-size-3xl);
+  }
+
+
 }

--- a/src/components/modus-wc-typography/modus-wc-typography.scss
+++ b/src/components/modus-wc-typography/modus-wc-typography.scss
@@ -62,7 +62,6 @@ modus-wc-typography {
     font-weight: var(--modus-wc-font-weight-bold);
   }
 
-
   // Text size classes
   .modus-wc-text-xs {
     font-size: var(--modus-wc-font-size-xs);
@@ -91,6 +90,4 @@ modus-wc-typography {
   .modus-wc-text-3xl {
     font-size: var(--modus-wc-font-size-3xl);
   }
-
-
 }

--- a/src/components/modus-wc-typography/modus-wc-typography.spec.ts
+++ b/src/components/modus-wc-typography/modus-wc-typography.spec.ts
@@ -15,7 +15,7 @@ describe('modus-wc-typography', () => {
   it('should render with custom props', async () => {
     const page = await newSpecPage({
       components: [ModusWCTypography],
-      html: `<modus-wc-typography custom-class="test-class" size="sm" variant="body" weight="bold">Test content</modus-wc-typography>`,
+      html: `<modus-wc-typography custom-class="test-class" size="sm" hierarchy="body" weight="bold">Test content</modus-wc-typography>`,
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -23,7 +23,7 @@ describe('modus-wc-typography', () => {
   it('should render headings', async () => {
     const page = await newSpecPage({
       components: [ModusWCTypography],
-      html: `<modus-wc-typography variant="h1">Test content</modus-wc-typography>`,
+      html: `<modus-wc-typography hierarchy="h1">Test content</modus-wc-typography>`,
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -33,7 +33,7 @@ describe('modus-wc-typography - heading override class', () => {
   it('should add override class for heading with size/weight overrides', async () => {
     const page = await newSpecPage({
       components: [ModusWCTypography],
-      html: `<modus-wc-typography variant="h2" size="lg" weight="bold">Heading</modus-wc-typography>`,
+      html: `<modus-wc-typography hierarchy="h2" size="lg" weight="bold">Heading</modus-wc-typography>`,
     });
     expect(page.root).toBeDefined();
     const el = page.root && page.root.querySelector('h2');
@@ -65,7 +65,7 @@ describe('modus-wc-typography - convertPropsToClasses', () => {
     }
   );
 
-  it('returns combined classes when size and weight are provided and variant is not a heading', () => {
+  it('returns combined classes when size and weight are provided and hierarchy is not a heading', () => {
     expect(
       convertPropsToClasses({
         size: 'md',

--- a/src/components/modus-wc-typography/modus-wc-typography.spec.ts
+++ b/src/components/modus-wc-typography/modus-wc-typography.spec.ts
@@ -1,9 +1,5 @@
 import { newSpecPage } from '@stencil/core/testing';
-import {
-  ModusWCTypography,
-  TypographyVariant,
-  TypographyWeight,
-} from './modus-wc-typography';
+import { ModusWCTypography, TypographyWeight } from './modus-wc-typography';
 import { convertPropsToClasses } from './modus-wc-typography.tailwind';
 import { DaisySize } from '../types';
 
@@ -33,24 +29,22 @@ describe('modus-wc-typography', () => {
   });
 });
 
+describe('modus-wc-typography - heading override class', () => {
+  it('should add override class for heading with size/weight overrides', async () => {
+    const page = await newSpecPage({
+      components: [ModusWCTypography],
+      html: `<modus-wc-typography variant="h2" size="lg" weight="bold">Heading</modus-wc-typography>`,
+    });
+    expect(page.root).toBeDefined();
+    const el = page.root && page.root.querySelector('h2');
+    expect(el).not.toBeNull();
+    expect(el && el.className).toContain('modus-wc-typography-override');
+  });
+});
+
 describe('modus-wc-typography - convertPropsToClasses', () => {
   it('returns empty string when no props are provided', () => {
     expect(convertPropsToClasses({})).toBe('');
-  });
-
-  it.each([['h1'], ['h2'], ['h3'], ['h4'], ['h5'], ['h6']])(
-    'returns empty string when variant is a heading (%s)',
-    (headingVariant) => {
-      expect(
-        convertPropsToClasses({ variant: headingVariant as TypographyVariant })
-      ).toBe('');
-    }
-  );
-
-  it('returns empty string when variant is a heading AND other props are provided', () => {
-    expect(
-      convertPropsToClasses({ size: 'sm', variant: 'h1', weight: 'bold' })
-    ).toBe('');
   });
 
   it.each([['sm'], ['md'], ['lg']])(
@@ -76,7 +70,6 @@ describe('modus-wc-typography - convertPropsToClasses', () => {
       convertPropsToClasses({
         size: 'md',
         weight: 'semibold',
-        variant: 'body',
       })
     ).toBe('modus-wc-text-md modus-wc-typography-weight-semibold');
   });

--- a/src/components/modus-wc-typography/modus-wc-typography.stories.ts
+++ b/src/components/modus-wc-typography/modus-wc-typography.stories.ts
@@ -2,8 +2,8 @@ import { Meta, StoryObj } from '@storybook/web-components';
 import { html, render } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import {
+  TypographyHierarchy,
   TypographySize,
-  TypographyVariant,
   TypographyWeight,
 } from './modus-wc-typography';
 
@@ -15,7 +15,7 @@ const content = 'The quick brown fox jumps over the lazy dog';
 interface TypographyArgs {
   'custom-class'?: string;
   size?: TypographySize;
-  variant: TypographyVariant;
+  hierarchy: TypographyHierarchy;
   weight?: TypographyWeight;
 }
 
@@ -24,7 +24,7 @@ const meta: Meta<TypographyArgs> = {
   component: 'modus-wc-typography',
   args: {
     size: 'md',
-    variant: 'p',
+    hierarchy: 'p',
     weight: 'normal',
   },
   argTypes: {
@@ -46,7 +46,7 @@ const meta: Meta<TypographyArgs> = {
         '9xl',
       ],
     },
-    variant: {
+    hierarchy: {
       control: { type: 'select' },
       options: ['body', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p'],
     },
@@ -87,7 +87,7 @@ export const Default: Story = {
     <modus-wc-typography
       custom-class=${ifDefined(args['custom-class'])}
       size=${ifDefined(args.size)}
-      variant=${args.variant}
+      hierarchy=${args.hierarchy}
       weight=${ifDefined(args.weight)}
     ></modus-wc-typography>
   `,
@@ -95,48 +95,48 @@ export const Default: Story = {
 
 export const Body: Story = {
   args: {
-    variant: 'body',
+    hierarchy: 'body',
   },
 };
 
 export const Heading1: Story = {
   args: {
-    variant: 'h1',
+    hierarchy: 'h1',
   },
 };
 
 export const Heading2: Story = {
   args: {
-    variant: 'h2',
+    hierarchy: 'h2',
   },
 };
 
 export const Heading3: Story = {
   args: {
-    variant: 'h3',
+    hierarchy: 'h3',
   },
 };
 
 export const Heading4: Story = {
   args: {
-    variant: 'h4',
+    hierarchy: 'h4',
   },
 };
 
 export const Heading5: Story = {
   args: {
-    variant: 'h5',
+    hierarchy: 'h5',
   },
 };
 
 export const Heading6: Story = {
   args: {
-    variant: 'h6',
+    hierarchy: 'h6',
   },
 };
 
 export const Paragraph: Story = {
   args: {
-    variant: 'p',
+    hierarchy: 'p',
   },
 };

--- a/src/components/modus-wc-typography/modus-wc-typography.tailwind.ts
+++ b/src/components/modus-wc-typography/modus-wc-typography.tailwind.ts
@@ -1,26 +1,13 @@
-import {
-  TypographySize,
-  TypographyVariant,
-  TypographyWeight,
-} from './modus-wc-typography';
-
-const HEADINGS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+import { TypographySize, TypographyWeight } from './modus-wc-typography';
 
 export const convertPropsToClasses = ({
   size,
   weight,
-  variant,
 }: {
   size?: TypographySize;
   weight?: TypographyWeight;
-  variant?: TypographyVariant;
 }): string => {
   let classes = '';
-
-  // Heading styles are handled in modus-wc-typography.scss
-  if (variant && HEADINGS.includes(variant)) {
-    return classes;
-  }
 
   if (size) {
     classes = `${classes} modus-wc-text-${size}`;

--- a/src/components/modus-wc-typography/modus-wc-typography.tsx
+++ b/src/components/modus-wc-typography/modus-wc-typography.tsx
@@ -2,20 +2,7 @@ import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-typography.tailwind';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
-export type TypographySize =
-  | 'xs'
-  | 'sm'
-  | 'md'
-  | 'lg'
-  | 'xl'
-  | '2xl'
-  | '3xl'
-  | '4xl'
-  | '5xl'
-  | '6xl'
-  | '7xl'
-  | '8xl'
-  | '9xl';
+export type TypographySize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 
 export type TypographyVariant =
   | 'body'
@@ -62,9 +49,19 @@ export class ModusWCTypography {
   private getClasses(): string {
     const classList = ['modus-wc-typography'];
 
+    // Check if we're dealing with a heading and have size/weight overrides
+    const isHeading = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(
+      this.variant
+    );
+    const hasOverrides = this.size !== 'md' || this.weight !== 'normal';
+
+    if (isHeading && hasOverrides) {
+      // Add a class to indicate overrides for headings
+      classList.push('modus-wc-typography-override');
+    }
+
     const propClasses = convertPropsToClasses({
       size: this.size,
-      variant: this.variant,
       weight: this.weight,
     });
 

--- a/src/components/modus-wc-typography/modus-wc-typography.tsx
+++ b/src/components/modus-wc-typography/modus-wc-typography.tsx
@@ -2,9 +2,7 @@ import { Component, Element, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-typography.tailwind';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
-export type TypographySize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
-
-export type TypographyVariant =
+export type TypographyHierarchy =
   | 'body'
   | 'h1'
   | 'h2'
@@ -13,6 +11,8 @@ export type TypographyVariant =
   | 'h5'
   | 'h6'
   | 'p';
+
+export type TypographySize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | '3xl';
 
 export type TypographyWeight = 'light' | 'normal' | 'semibold' | 'bold';
 
@@ -33,11 +33,11 @@ export class ModusWCTypography {
   /** Custom CSS class to apply to the typography element. */
   @Prop() customClass?: string = '';
 
+  /** The hierarchy of the typography component. */
+  @Prop() hierarchy: TypographyHierarchy = 'p';
+
   /** The size of the font. */
   @Prop() size?: TypographySize = 'md';
-
-  /** The variant of the typography component. */
-  @Prop() variant: TypographyVariant = 'p';
 
   /** The weight of the text. */
   @Prop() weight?: TypographyWeight = 'normal';
@@ -51,7 +51,7 @@ export class ModusWCTypography {
 
     // Check if we're dealing with a heading and have size/weight overrides
     const isHeading = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(
-      this.variant
+      this.hierarchy
     );
     const hasOverrides = this.size !== 'md' || this.weight !== 'normal';
 
@@ -73,7 +73,7 @@ export class ModusWCTypography {
   }
 
   render() {
-    const Element = this.variant;
+    const Element = this.hierarchy;
 
     return (
       <Host>

--- a/src/components/modus-wc-typography/readme.md
+++ b/src/components/modus-wc-typography/readme.md
@@ -11,12 +11,12 @@ A customizable typography component used to render text with different sizes, va
 
 ## Properties
 
-| Property      | Attribute      | Description                                          | Type                                                                                                                        | Default    |
-| ------------- | -------------- | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `customClass` | `custom-class` | Custom CSS class to apply to the typography element. | `string \| undefined`                                                                                                       | `''`       |
-| `size`        | `size`         | The size of the font.                                | `"2xl" \| "3xl" \| "4xl" \| "5xl" \| "6xl" \| "7xl" \| "8xl" \| "9xl" \| "lg" \| "md" \| "sm" \| "xl" \| "xs" \| undefined` | `'md'`     |
-| `variant`     | `variant`      | The variant of the typography component.             | `"body" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`                                                             | `'p'`      |
-| `weight`      | `weight`       | The weight of the text.                              | `"bold" \| "light" \| "normal" \| "semibold" \| undefined`                                                                  | `'normal'` |
+| Property      | Attribute      | Description                                          | Type                                                                  | Default    |
+| ------------- | -------------- | ---------------------------------------------------- | --------------------------------------------------------------------- | ---------- |
+| `customClass` | `custom-class` | Custom CSS class to apply to the typography element. | `string \| undefined`                                                 | `''`       |
+| `size`        | `size`         | The size of the font.                                | `"2xl" \| "3xl" \| "lg" \| "md" \| "sm" \| "xl" \| "xs" \| undefined` | `'md'`     |
+| `variant`     | `variant`      | The variant of the typography component.             | `"body" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`       | `'p'`      |
+| `weight`      | `weight`       | The weight of the text.                              | `"bold" \| "light" \| "normal" \| "semibold" \| undefined`            | `'normal'` |
 
 
 ----------------------------------------------

--- a/src/components/modus-wc-typography/readme.md
+++ b/src/components/modus-wc-typography/readme.md
@@ -14,8 +14,8 @@ A customizable typography component used to render text with different sizes, va
 | Property      | Attribute      | Description                                          | Type                                                                  | Default    |
 | ------------- | -------------- | ---------------------------------------------------- | --------------------------------------------------------------------- | ---------- |
 | `customClass` | `custom-class` | Custom CSS class to apply to the typography element. | `string \| undefined`                                                 | `''`       |
+| `hierarchy`   | `hierarchy`    | The hierarchy of the typography component.           | `"body" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`       | `'p'`      |
 | `size`        | `size`         | The size of the font.                                | `"2xl" \| "3xl" \| "lg" \| "md" \| "sm" \| "xl" \| "xs" \| undefined` | `'md'`     |
-| `variant`     | `variant`      | The variant of the typography component.             | `"body" \| "h1" \| "h2" \| "h3" \| "h4" \| "h5" \| "h6" \| "p"`       | `'p'`      |
 | `weight`      | `weight`       | The weight of the text.                              | `"bold" \| "light" \| "normal" \| "semibold" \| undefined`            | `'normal'` |
 
 

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -6705,21 +6705,21 @@
               }
             },
             {
+              "name": "hierarchy",
+              "fieldName": "hierarchy",
+              "default": "'p'",
+              "description": "The hierarchy of the typography component.",
+              "type": {
+                "text": "TypographyHierarchy"
+              }
+            },
+            {
               "name": "size",
               "fieldName": "size",
               "default": "'md'",
               "description": "The size of the font.",
               "type": {
                 "text": "TypographySize"
-              }
-            },
-            {
-              "name": "variant",
-              "fieldName": "variant",
-              "default": "'p'",
-              "description": "The variant of the typography component.",
-              "type": {
-                "text": "TypographyVariant"
               }
             },
             {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -4076,7 +4076,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable radio button component used to create radio inputs.",
+          "description": "A customizable radio button component.",
           "name": "ModusWcRadio",
           "members": [
             {
@@ -4354,7 +4354,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable select component used to create selects with different options.",
+          "description": "A customizable select component used to pick a value from a list of options",
           "name": "ModusWcSelect",
           "members": [
             {
@@ -6537,7 +6537,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable tooltip component used to create tooltips with different content.\n\nThe tooltip can be dismissed by pressing the Escape key.",
+          "description": "A customizable tooltip component used to create tooltips with different content.\n\nThe tooltip can be dismissed by pressing the Escape key when hovering over it.\nWhen forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.",
           "name": "ModusWcTooltip",
           "members": [
             {
@@ -6566,30 +6566,12 @@
               ]
             },
             {
-              "kind": "field",
-              "name": "escapeDismissed",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Track if tooltip was dismissed with Escape key"
-            },
-            {
               "kind": "method",
               "name": "handleMouseEnter"
             },
             {
               "kind": "method",
               "name": "handleMouseLeave"
-            },
-            {
-              "kind": "field",
-              "name": "isVisible",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Track if tooltip is currently visible"
             },
             {
               "kind": "method",


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Introduce an override class for heading elements (h1–h6) that activates when size or weight props deviate from their defaults, ensuring custom styles are applied

- Change variant to hierachy and the type TypographyVariant to TypographyHierarchy

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #457 
