### PR TITLE
Avatar: Render initital as fallback when no image url is provided

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -239,6 +239,10 @@ export namespace Components {
          */
         "imgSrc": string;
         /**
+          * The initials to display when no image is provided.
+         */
+        "initials"?: string;
+        /**
           * The shape of the avatar.
          */
         "shape"?: 'circle' | 'square';
@@ -750,7 +754,7 @@ export namespace Components {
     interface ModusWcMenuItem {
         "bordered"?: boolean;
         /**
-          * If true, renders a checkbox slot at the start of the menu item.
+          * If true, renders a checkbox at the start of the menu item.
          */
         "checkbox"?: boolean;
         /**
@@ -2981,6 +2985,10 @@ declare namespace LocalJSX {
          */
         "imgSrc"?: string;
         /**
+          * The initials to display when no image is provided.
+         */
+        "initials"?: string;
+        /**
           * The shape of the avatar.
          */
         "shape"?: 'circle' | 'square';
@@ -3544,7 +3552,7 @@ declare namespace LocalJSX {
     interface ModusWcMenuItem {
         "bordered"?: boolean;
         /**
-          * If true, renders a checkbox slot at the start of the menu item.
+          * If true, renders a checkbox at the start of the menu item.
          */
         "checkbox"?: boolean;
         /**

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -223,7 +223,9 @@ export namespace Components {
         "value": string;
     }
     /**
-     * A customizable avatar component used to create avatars with different images.
+     * A customizable avatar component used to create avatars with different images or user initials.
+     * When no image is provided, the component can display initials (up to 3 characters) from the initials prop.
+     * The component will extract the first letter of each word in the initials string.
      */
     interface ModusWcAvatar {
         /**
@@ -1991,7 +1993,9 @@ declare global {
         new (): HTMLModusWcAutocompleteElement;
     };
     /**
-     * A customizable avatar component used to create avatars with different images.
+     * A customizable avatar component used to create avatars with different images or user initials.
+     * When no image is provided, the component can display initials (up to 3 characters) from the initials prop.
+     * The component will extract the first letter of each word in the initials string.
      */
     interface HTMLModusWcAvatarElement extends Components.ModusWcAvatar, HTMLStencilElement {
     }
@@ -2969,7 +2973,9 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     /**
-     * A customizable avatar component used to create avatars with different images.
+     * A customizable avatar component used to create avatars with different images or user initials.
+     * When no image is provided, the component can display initials (up to 3 characters) from the initials prop.
+     * The component will extract the first letter of each word in the initials string.
      */
     interface ModusWcAvatar {
         /**
@@ -4900,7 +4906,9 @@ declare module "@stencil/core" {
              */
             "modus-wc-autocomplete": LocalJSX.ModusWcAutocomplete & JSXBase.HTMLAttributes<HTMLModusWcAutocompleteElement>;
             /**
-             * A customizable avatar component used to create avatars with different images.
+             * A customizable avatar component used to create avatars with different images or user initials.
+             * When no image is provided, the component can display initials (up to 3 characters) from the initials prop.
+             * The component will extract the first letter of each word in the initials string.
              */
             "modus-wc-avatar": LocalJSX.ModusWcAvatar & JSXBase.HTMLAttributes<HTMLModusWcAvatarElement>;
             /**

--- a/src/components/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
+++ b/src/components/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
@@ -13,7 +13,9 @@ exports[`modus-wc-avatar should render with custom props 1`] = `
 exports[`modus-wc-avatar should render with default props 1`] = `
 <modus-wc-avatar alt="Default avatar">
   <div aria-label="Default avatar" class="modus-wc-avatar">
-    <div class="modus-wc-rounded-full modus-wc-w-16"></div>
+    <div class="modus-wc-rounded-full modus-wc-w-16 no-image">
+      <modus-wc-icon aria-label="Default avatar" name="person" size="md" variant="solid"></modus-wc-icon>
+    </div>
   </div>
 </modus-wc-avatar>
 `;
@@ -45,7 +47,9 @@ exports[`modus-wc-avatar should render with initials when imgSrc is not provided
 exports[`modus-wc-avatar should render with no props 1`] = `
 <modus-wc-avatar>
   <div class="modus-wc-avatar">
-    <div class="modus-wc-rounded-full modus-wc-w-16"></div>
+    <div class="modus-wc-rounded-full modus-wc-w-16 no-image">
+      <modus-wc-icon aria-label="Avatar image" name="person" size="md" variant="solid"></modus-wc-icon>
+    </div>
   </div>
 </modus-wc-avatar>
 `;

--- a/src/components/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
+++ b/src/components/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
@@ -13,8 +13,30 @@ exports[`modus-wc-avatar should render with custom props 1`] = `
 exports[`modus-wc-avatar should render with default props 1`] = `
 <modus-wc-avatar alt="Default avatar">
   <div aria-label="Default avatar" class="modus-wc-avatar">
+    <div class="modus-wc-rounded-full modus-wc-w-16"></div>
+  </div>
+</modus-wc-avatar>
+`;
+
+exports[`modus-wc-avatar should render with initials limited to 3 characters 1`] = `
+<modus-wc-avatar initials="John Michael Doe">
+  <div class="modus-wc-avatar">
     <div class="modus-wc-rounded-full modus-wc-w-16">
-      <img alt="Default avatar" src="">
+      <span aria-label="John Michael Doe" class="initials">
+        JMD
+      </span>
+    </div>
+  </div>
+</modus-wc-avatar>
+`;
+
+exports[`modus-wc-avatar should render with initials when imgSrc is not provided 1`] = `
+<modus-wc-avatar alt="User initials" initials="John Doe">
+  <div aria-label="User initials" class="modus-wc-avatar">
+    <div class="modus-wc-rounded-full modus-wc-w-16">
+      <span aria-label="User initials" class="initials">
+        JD
+      </span>
     </div>
   </div>
 </modus-wc-avatar>
@@ -23,9 +45,7 @@ exports[`modus-wc-avatar should render with default props 1`] = `
 exports[`modus-wc-avatar should render with no props 1`] = `
 <modus-wc-avatar>
   <div class="modus-wc-avatar">
-    <div class="modus-wc-rounded-full modus-wc-w-16">
-      <img alt="Avatar image" src="">
-    </div>
+    <div class="modus-wc-rounded-full modus-wc-w-16"></div>
   </div>
 </modus-wc-avatar>
 `;

--- a/src/components/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
+++ b/src/components/modus-wc-avatar/__snapshots__/modus-wc-avatar.spec.ts.snap
@@ -48,7 +48,7 @@ exports[`modus-wc-avatar should render with no props 1`] = `
 <modus-wc-avatar>
   <div class="modus-wc-avatar">
     <div class="modus-wc-rounded-full modus-wc-w-16 no-image">
-      <modus-wc-icon aria-label="Avatar image" name="person" size="md" variant="solid"></modus-wc-icon>
+      <modus-wc-icon aria-label="User avatar" name="person" size="md" variant="solid"></modus-wc-icon>
     </div>
   </div>
 </modus-wc-avatar>

--- a/src/components/modus-wc-avatar/modus-wc-avatar.scss
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.scss
@@ -2,3 +2,34 @@
 * This component uses Tailwind CSS and DaisyUI.
 * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
 */
+
+modus-wc-avatar .modus-wc-avatar {
+  .initials {
+    align-items: center;
+    background-color: var(--modus-wc-color-black);
+    color: var(--modus-wc-color-white);
+    display: flex;
+    font-weight: 600;
+    height: 100%;
+    justify-content: center;
+    text-transform: uppercase;
+    width: 100%;
+  }
+
+  // Size-specific styling for the text based on the Tailwind classes
+  .modus-wc-w-8 .initials {
+    font-size: var(--modus-wc-font-size-xs, 0.75rem);
+  }
+
+  .modus-wc-w-12 .initials {
+    font-size: var(--modus-wc-font-size-sm, 0.875rem);
+  }
+
+  .modus-wc-w-16 .initials {
+    font-size: var(--modus-wc-font-size-md, 1rem);
+  }
+
+  .modus-wc-w-20 .initials {
+    font-size: var(--modus-wc-font-size-lg, 1.25rem);
+  }
+}

--- a/src/components/modus-wc-avatar/modus-wc-avatar.scss
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.scss
@@ -16,6 +16,14 @@ modus-wc-avatar .modus-wc-avatar {
     width: 100%;
   }
 
+  .no-image {
+    align-items: center;
+    background-color: var(--modus-wc-color-gray-2);
+    color: var(--modus-wc-color-white);
+    display: flex;
+    justify-content: center;
+  }
+
   // Size-specific styling for the text based on the Tailwind classes
   .modus-wc-w-8 .initials {
     font-size: var(--modus-wc-font-size-xs, 0.75rem);

--- a/src/components/modus-wc-avatar/modus-wc-avatar.spec.ts
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.spec.ts
@@ -25,4 +25,29 @@ describe('modus-wc-avatar', () => {
     });
     expect(page.root).toMatchSnapshot();
   });
+
+  it('should render with initials when imgSrc is not provided', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcAvatar],
+      html: '<modus-wc-avatar alt="User initials" aria-label="User initials" initials="John Doe"></modus-wc-avatar>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with initials limited to 3 characters', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcAvatar],
+      html: '<modus-wc-avatar initials="John Michael Doe"></modus-wc-avatar>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should return empty string for initials when none are provided', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcAvatar],
+      html: '<modus-wc-avatar></modus-wc-avatar>',
+    });
+    const avatarInstance = page.rootInstance;
+    expect(avatarInstance.getUserInitials()).toBe('');
+  });
 });

