### PR TITLE
Tooltip : Enable force open to show tooltip instead of hover

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1729,7 +1729,7 @@ export namespace Components {
     /**
      * A customizable tooltip component used to create tooltips with different content.
      * The tooltip can be dismissed by pressing the Escape key when hovering over it.
-     * When forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.
+     * When forceOpen is enabled, the tooltip will remain open and can only be closed by setting forceOpen to false.
      */
     interface ModusWcTooltip {
         /**
@@ -2670,7 +2670,7 @@ declare global {
     /**
      * A customizable tooltip component used to create tooltips with different content.
      * The tooltip can be dismissed by pressing the Escape key when hovering over it.
-     * When forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.
+     * When forceOpen is enabled, the tooltip will remain open and can only be closed by setting forceOpen to false.
      */
     interface HTMLModusWcTooltipElement extends Components.ModusWcTooltip, HTMLStencilElement {
         addEventListener<K extends keyof HTMLModusWcTooltipElementEventMap>(type: K, listener: (this: HTMLModusWcTooltipElement, ev: ModusWcTooltipCustomEvent<HTMLModusWcTooltipElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4740,7 +4740,7 @@ declare namespace LocalJSX {
     /**
      * A customizable tooltip component used to create tooltips with different content.
      * The tooltip can be dismissed by pressing the Escape key when hovering over it.
-     * When forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.
+     * When forceOpen is enabled, the tooltip will remain open and can only be closed by setting forceOpen to false.
      */
     interface ModusWcTooltip {
         /**
@@ -5052,7 +5052,7 @@ declare module "@stencil/core" {
             /**
              * A customizable tooltip component used to create tooltips with different content.
              * The tooltip can be dismissed by pressing the Escape key when hovering over it.
-             * When forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.
+             * When forceOpen is enabled, the tooltip will remain open and can only be closed by setting forceOpen to false.
              */
             "modus-wc-tooltip": LocalJSX.ModusWcTooltip & JSXBase.HTMLAttributes<HTMLModusWcTooltipElement>;
             /**

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.scss
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.scss
@@ -11,10 +11,14 @@
   font-size: 0.875rem;
   font-weight: var(--modus-wc-font-weight-regular);
   max-width: 20rem;
+  overflow-wrap: break-word;
   padding: 0.25rem 0.5rem;
   pointer-events: none;
   position: relative;
+  text-align: center;
+  white-space: normal;
   width: max-content;
+  word-break: break-word;
   z-index: 1000;
 }
 
@@ -28,6 +32,7 @@
 }
 
 .modus-wc-tooltip-arrow {
+  text-align: initial;
   visibility: hidden;
 }
 

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
@@ -10,6 +10,105 @@ describe('modus-wc-tooltip', () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  describe('forceOpen watcher', () => {
+    it('should show the tooltip when forceOpen changes from false to true', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test"></modus-wc-tooltip>',
+      });
+
+      // Spy on the showTooltip method
+      const showTooltipSpy = jest.spyOn(page.rootInstance, 'showTooltip');
+
+      // Change forceOpen to true
+      if (page.root) {
+        page.root.forceOpen = true;
+      }
+      await page.waitForChanges();
+
+      // Should call showTooltip method
+      expect(showTooltipSpy).toHaveBeenCalled();
+    });
+
+    it('should hide the tooltip when forceOpen changes from true to false', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test" force-open="true"></modus-wc-tooltip>',
+      });
+
+      // Spy on the hideTooltip method
+      const hideTooltipSpy = jest.spyOn(page.rootInstance, 'hideTooltip');
+
+      // Change forceOpen to false
+      if (page.root) {
+        page.root.forceOpen = false;
+      }
+      await page.waitForChanges();
+
+      // Should call hideTooltip method
+      expect(hideTooltipSpy).toHaveBeenCalled();
+    });
+
+    it('should not show the tooltip when forceOpen is true but disabled is also true', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test" disabled="true"></modus-wc-tooltip>',
+      });
+
+      // Spy on the showTooltip method
+      const showTooltipSpy = jest.spyOn(page.rootInstance, 'showTooltip');
+
+      // Change forceOpen to true
+      if (page.root) {
+        page.root.forceOpen = true;
+      }
+      await page.waitForChanges();
+
+      // Should not call showTooltip method due to disabled state
+      expect(showTooltipSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not show the tooltip when forceOpen is true but it was previously dismissed with Escape', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test" force-open="true"></modus-wc-tooltip>',
+      });
+
+      // First make tooltip visible
+      if (page.root) {
+        // The component sets isVisible state when force-open is true
+        await page.waitForChanges();
+      }
+
+      // Spy on methods
+      const hideTooltipSpy = jest.spyOn(page.rootInstance, 'hideTooltip');
+      const showTooltipSpy = jest.spyOn(page.rootInstance, 'showTooltip');
+
+      // Simulate Escape key press when tooltip is visible (sets escapeDismissed to true)
+      const escapeEvent = new KeyboardEvent('keyup', { code: 'Escape' });
+      document.dispatchEvent(escapeEvent);
+      await page.waitForChanges();
+
+      // Should have called hideTooltip due to Escape
+      expect(hideTooltipSpy).toHaveBeenCalled();
+
+      // Reset spies
+      hideTooltipSpy.mockClear();
+      showTooltipSpy.mockClear();
+
+      // Set forceOpen again to test that it doesn't show after escape dismiss
+      if (page.root) {
+        page.root.forceOpen = false;
+        await page.waitForChanges();
+        page.root.forceOpen = true;
+      }
+      await page.waitForChanges();
+
+      // Should not call showTooltip method due to previous escape dismissal
+      expect(showTooltipSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it('should render with custom props', async () => {
     const page = await newSpecPage({
       components: [ModusWcTooltip],

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
@@ -68,44 +68,50 @@ describe('modus-wc-tooltip', () => {
       expect(showTooltipSpy).not.toHaveBeenCalled();
     });
 
-    it('should not show the tooltip when forceOpen is true but it was previously dismissed with Escape', async () => {
+    it('should only hide the tooltip opened by forceOpen when forceOpen is set to false', async () => {
       const page = await newSpecPage({
         components: [ModusWcTooltip],
         html: '<modus-wc-tooltip content="Test" force-open="true"></modus-wc-tooltip>',
       });
 
-      // First make tooltip visible
       if (page.root) {
-        // The component sets isVisible state when force-open is true
         await page.waitForChanges();
       }
 
-      // Spy on methods
       const hideTooltipSpy = jest.spyOn(page.rootInstance, 'hideTooltip');
       const showTooltipSpy = jest.spyOn(page.rootInstance, 'showTooltip');
 
-      // Simulate Escape key press when tooltip is visible (sets escapeDismissed to true)
+      expect(page.rootInstance.isVisible).toBe(true);
+
       const escapeEvent = new KeyboardEvent('keyup', { code: 'Escape' });
       document.dispatchEvent(escapeEvent);
       await page.waitForChanges();
 
-      // Should have called hideTooltip due to Escape
-      expect(hideTooltipSpy).toHaveBeenCalled();
+      expect(hideTooltipSpy).not.toHaveBeenCalled();
+      expect(page.rootInstance.isVisible).toBe(true);
 
       // Reset spies
       hideTooltipSpy.mockClear();
       showTooltipSpy.mockClear();
 
-      // Set forceOpen again to test that it doesn't show after escape dismiss
       if (page.root) {
         page.root.forceOpen = false;
         await page.waitForChanges();
-        page.root.forceOpen = true;
       }
-      await page.waitForChanges();
+      expect(hideTooltipSpy).toHaveBeenCalled();
 
-      // Should not call showTooltip method due to previous escape dismissal
-      expect(showTooltipSpy).not.toHaveBeenCalled();
+      hideTooltipSpy.mockClear();
+      showTooltipSpy.mockClear();
+
+      if (page.root) {
+        page.root.forceOpen = true;
+        await page.waitForChanges();
+      }
+
+      const leaveEvent = new MouseEvent('mouseleave');
+      page.root?.dispatchEvent(leaveEvent);
+      await page.waitForChanges();
+      expect(hideTooltipSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
@@ -72,7 +72,6 @@ export class ModusWcTooltip {
         // When forceOpen is true, Escape should NOT dismiss it
         if (this.isVisible && !this.forceOpen) {
           this.escapeDismissed = true;
-          this.isVisible = false;
           this.dismissEscape.emit();
           this.hideTooltip();
         }
@@ -248,29 +247,23 @@ export class ModusWcTooltip {
   }
 
   @Watch('forceOpen')
-  handleForceOpenChange(newForceOpen: boolean) {
-    if (newForceOpen && !this.disabled && !this.escapeDismissed) {
+  handleForceOpenChange(forceOpen: boolean) {
+    if (forceOpen && !this.disabled) {
       this.showTooltip();
-    } else if (!newForceOpen) {
+    } else {
       this.hideTooltip();
     }
   }
 
   @Listen('mouseenter')
   handleMouseEnter() {
-    // If escapeDismissed is true, reset it on mouseenter
-    if (this.escapeDismissed) {
-      this.escapeDismissed = false;
-    }
-    this.isVisible = true;
+    this.escapeDismissed = false;
     this.showTooltip();
   }
 
   @Listen('mouseleave')
   handleMouseLeave() {
-    // Clear visibility state only if not forced open
     if (!this.forceOpen) {
-      this.isVisible = false;
       this.hideTooltip();
     }
   }

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
@@ -17,7 +17,7 @@ import { Attributes, inheritAriaAttributes } from '../utils';
  * A customizable tooltip component used to create tooltips with different content.
  *
  * The tooltip can be dismissed by pressing the Escape key when hovering over it.
- * When forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.
+ * When forceOpen is enabled, the tooltip will remain open and can only be closed by setting forceOpen to false.
  */
 @Component({
   tag: 'modus-wc-tooltip',
@@ -69,8 +69,8 @@ export class ModusWcTooltip {
     switch (event.code) {
       case 'Escape': {
         // Allow Escape to dismiss tooltip when it's visible
-        // When forceOpen is true, Escape should still work to dismiss it
-        if (this.isVisible) {
+        // When forceOpen is true, Escape should NOT dismiss it
+        if (this.isVisible && !this.forceOpen) {
           this.escapeDismissed = true;
           this.isVisible = false;
           this.dismissEscape.emit();

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
@@ -68,9 +68,9 @@ export class ModusWcTooltip {
   elementKeyupHandler(event: KeyboardEvent): void {
     switch (event.code) {
       case 'Escape': {
-        // Escape only works when hovering (isVisible is true)
-        // This ensures when forceOpen is true, escape only works during hover
-        if (this.isVisible && !this.forceOpen) {
+        // Allow Escape to dismiss tooltip when it's visible
+        // When forceOpen is true, Escape should still work to dismiss it
+        if (this.isVisible) {
           this.escapeDismissed = true;
           this.isVisible = false;
           this.dismissEscape.emit();
@@ -247,19 +247,32 @@ export class ModusWcTooltip {
     }
   }
 
+  @Watch('forceOpen')
+  handleForceOpenChange(newForceOpen: boolean) {
+    if (newForceOpen && !this.disabled && !this.escapeDismissed) {
+      this.showTooltip();
+    } else if (!newForceOpen) {
+      this.hideTooltip();
+    }
+  }
+
   @Listen('mouseenter')
   handleMouseEnter() {
-    // Reset escape dismissal and set visibility state
-    this.escapeDismissed = false;
+    // If escapeDismissed is true, reset it on mouseenter
+    if (this.escapeDismissed) {
+      this.escapeDismissed = false;
+    }
     this.isVisible = true;
     this.showTooltip();
   }
 
   @Listen('mouseleave')
   handleMouseLeave() {
-    // Clear visibility state
-    this.isVisible = false;
-    this.hideTooltip();
+    // Clear visibility state only if not forced open
+    if (!this.forceOpen) {
+      this.isVisible = false;
+      this.hideTooltip();
+    }
   }
 
   render() {

--- a/src/components/modus-wc-tooltip/readme.md
+++ b/src/components/modus-wc-tooltip/readme.md
@@ -10,7 +10,7 @@
 A customizable tooltip component used to create tooltips with different content.
 
 The tooltip can be dismissed by pressing the Escape key when hovering over it.
-When forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.
+When forceOpen is enabled, the tooltip will remain open and can only be closed by setting forceOpen to false.
 
 ## Properties
 


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Enable force open to show tooltip instead of hover
- UI fixes - word break, content center alignment 

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #585 #596 