--- a/src/components/modus-wc-avatar/modus-wc-avatar.stories.ts
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.stories.ts
@@ -7,6 +7,7 @@ interface AvatarArgs {
   alt: string;
   'custom-class'?: string;
   'img-src': string;
+  initials: string;
   shape: string;
   size: DaisySize;
 }
@@ -19,6 +20,7 @@ const meta: Meta<AvatarArgs> = {
     'img-src':
       'https://i.pinimg.com/474x/73/54/79/7354794bf3873c3ef2666f778da4bcac.jpg',
     shape: 'circle',
+    initials: '',
     size: 'md',
   },
   argTypes: {
@@ -44,6 +46,7 @@ const Template: Story = {
         alt="${args.alt}"
         custom-class="${ifDefined(args['custom-class'])}"
         img-src="${args['img-src']}"
+        initials="${args.initials}"
         shape="${args.shape}"
         size="${args.size}"
       ></modus-wc-avatar>

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -26,6 +26,9 @@ export class ModusWcAvatar {
   /** The location of the image. */
   @Prop() imgSrc: string = '';
 
+  /** The initials to display when no image is provided. */
+  @Prop() initials?: string = '';
+
   // TODO - add placeholder support (need UX logic)
 
   /** The shape of the avatar. */
@@ -35,7 +38,7 @@ export class ModusWcAvatar {
   @Prop() size?: DaisySize = 'md';
 
   componentWillLoad() {
-    if (!this.alt) {
+    if (!this.alt && !this.initials) {
       this.alt = 'Avatar image';
     }
 
@@ -57,12 +60,29 @@ export class ModusWcAvatar {
     return classList.join(' ');
   }
 
+  private getUserInitials(): string {
+    if (!this.initials) return '';
+
+    return this.initials
+      .split(' ')
+      .map((part) => part.charAt(0))
+      .join('')
+      .substring(0, 3)
+      .toUpperCase();
+  }
+
   render() {
     return (
       <Host>
         <div class="modus-wc-avatar" {...this.inheritedAttributes}>
           <div class={this.getClasses()}>
-            <img src={this.imgSrc} alt={this.alt} />
+            {this.imgSrc ? (
+              <img src={this.imgSrc} alt={this.alt} />
+            ) : this.initials ? (
+              <span class="initials" aria-label={this.alt || this.initials}>
+                {this.getUserInitials()}
+              </span>
+            ) : null}
           </div>
         </div>
       </Host>

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -63,7 +63,7 @@ export class ModusWcAvatar {
       .trim()
       .split(/\s+/)
       .filter(Boolean)
-      .map((part) => part[0] || '')
+      .map((part) => part.charAt(0))
       .join('')
       .substring(0, 3)
       .toUpperCase();

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -4,7 +4,9 @@ import { DaisySize } from '../types';
 import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
- * A customizable avatar component used to create avatars with different images.
+ * A customizable avatar component used to create avatars with different images or user initials.
+ * When no image is provided, the component can display initials (up to 3 characters) from the initials prop.
+ * The component will extract the first letter of each word in the initials string.
  */
 @Component({
   tag: 'modus-wc-avatar',

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -74,7 +74,6 @@ export class ModusWcAvatar {
 
   render() {
     const altText = this.alt || 'User avatar';
-    const initialsAltText = (this.alt || this.initials) ?? 'User avatar';
 
     return (
       <Host>
@@ -83,7 +82,7 @@ export class ModusWcAvatar {
             {this.imgSrc ? (
               <img src={this.imgSrc} alt={altText} />
             ) : this.initials ? (
-              <span class="initials" aria-label={initialsAltText}>
+              <span class="initials" aria-label={this.alt || this.initials}>
                 {this.getUserInitials()}
               </span>
             ) : (

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -60,8 +60,10 @@ export class ModusWcAvatar {
     if (!this.initials) return '';
 
     return this.initials
-      .split(' ')
-      .map((part) => part.charAt(0))
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((part) => part[0] || '')
       .join('')
       .substring(0, 3)
       .toUpperCase();

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -38,10 +38,6 @@ export class ModusWcAvatar {
   @Prop() size?: DaisySize = 'md';
 
   componentWillLoad() {
-    if (!this.alt && !this.initials) {
-      this.alt = 'Avatar image';
-    }
-
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
@@ -72,14 +68,17 @@ export class ModusWcAvatar {
   }
 
   render() {
+    const altText =
+      this.alt || (this.initials ? this.initials : 'Avatar image');
+
     return (
       <Host>
         <div class="modus-wc-avatar" {...this.inheritedAttributes}>
           <div class={this.getClasses()}>
             {this.imgSrc ? (
-              <img src={this.imgSrc} alt={this.alt} />
+              <img src={this.imgSrc} alt={altText} />
             ) : this.initials ? (
-              <span class="initials" aria-label={this.alt || this.initials}>
+              <span class="initials" aria-label={altText}>
                 {this.getUserInitials()}
               </span>
             ) : null}

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -73,8 +73,8 @@ export class ModusWcAvatar {
   }
 
   render() {
-    const altText =
-      this.alt || (this.initials ? this.initials : 'Avatar image');
+    const altText = this.alt || 'User avatar';
+    const initialsAltText = (this.alt || this.initials) ?? 'User avatar';
 
     return (
       <Host>
@@ -83,7 +83,7 @@ export class ModusWcAvatar {
             {this.imgSrc ? (
               <img src={this.imgSrc} alt={altText} />
             ) : this.initials ? (
-              <span class="initials" aria-label={altText}>
+              <span class="initials" aria-label={initialsAltText}>
                 {this.getUserInitials()}
               </span>
             ) : (

--- a/src/components/modus-wc-avatar/modus-wc-avatar.tsx
+++ b/src/components/modus-wc-avatar/modus-wc-avatar.tsx
@@ -54,6 +54,7 @@ export class ModusWcAvatar {
     // The order CSS classes are added matters to CSS specificity
     if (propClasses) classList.push(propClasses);
     if (this.customClass) classList.push(this.customClass);
+    if (!this.imgSrc && !this.initials) classList.push('no-image');
 
     return classList.join(' ');
   }
@@ -85,7 +86,14 @@ export class ModusWcAvatar {
               <span class="initials" aria-label={altText}>
                 {this.getUserInitials()}
               </span>
-            ) : null}
+            ) : (
+              <modus-wc-icon
+                aria-label={altText}
+                name="person"
+                size={this.size}
+                variant="solid"
+              ></modus-wc-icon>
+            )}
           </div>
         </div>
       </Host>

--- a/src/components/modus-wc-avatar/readme.md
+++ b/src/components/modus-wc-avatar/readme.md
@@ -11,13 +11,14 @@ A customizable avatar component used to create avatars with different images.
 
 ## Properties
 
-| Property           | Attribute      | Description                                 | Type                                        | Default     |
-| ------------------ | -------------- | ------------------------------------------- | ------------------------------------------- | ----------- |
-| `alt` _(required)_ | `alt`          | The image alt attribute for accessibility.  | `string`                                    | `undefined` |
-| `customClass`      | `custom-class` | Custom CSS class to apply to the inner div. | `string \| undefined`                       | `''`        |
-| `imgSrc`           | `img-src`      | The location of the image.                  | `string`                                    | `''`        |
-| `shape`            | `shape`        | The shape of the avatar.                    | `"circle" \| "square" \| undefined`         | `'circle'`  |
-| `size`             | `size`         | The size of the avatar.                     | `"lg" \| "md" \| "sm" \| "xs" \| undefined` | `'md'`      |
+| Property           | Attribute      | Description                                        | Type                                        | Default     |
+| ------------------ | -------------- | -------------------------------------------------- | ------------------------------------------- | ----------- |
+| `alt` _(required)_ | `alt`          | The image alt attribute for accessibility.         | `string`                                    | `undefined` |
+| `customClass`      | `custom-class` | Custom CSS class to apply to the inner div.        | `string \| undefined`                       | `''`        |
+| `imgSrc`           | `img-src`      | The location of the image.                         | `string`                                    | `''`        |
+| `initials`         | `initials`     | The initials to display when no image is provided. | `string \| undefined`                       | `''`        |
+| `shape`            | `shape`        | The shape of the avatar.                           | `"circle" \| "square" \| undefined`         | `'circle'`  |
+| `size`             | `size`         | The size of the avatar.                            | `"lg" \| "md" \| "sm" \| "xs" \| undefined` | `'md'`      |
 
 
 ## Dependencies

--- a/src/components/modus-wc-avatar/readme.md
+++ b/src/components/modus-wc-avatar/readme.md
@@ -18,7 +18,7 @@ The component will extract the first letter of each word in the initials string.
 | `alt` _(required)_ | `alt`          | The image alt attribute for accessibility.         | `string`                                    | `undefined` |
 | `customClass`      | `custom-class` | Custom CSS class to apply to the inner div.        | `string \| undefined`                       | `''`        |
 | `imgSrc`           | `img-src`      | The location of the image.                         | `string`                                    | `''`        |
-| `initials`         | `initials`     | The initials to display when no image is provided. | `string \| undefined`                       | `undefined` |
+| `initials`         | `initials`     | The initials to display when no image is provided. | `string \| undefined`                       | `''`        |
 | `shape`            | `shape`        | The shape of the avatar.                           | `"circle" \| "square" \| undefined`         | `'circle'`  |
 | `size`             | `size`         | The size of the avatar.                            | `"lg" \| "md" \| "sm" \| "xs" \| undefined` | `'md'`      |
 

--- a/src/components/modus-wc-avatar/readme.md
+++ b/src/components/modus-wc-avatar/readme.md
@@ -7,7 +7,9 @@
 
 ## Overview
 
-A customizable avatar component used to create avatars with different images.
+A customizable avatar component used to create avatars with different images or user initials.
+When no image is provided, the component can display initials (up to 3 characters) from the initials prop.
+The component will extract the first letter of each word in the initials string.
 
 ## Properties
 
@@ -16,7 +18,7 @@ A customizable avatar component used to create avatars with different images.
 | `alt` _(required)_ | `alt`          | The image alt attribute for accessibility.         | `string`                                    | `undefined` |
 | `customClass`      | `custom-class` | Custom CSS class to apply to the inner div.        | `string \| undefined`                       | `''`        |
 | `imgSrc`           | `img-src`      | The location of the image.                         | `string`                                    | `''`        |
-| `initials`         | `initials`     | The initials to display when no image is provided. | `string \| undefined`                       | `''`        |
+| `initials`         | `initials`     | The initials to display when no image is provided. | `string \| undefined`                       | `undefined` |
 | `shape`            | `shape`        | The shape of the avatar.                           | `"circle" \| "square" \| undefined`         | `'circle'`  |
 | `size`             | `size`         | The size of the avatar.                            | `"lg" \| "md" \| "sm" \| "xs" \| undefined` | `'md'`      |
 
@@ -27,9 +29,14 @@ A customizable avatar component used to create avatars with different images.
 
  - [modus-wc-navbar](../modus-wc-navbar)
 
+### Depends on
+
+- [modus-wc-icon](../modus-wc-icon)
+
 ### Graph
 ```mermaid
 graph TD;
+  modus-wc-avatar --> modus-wc-icon
   modus-wc-navbar --> modus-wc-avatar
   style modus-wc-avatar fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/modus-wc-icon/readme.md
+++ b/src/components/modus-wc-icon/readme.md
@@ -28,6 +28,7 @@ A customizable icon component used to render Modus icons.
 
  - [modus-wc-alert](../modus-wc-alert)
  - [modus-wc-autocomplete](../modus-wc-autocomplete)
+ - [modus-wc-avatar](../modus-wc-avatar)
  - [modus-wc-collapse](../modus-wc-collapse)
  - [modus-wc-input-feedback](../modus-wc-input-feedback)
  - [modus-wc-menu-item](../modus-wc-menu-item)
@@ -39,6 +40,7 @@ A customizable icon component used to render Modus icons.
 graph TD;
   modus-wc-alert --> modus-wc-icon
   modus-wc-autocomplete --> modus-wc-icon
+  modus-wc-avatar --> modus-wc-icon
   modus-wc-collapse --> modus-wc-icon
   modus-wc-input-feedback --> modus-wc-icon
   modus-wc-menu-item --> modus-wc-icon

--- a/src/components/modus-wc-menu-item/readme.md
+++ b/src/components/modus-wc-menu-item/readme.md
@@ -11,21 +11,21 @@ A customizable menu item component used to display the item portion of a menu
 
 ## Properties
 
-| Property          | Attribute          | Description                                                     | Type                                                            | Default     |
-| ----------------- | ------------------ | --------------------------------------------------------------- | --------------------------------------------------------------- | ----------- |
-| `bordered`        | `bordered`         |                                                                 | `boolean \| undefined`                                          | `undefined` |
-| `checkbox`        | `checkbox`         | If true, renders a checkbox slot at the start of the menu item. | `boolean \| undefined`                                          | `undefined` |
-| `customClass`     | `custom-class`     | Custom CSS class to apply to the li element.                    | `string \| undefined`                                           | `''`        |
-| `disabled`        | `disabled`         | The disabled state of the menu item.                            | `boolean \| undefined`                                          | `undefined` |
-| `focused`         | `focused`          | The focused state of the menu item.                             | `boolean \| undefined`                                          | `undefined` |
-| `label`           | `label`            | The text rendered in the menu item.                             | `string`                                                        | `''`        |
-| `selected`        | `selected`         | The selected state of the menu item.                            | `boolean \| undefined`                                          | `undefined` |
-| `size`            | `size`             | The size of the menu item.                                      | `"lg" \| "md" \| "sm" \| undefined`                             | `'md'`      |
-| `startIcon`       | `start-icon`       | The modus icon name to render on the start of the menu item.    | `string \| undefined`                                           | `undefined` |
-| `subLabel`        | `sub-label`        | The text rendered beneath the label.                            | `string \| undefined`                                           | `undefined` |
-| `tooltipContent`  | `tooltip-content`  | The tooltip text to display when hovering over the menu item.   | `string \| undefined`                                           | `undefined` |
-| `tooltipPosition` | `tooltip-position` | The position of the tooltip relative to the menu item.          | `"auto" \| "bottom" \| "left" \| "right" \| "top" \| undefined` | `'auto'`    |
-| `value`           | `value`            | The unique identifying value of the menu item.                  | `string`                                                        | `''`        |
+| Property          | Attribute          | Description                                                   | Type                                                            | Default     |
+| ----------------- | ------------------ | ------------------------------------------------------------- | --------------------------------------------------------------- | ----------- |
+| `bordered`        | `bordered`         |                                                               | `boolean \| undefined`                                          | `undefined` |
+| `checkbox`        | `checkbox`         | If true, renders a checkbox at the start of the menu item.    | `boolean \| undefined`                                          | `undefined` |
+| `customClass`     | `custom-class`     | Custom CSS class to apply to the li element.                  | `string \| undefined`                                           | `''`        |
+| `disabled`        | `disabled`         | The disabled state of the menu item.                          | `boolean \| undefined`                                          | `undefined` |
+| `focused`         | `focused`          | The focused state of the menu item.                           | `boolean \| undefined`                                          | `undefined` |
+| `label`           | `label`            | The text rendered in the menu item.                           | `string`                                                        | `''`        |
+| `selected`        | `selected`         | The selected state of the menu item.                          | `boolean \| undefined`                                          | `undefined` |
+| `size`            | `size`             | The size of the menu item.                                    | `"lg" \| "md" \| "sm" \| undefined`                             | `'md'`      |
+| `startIcon`       | `start-icon`       | The modus icon name to render on the start of the menu item.  | `string \| undefined`                                           | `undefined` |
+| `subLabel`        | `sub-label`        | The text rendered beneath the label.                          | `string \| undefined`                                           | `undefined` |
+| `tooltipContent`  | `tooltip-content`  | The tooltip text to display when hovering over the menu item. | `string \| undefined`                                           | `undefined` |
+| `tooltipPosition` | `tooltip-position` | The position of the tooltip relative to the menu item.        | `"auto" \| "bottom" \| "left" \| "right" \| "top" \| undefined` | `'auto'`    |
+| `value`           | `value`            | The unique identifying value of the menu item.                | `string`                                                        | `''`        |
 
 
 ## Events

--- a/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
+++ b/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
@@ -57,13 +57,13 @@ exports[`modus-wc-navbar should render with custom props and slots 1`] = `
           <modus-wc-button>
             <!---->
             <button class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-circle modus-wc-btn-primary modus-wc-btn-sm user-button" tabindex="0" type="button">
-              <modus-wc-avatar alt="" size="xs"></modus-wc-avatar>
+              <modus-wc-avatar alt="User avatar" size="xs"></modus-wc-avatar>
             </button>
           </modus-wc-button>
           <div class="hidden user">
             <modus-wc-card>
               <div slot="header">
-                <modus-wc-avatar alt=""></modus-wc-avatar>
+                <modus-wc-avatar alt="User avatar"></modus-wc-avatar>
               </div>
               <div slot="title"></div>
               <div></div>
@@ -139,13 +139,13 @@ exports[`modus-wc-navbar should render with no props 1`] = `
           <modus-wc-button>
             <!---->
             <button class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-circle modus-wc-btn-primary modus-wc-btn-sm user-button" tabindex="0" type="button">
-              <modus-wc-avatar alt="" size="xs"></modus-wc-avatar>
+              <modus-wc-avatar alt="User avatar" size="xs"></modus-wc-avatar>
             </button>
           </modus-wc-button>
           <div class="hidden user">
             <modus-wc-card>
               <div slot="header">
-                <modus-wc-avatar alt=""></modus-wc-avatar>
+                <modus-wc-avatar alt="User avatar"></modus-wc-avatar>
               </div>
               <div slot="title"></div>
               <div></div>

--- a/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
+++ b/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
@@ -57,12 +57,13 @@ exports[`modus-wc-navbar should render with custom props and slots 1`] = `
           <modus-wc-button>
             <!---->
             <button class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-circle modus-wc-btn-primary modus-wc-btn-sm user-button" tabindex="0" type="button">
+              <modus-wc-avatar alt="User avatar" size="xs"></modus-wc-avatar>
             </button>
           </modus-wc-button>
           <div class="hidden user">
             <modus-wc-card>
               <div slot="header">
-                <div class="initials"></div>
+                <modus-wc-avatar alt="User avatar"></modus-wc-avatar>
               </div>
               <div slot="title"></div>
               <div></div>
@@ -138,12 +139,13 @@ exports[`modus-wc-navbar should render with no props 1`] = `
           <modus-wc-button>
             <!---->
             <button class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-circle modus-wc-btn-primary modus-wc-btn-sm user-button" tabindex="0" type="button">
+              <modus-wc-avatar alt="User avatar" size="xs"></modus-wc-avatar>
             </button>
           </modus-wc-button>
           <div class="hidden user">
             <modus-wc-card>
               <div slot="header">
-                <div class="initials"></div>
+                <modus-wc-avatar alt="User avatar"></modus-wc-avatar>
               </div>
               <div slot="title"></div>
               <div></div>

--- a/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
+++ b/src/components/modus-wc-navbar/__snapshots__/modus-wc-navbar.spec.ts.snap
@@ -57,13 +57,13 @@ exports[`modus-wc-navbar should render with custom props and slots 1`] = `
           <modus-wc-button>
             <!---->
             <button class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-circle modus-wc-btn-primary modus-wc-btn-sm user-button" tabindex="0" type="button">
-              <modus-wc-avatar alt="User avatar" size="xs"></modus-wc-avatar>
+              <modus-wc-avatar alt="" size="xs"></modus-wc-avatar>
             </button>
           </modus-wc-button>
           <div class="hidden user">
             <modus-wc-card>
               <div slot="header">
-                <modus-wc-avatar alt="User avatar"></modus-wc-avatar>
+                <modus-wc-avatar alt=""></modus-wc-avatar>
               </div>
               <div slot="title"></div>
               <div></div>
@@ -139,13 +139,13 @@ exports[`modus-wc-navbar should render with no props 1`] = `
           <modus-wc-button>
             <!---->
             <button class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-circle modus-wc-btn-primary modus-wc-btn-sm user-button" tabindex="0" type="button">
-              <modus-wc-avatar alt="User avatar" size="xs"></modus-wc-avatar>
+              <modus-wc-avatar alt="" size="xs"></modus-wc-avatar>
             </button>
           </modus-wc-button>
           <div class="hidden user">
             <modus-wc-card>
               <div slot="header">
-                <modus-wc-avatar alt="User avatar"></modus-wc-avatar>
+                <modus-wc-avatar alt=""></modus-wc-avatar>
               </div>
               <div slot="title"></div>
               <div></div>

--- a/src/components/modus-wc-navbar/modus-wc-navbar.scss
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.scss
@@ -177,16 +177,6 @@ modus-wc-navbar .modus-wc-navbar {
   }
 }
 
-[data-theme='modus-classic-light'] modus-wc-navbar .modus-wc-navbar {
-  background-color: var(--modus-wc-color-white);
-
-  // Common button styles
-  &:not(.trimble-logo)
-    .modus-wc-btn.modus-wc-btn-borderless.modus-wc-btn-primary {
-    background: transparent;
-  }
-}
-
 [data-theme='modus-classic-dark'] modus-wc-navbar .modus-wc-navbar {
   background-color: var(--modus-wc-color-gray-10);
 

--- a/src/components/modus-wc-navbar/modus-wc-navbar.tsx
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.tsx
@@ -610,7 +610,7 @@ export class ModusWcNavbar {
                   variant="borderless"
                 >
                   <modus-wc-avatar
-                    alt={this.userCard?.avatarAlt || ''}
+                    alt={this.userCard?.avatarAlt || 'User avatar'}
                     imgSrc={this.userCard?.avatarSrc}
                     initials={this.userCard?.name}
                     size="xs"
@@ -623,7 +623,7 @@ export class ModusWcNavbar {
                   <modus-wc-card>
                     <div slot="header">
                       <modus-wc-avatar
-                        alt={this.userCard?.avatarAlt || ''}
+                        alt={this.userCard?.avatarAlt || 'User avatar'}
                         imgSrc={this.userCard?.avatarSrc}
                         initials={this.userCard?.name}
                       />

--- a/src/components/modus-wc-navbar/modus-wc-navbar.tsx
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.tsx
@@ -610,7 +610,7 @@ export class ModusWcNavbar {
                   variant="borderless"
                 >
                   <modus-wc-avatar
-                    alt={this.userCard?.avatarAlt || 'User avatar'}
+                    alt={this.userCard?.avatarAlt || ''}
                     imgSrc={this.userCard?.avatarSrc}
                     initials={this.userCard?.name}
                     size="xs"
@@ -623,7 +623,7 @@ export class ModusWcNavbar {
                   <modus-wc-card>
                     <div slot="header">
                       <modus-wc-avatar
-                        alt={this.userCard?.avatarAlt || 'User avatar'}
+                        alt={this.userCard?.avatarAlt || ''}
                         imgSrc={this.userCard?.avatarSrc}
                         initials={this.userCard?.name}
                       />

--- a/src/components/modus-wc-navbar/modus-wc-navbar.tsx
+++ b/src/components/modus-wc-navbar/modus-wc-navbar.tsx
@@ -299,16 +299,6 @@ export class ModusWcNavbar {
     return classList.join(' ');
   }
 
-  private getUserInitials(): string {
-    if (!this.userCard?.name) return '';
-
-    return this.userCard.name
-      .split(' ')
-      .map((part) => part.charAt(0))
-      .join('')
-      .toUpperCase();
-  }
-
   private handleAiClick = (event?: CustomEvent<MouseEvent | KeyboardEvent>) => {
     this.aiClick.emit(event?.detail);
   };
@@ -619,15 +609,12 @@ export class ModusWcNavbar {
                   size="sm"
                   variant="borderless"
                 >
-                  {this.userCard?.avatarSrc ? (
-                    <modus-wc-avatar
-                      alt={this.userCard.avatarAlt || 'User avatar'}
-                      imgSrc={this.userCard.avatarSrc}
-                      size="xs"
-                    />
-                  ) : (
-                    this.getUserInitials()
-                  )}
+                  <modus-wc-avatar
+                    alt={this.userCard?.avatarAlt || 'User avatar'}
+                    imgSrc={this.userCard?.avatarSrc}
+                    initials={this.userCard?.name}
+                    size="xs"
+                  />
                 </modus-wc-button>
                 <div
                   class={`user ${this.userMenuOpen ? 'visible' : 'hidden'}`}
@@ -635,14 +622,11 @@ export class ModusWcNavbar {
                 >
                   <modus-wc-card>
                     <div slot="header">
-                      {this.userCard?.avatarSrc ? (
-                        <modus-wc-avatar
-                          alt={this.userCard.avatarAlt || 'User avatar'}
-                          imgSrc={this.userCard.avatarSrc}
-                        />
-                      ) : (
-                        <div class="initials">{this.getUserInitials()}</div>
-                      )}
+                      <modus-wc-avatar
+                        alt={this.userCard?.avatarAlt || 'User avatar'}
+                        imgSrc={this.userCard?.avatarSrc}
+                        initials={this.userCard?.name}
+                      />
                     </div>
                     <div slot="title">{this.userCard?.name}</div>
                     <div>{this.userCard?.email}</div>

--- a/src/components/modus-wc-navbar/readme.md
+++ b/src/components/modus-wc-navbar/readme.md
@@ -80,6 +80,7 @@ graph TD;
   modus-wc-text-input --> modus-wc-input-label
   modus-wc-text-input --> modus-wc-input-feedback
   modus-wc-input-feedback --> modus-wc-icon
+  modus-wc-avatar --> modus-wc-icon
   style modus-wc-navbar fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1222,7 +1222,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable avatar component used to create avatars with different images.",
+          "description": "A customizable avatar component used to create avatars with different images or user initials.\r\nWhen no image is provided, the component can display initials (up to 3 characters) from the initials prop.\r\nThe component will extract the first letter of each word in the initials string.",
           "name": "ModusWcAvatar",
           "members": [
             {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -411,7 +411,7 @@
           "name": "processItemSelection",
           "return": {
             "type": {
-              "text": "{\r\n  updatedItems: IAutocompleteItem[] | undefined;\r\n  updatedValue: string | undefined;\r\n  updatedSelectionOrder: string[];\r\n  shouldExpandChips: boolean;\r\n  shouldCloseMenu: boolean;\r\n  isDeselecting?: boolean;\r\n}"
+              "text": "{\r\n  updatedItems: IAutocompleteItem[] | undefined;\r\n  updatedValue: string | undefined;\r\n  updatedSelectionOrder: string[];\r\n  shouldExpandChips: boolean;\r\n  shouldCloseMenu: boolean;\r\n}"
             }
           },
           "parameters": [
@@ -952,7 +952,7 @@
               "name": "debounce-ms",
               "fieldName": "debounceMs",
               "default": "300",
-              "description": "The debounce timeout in milliseconds.\nSet to 0 to disable debouncing.",
+              "description": "The debounce timeout in milliseconds.\r\nSet to 0 to disable debouncing.",
               "type": {
                 "text": "number"
               }
@@ -1004,7 +1004,7 @@
               "name": "items",
               "fieldName": "items",
               "default": "[]",
-              "description": "The items to display in the menu.\nCreating a new array of items will ensure proper component re-render.",
+              "description": "The items to display in the menu.\r\nCreating a new array of items will ensure proper component re-render.",
               "type": {
                 "text": "IAutocompleteItem[]"
               }
@@ -1175,7 +1175,7 @@
               "type": {
                 "text": "EventEmitter<Event>"
               },
-              "description": "Event emitted when the input value changes.\nThis event is debounced based on the debounceMs prop."
+              "description": "Event emitted when the input value changes.\r\nThis event is debounced based on the debounceMs prop."
             },
             {
               "kind": "field",
@@ -1261,6 +1261,15 @@
               "fieldName": "imgSrc",
               "default": "''",
               "description": "The location of the image.",
+              "type": {
+                "text": "string"
+              }
+            },
+            {
+              "name": "initials",
+              "fieldName": "initials",
+              "default": "''",
+              "description": "The initials to display when no image is provided.",
               "type": {
                 "text": "string"
               }
@@ -3026,7 +3035,7 @@
             {
               "name": "checkbox",
               "fieldName": "checkbox",
-              "description": "If true, renders a checkbox slot at the start of the menu item.",
+              "description": "If true, renders a checkbox at the start of the menu item.",
               "type": {
                 "text": "boolean"
               }
@@ -6578,7 +6587,7 @@
       "declarations": [
         {
           "kind": "class",
-          "description": "A customizable tooltip component used to create tooltips with different content.\r\n\r\nThe tooltip can be dismissed by pressing the Escape key when hovering over it.\r\nWhen forceOpen is enabled, the tooltip will remain open unless dismissed via Escape while hovering.",
+          "description": "A customizable tooltip component used to create tooltips with different content.\r\n\r\nThe tooltip can be dismissed by pressing the Escape key when hovering over it.\r\nWhen forceOpen is enabled, the tooltip will remain open and can only be closed by setting forceOpen to false.",
           "name": "ModusWcTooltip",
           "members": [
             {
@@ -6614,6 +6623,18 @@
                   "name": "newContent",
                   "type": {
                     "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handleForceOpenChange",
+              "parameters": [
+                {
+                  "name": "forceOpen",
+                  "type": {
+                    "text": "boolean"
                   }
                 }
               ]


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

-Render initital as fallback when no image url is provided
-revert navbar css for initials and button background
-update navbar to use avatar fallback for initials

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #586 
