### PR TITLE
feat: add custom icon support for text input and autocomplete

### DIFF
--- a/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
+++ b/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
@@ -4,8 +4,9 @@ exports[`modus-wc-autocomplete should close the menu when clicking outside if le
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Default autocomplete" class="modus-wc-grow" id="mwc_id_13" placeholder="" type="text" value="">
+      <input aria-label="Default autocomplete" class="modus-wc-grow" id="mwc_id_15" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -15,8 +16,9 @@ exports[`modus-wc-autocomplete should close the menu when clicking outside if le
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Default autocomplete" class="modus-wc-grow" id="mwc_id_26" placeholder="" type="text" value="">
+      <input aria-label="Default autocomplete" class="modus-wc-grow" id="mwc_id_28" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -26,8 +28,9 @@ exports[`modus-wc-autocomplete should display no results ui when no items are av
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="No results test" class="modus-wc-grow" id="mwc_id_12" placeholder="" type="text" value="">
+      <input aria-label="No results test" class="modus-wc-grow" id="mwc_id_14" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -37,8 +40,9 @@ exports[`modus-wc-autocomplete should display no results ui when no items are av
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="No results test" class="modus-wc-grow" id="mwc_id_25" placeholder="" type="text" value="">
+      <input aria-label="No results test" class="modus-wc-grow" id="mwc_id_27" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -48,8 +52,9 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 1`
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_16" placeholder="" type="text" value="">
+      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_18" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -59,8 +64,9 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 2`
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-disabled modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Leave menu open test" class="modus-wc-grow" disabled="" id="mwc_id_16" placeholder="" type="text" value="">
+      <input aria-label="Leave menu open test" class="modus-wc-grow" disabled="" id="mwc_id_18" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -70,8 +76,9 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 3`
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-text-input--readonly modus-wc-w-full">
-      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_16" placeholder="" readonly="" type="text" value="">
+      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_18" placeholder="" readonly="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -81,8 +88,9 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 4`
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_29" placeholder="" type="text" value="">
+      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_31" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -92,8 +100,9 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 5`
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-disabled modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Leave menu open test" class="modus-wc-grow" disabled="" id="mwc_id_29" placeholder="" type="text" value="">
+      <input aria-label="Leave menu open test" class="modus-wc-grow" disabled="" id="mwc_id_31" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -103,8 +112,9 @@ exports[`modus-wc-autocomplete should handle leaveMenuOpen behavior correctly 6`
 <modus-wc-autocomplete class="modus-wc-autocomplete" leave-menu-open="true" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-text-input--readonly modus-wc-w-full">
-      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_29" placeholder="" readonly="" type="text" value="">
+      <input aria-label="Leave menu open test" class="modus-wc-grow" id="mwc_id_31" placeholder="" readonly="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>
@@ -114,8 +124,9 @@ exports[`modus-wc-autocomplete should handle undefined filtered items 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Undefined items test" class="modus-wc-grow" id="mwc_id_71" placeholder="" type="text" value="">
+      <input aria-label="Undefined items test" class="modus-wc-grow" id="mwc_id_73" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
   <modus-wc-menu class="menu-visible">
@@ -143,8 +154,9 @@ exports[`modus-wc-autocomplete should handle undefined filtered items 2`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Undefined items test" class="modus-wc-grow" id="mwc_id_81" placeholder="" type="text" value="">
+      <input aria-label="Undefined items test" class="modus-wc-grow" id="mwc_id_83" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
   <modus-wc-menu class="menu-visible">
@@ -196,8 +208,9 @@ exports[`modus-wc-autocomplete should render chips for selected items in multi-s
         </button>
       </modus-wc-chip>
       <modus-wc-text-input inputmode="text" value="">
+        <!---->
         <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-          <input aria-label="MultiSelect Chip Test" class="modus-wc-grow" id="mwc_id_38" placeholder="" type="text" value="">
+          <input aria-label="MultiSelect Chip Test" class="modus-wc-grow" id="mwc_id_40" placeholder="" type="text" value="">
         </label>
       </modus-wc-text-input>
     </div>
@@ -378,6 +391,7 @@ exports[`modus-wc-autocomplete should render multi select without border 1`] = `
   <div class="modus-wc-autocomplete-multi-select modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-md modus-wc-items-center modus-wc-w-full">
     <div class="modus-wc-autocomplete-content">
       <modus-wc-text-input inputmode="text" value="">
+        <!---->
         <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
           <input aria-label="Default autocomplete" class="modus-wc-grow" id="mwc_id_2" placeholder="" type="text" value="">
         </label>
@@ -388,11 +402,31 @@ exports[`modus-wc-autocomplete should render multi select without border 1`] = `
 </modus-wc-autocomplete>
 `;
 
+exports[`modus-wc-autocomplete should render with custom icon slot 1`] = `
+<modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
+  <!---->
+  <modus-wc-text-input inputmode="text" value="">
+    <!---->
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
+      <div class="modus-wc-text-input-icon modus-wc-text-input-icon-custom">
+        <modus-wc-icon class="modus-wc-flex modus-wc-items-center" name="heart" size="sm" slot="custom-icon">
+          <i aria-hidden="true" class="modus-icons modus-wc-icon modus-wc-icon--sm" tabindex="-1">
+            heart
+          </i>
+        </modus-wc-icon>
+      </div>
+      <input aria-label="Custom icon test" class="modus-wc-grow" id="mwc_id_3" placeholder="" type="text" value="">
+    </label>
+  </modus-wc-text-input>
+</modus-wc-autocomplete>
+`;
+
 exports[`modus-wc-autocomplete should render with custom props 1`] = `
 <modus-wc-autocomplete active-item-value="1" bordered="false" class="modus-wc-autocomplete test-class" custom-class="test-class" debounce-ms="500" disabled="true" include-clear="true" include-search="true" input-id="test-id" input-tab-index="1" label="Test label" min-chars="2" name="test-name" placeholder="Test placeholder" readonly="true" required="true" size="lg" value="Item 1" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-input-label forid="test-id" labeltext="Test label" required="" size="lg"></modus-wc-input-label>
   <modus-wc-text-input inputmode="text" value="Item 1">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-disabled modus-wc-input-lg modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <svg aria-hidden="true" class="modus-wc-text-input-icon modus-wc-text-input-icon-search" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path d="m16.38 14.92-.66.05-.41-.41c2.44-2.81 2.28-7.1-.5-9.7S7.8 2.4 5.17 4.94a6.99 6.99 0 0 0-.08 9.98c2.61 2.61 6.77 2.72 9.52.34l.41.41-.05.65 3.89 3.89a.996.996 0 1 0 1.41-1.41l-3.88-3.88Zm-2.81-1.41a5.016 5.016 0 0 1-7.08 0c-1.95-1.95-1.95-5.13 0-7.08s5.13-1.95 7.08 0 1.95 5.13 0 7.08"></path>
@@ -412,8 +446,21 @@ exports[`modus-wc-autocomplete should render with default props 1`] = `
 <modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
   <!---->
   <modus-wc-text-input inputmode="text" value="">
+    <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
       <input aria-label="Default autocomplete" class="modus-wc-grow" id="mwc_id_0" placeholder="" type="text" value="">
+    </label>
+  </modus-wc-text-input>
+</modus-wc-autocomplete>
+`;
+
+exports[`modus-wc-autocomplete should render without custom icon slot 1`] = `
+<modus-wc-autocomplete class="modus-wc-autocomplete" value="" style="--modus-autocomplete-min-input-width: 10px;">
+  <!---->
+  <modus-wc-text-input inputmode="text" value="">
+    <!---->
+    <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
+      <input aria-label="No custom icon test" class="modus-wc-grow" id="mwc_id_4" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
@@ -709,6 +709,7 @@ interface RenderInputParams {
   size?: ModusSize;
   value: string;
   inheritedAttributes: Attributes;
+  customIconSlot?: boolean;
   onBlur: (event: CustomEvent<FocusEvent>) => void;
   onChange: (event: CustomEvent<Event>) => void;
   onFocus: (event: CustomEvent<FocusEvent>) => void;
@@ -733,7 +734,9 @@ export function renderInput(params: RenderInputParams): JSX.Element {
       size={params.size}
       value={params.value}
       {...params.inheritedAttributes}
-    />
+    >
+      {params.customIconSlot ? <slot name="custom-icon" /> : undefined}
+    </modus-wc-text-input>
   );
 }
 

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -91,6 +91,26 @@ describe('modus-wc-autocomplete', () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it('should render with custom icon slot', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcAutocomplete, ModusWcTextInput, ModusWcIcon],
+      html: `<modus-wc-autocomplete aria-label="Custom icon test">
+        <modus-wc-icon slot="custom-icon" name="heart" size="sm"></modus-wc-icon>
+      </modus-wc-autocomplete>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render without custom icon slot', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcAutocomplete, ModusWcTextInput],
+      html: '<modus-wc-autocomplete aria-label="No custom icon test"></modus-wc-autocomplete>',
+    });
+
+    expect(page.root).toMatchSnapshot();
+  });
+
   it('should emit blur event', async () => {
     const page = await newSpecPage({
       components: [ModusWcAutocomplete, ModusWcTextInput],

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -325,6 +325,48 @@ export const Default: Story = {
   ...Template,
 };
 
+export const WithCustomIconSlot: Story = {
+  // prettier-ignore
+  render: (args) => html`
+<style>
+  div[id^='story--components-forms-autocomplete--with-custom-icon-slot'] {
+    height: 400px;
+  }
+</style>
+<modus-wc-autocomplete
+  aria-label="Autocomplete with custom icon"
+  ?bordered=${args.bordered}
+  custom-class=${ifDefined(args['custom-class'])}
+  debounce-ms=${ifDefined(args['debounce-ms'])}
+  ?disabled=${args.disabled}
+  ?include-clear=${args['include-clear']}
+  ?include-search=${args['include-search']}
+  input-id=${ifDefined(args['input-id'])}
+  input-tab-index=${ifDefined(args['input-tab-index'])}
+  .items=${args.items}
+  label=${ifDefined(args.label)}
+  ?leave-menu-open=${args['leave-menu-open']}
+  min-chars=${args['min-chars']}
+  min-input-width=${ifDefined(args['min-input-width'])}
+  ?multi-select=${false}
+  name=${ifDefined(args.name)}
+  .noResults=${args['no-results']}
+  placeholder=${ifDefined(args.placeholder)}
+  ?read-only=${args['read-only']}
+  ?required=${args.required}
+  ?show-menu-on-focus=${args['show-menu-on-focus']}
+  ?show-spinner=${args['show-spinner']}
+  size=${ifDefined(args.size)}
+  value=${args.value}
+>
+  <modus-wc-icon slot="custom-icon" name="heart" size="sm"></modus-wc-icon>
+</modus-wc-autocomplete>
+  `,
+  args: {
+    placeholder: 'Search fruits...',
+  },
+};
+
 export const WithTooltips: Story = {
   name: 'With Tooltips',
   parameters: {

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -812,7 +812,10 @@ export class ModusWcAutocomplete {
     };
 
     // Check if we have slotted content
-    const hasSlottedContent = !!this.el.querySelector('[slot="menu-items"]');
+    const hasSlottedMenuItems = !!this.el.querySelector('[slot="menu-items"]');
+    const hasSlottedCustomIcon = !!this.el.querySelector(
+      '[slot="custom-icon"]'
+    );
 
     return (
       <Host class={this.getClasses()} style={cssVariables}>
@@ -859,6 +862,7 @@ export class ModusWcAutocomplete {
                 size: this.size,
                 value: this.value,
                 inheritedAttributes: this.inheritedAttributes,
+                customIconSlot: hasSlottedCustomIcon,
                 onBlur: this.handleBlur,
                 onChange: this.handleChange,
                 onFocus: this.handleFocus,
@@ -900,13 +904,14 @@ export class ModusWcAutocomplete {
               size: this.size,
               value: this.value,
               inheritedAttributes: this.inheritedAttributes,
+              customIconSlot: hasSlottedCustomIcon,
               onBlur: this.handleBlur,
               onChange: this.handleChange,
               onFocus: this.handleFocus,
             })}
           </Fragment>
         )}
-        {hasSlottedContent ? (
+        {hasSlottedMenuItems ? (
           // When using custom slots, keep menu in DOM and use CSS to hide/show
           <modus-wc-menu
             aria-label="Autocomplete menu"
@@ -922,7 +927,7 @@ export class ModusWcAutocomplete {
               filteredItems: this.filteredItems,
               items: this.items,
               noResults: this.noResults,
-              hasSlottedContent: hasSlottedContent,
+              hasSlottedContent: hasSlottedMenuItems,
               onItemSelect: this.handleItemSelectByValue,
             })}
             <slot name="menu-items"></slot>
@@ -944,7 +949,7 @@ export class ModusWcAutocomplete {
                 filteredItems: this.filteredItems,
                 items: this.items,
                 noResults: this.noResults,
-                hasSlottedContent: hasSlottedContent,
+                hasSlottedContent: hasSlottedMenuItems,
                 onItemSelect: this.handleItemSelectByValue,
               })}
               <slot name="menu-items"></slot>

--- a/src/components/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
+++ b/src/components/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`modus-wc-text-input should render with custom props 1`] = `
 <modus-wc-text-input auto-capitalize="words" auto-complete="on" auto-focus="true" clear-aria-label="Clear input" custom-class="test-class" disabled="true" include-clear="true" include-search="true" input-aria-invalid="grammar" input-id="test-id" input-mode="numeric" input-spellcheck="true" input-tab-index="1" inputmode="text" label="Test label" max-length="50" min-length="5" name="test-name" pattern="[A-Za-z]{3}" placeholder="Test placeholder" readonly="true" required="true" size="lg" type="email" value="test@example.com">
+  <!---->
   <modus-wc-input-label forid="test-id" labeltext="Test label" required="" size="lg"></modus-wc-input-label>
   <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-disabled modus-wc-input-lg modus-wc-items-center modus-wc-text-input modus-wc-w-full test-class">
     <svg aria-hidden="true" class="modus-wc-text-input-icon modus-wc-text-input-icon-search" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
@@ -19,6 +20,7 @@ exports[`modus-wc-text-input should render with custom props 1`] = `
 
 exports[`modus-wc-text-input should render with default props 1`] = `
 <modus-wc-text-input inputmode="text" value="">
+  <!---->
   <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
     <input aria-label="Default input" class="modus-wc-grow" id="mwc_id_0" placeholder="" type="text" value="">
   </label>
@@ -27,6 +29,7 @@ exports[`modus-wc-text-input should render with default props 1`] = `
 
 exports[`modus-wc-text-input should render with error feedback 1`] = `
 <modus-wc-text-input inputmode="text" value="">
+  <!---->
   <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input--error modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
     <input aria-label="Error input" class="modus-wc-grow" id="mwc_id_2" placeholder="" type="text" value="">
   </label>

--- a/src/components/modus-wc-text-input/modus-wc-text-input.scss
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.scss
@@ -21,21 +21,21 @@ modus-wc-text-input {
       padding: 0 var(--modus-wc-spacing-sm);
 
       &.modus-wc-input-sm {
-        .modus-wc-text-input-icon {
+        .modus-wc-text-input-icon:not(.modus-wc-text-input-icon-custom) {
           height: var(--modus-wc-line-height-sm);
           width: var(--modus-wc-line-height-sm);
         }
       }
 
       &.modus-wc-input-md {
-        .modus-wc-text-input-icon {
+        .modus-wc-text-input-icon:not(.modus-wc-text-input-icon-custom) {
           height: var(--modus-wc-line-height-md);
           width: var(--modus-wc-line-height-md);
         }
       }
 
       &.modus-wc-input-lg {
-        .modus-wc-text-input-icon {
+        .modus-wc-text-input-icon:not(.modus-wc-text-input-icon-custom) {
           height: var(--modus-wc-line-height-lg);
           width: var(--modus-wc-line-height-lg);
         }
@@ -44,6 +44,13 @@ modus-wc-text-input {
       .modus-wc-text-input-icon {
         &.modus-wc-text-input-icon-clear {
           cursor: pointer;
+        }
+
+        &.modus-wc-text-input-icon-custom {
+          align-items: center;
+          display: flex;
+          flex-shrink: 0;
+          justify-content: center;
         }
       }
 

--- a/src/components/modus-wc-text-input/modus-wc-text-input.spec.ts
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.spec.ts
@@ -262,4 +262,106 @@ describe('modus-wc-text-input', () => {
     clearContainer = page.root!.querySelector('.modus-wc-clear-icon-container');
     expect(clearContainer).toHaveClass('modus-wc-clear-icon-hidden');
   });
+
+  it('should render with custom icon slot', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextInput],
+      html: `<modus-wc-text-input aria-label="Custom icon test">
+        <modus-wc-icon slot="custom-icon" name="home" size="16px"></modus-wc-icon>
+      </modus-wc-text-input>`,
+    });
+
+    // Should have custom icon wrapper
+    const customIconWrapper = page.root!.querySelector(
+      '.modus-wc-text-input-icon-custom'
+    );
+    expect(customIconWrapper).not.toBeNull();
+
+    // Should have the slotted icon
+    const slottedIcon = page.root!.querySelector('[slot="custom-icon"]');
+    expect(slottedIcon).not.toBeNull();
+    expect(slottedIcon!.getAttribute('name')).toBe('home');
+  });
+
+  it('should prioritize custom icon over includeSearch', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextInput],
+      html: `<modus-wc-text-input include-search="true" aria-label="Priority test">
+        <modus-wc-icon slot="custom-icon" name="settings" size="16px"></modus-wc-icon>
+      </modus-wc-text-input>`,
+    });
+
+    // Should have custom icon wrapper, not search icon
+    const customIconWrapper = page.root!.querySelector(
+      '.modus-wc-text-input-icon-custom'
+    );
+    expect(customIconWrapper).not.toBeNull();
+
+    // Should NOT have search icon when custom icon is present
+    const searchIcon = page.root!.querySelector(
+      '.modus-wc-text-input-icon-search'
+    );
+    expect(searchIcon).toBeNull();
+
+    // Should have the slotted custom icon
+    const slottedIcon = page.root!.querySelector('[slot="custom-icon"]');
+    expect(slottedIcon).not.toBeNull();
+    expect(slottedIcon!.getAttribute('name')).toBe('settings');
+  });
+
+  it('should show search icon when includeSearch is true and no custom icon', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextInput],
+      html: '<modus-wc-text-input include-search="true" aria-label="Search icon test"></modus-wc-text-input>',
+    });
+
+    // Should have search icon
+    const searchIcon = page.root!.querySelector(
+      '.modus-wc-text-input-icon-search'
+    );
+    expect(searchIcon).not.toBeNull();
+
+    // Should NOT have custom icon wrapper
+    const customIconWrapper = page.root!.querySelector(
+      '.modus-wc-text-input-icon-custom'
+    );
+    expect(customIconWrapper).toBeNull();
+  });
+
+  it('should work with custom icon and clear button together', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTextInput],
+      html: `<modus-wc-text-input include-clear="true" value="Test Value" aria-label="Custom icon with clear test">
+        <modus-wc-icon slot="custom-icon" name="heart" size="16px"></modus-wc-icon>
+      </modus-wc-text-input>`,
+    });
+
+    // Should have both custom icon and clear button
+    const customIconWrapper = page.root!.querySelector(
+      '.modus-wc-text-input-icon-custom'
+    );
+    expect(customIconWrapper).not.toBeNull();
+
+    const clearContainer = page.root!.querySelector(
+      '.modus-wc-clear-icon-container'
+    );
+    expect(clearContainer).not.toBeNull();
+    expect(clearContainer).toHaveClass('modus-wc-clear-icon-visible');
+
+    // Test clearing still works
+    const component = page.rootInstance as ModusWcTextInput;
+    const changeSpy = jest.fn();
+    page.root!.addEventListener('inputChange', changeSpy);
+
+    const clearButton = page.root!.querySelector(
+      '.modus-wc-text-input-icon-clear'
+    );
+    expect(clearButton).not.toBeNull();
+    clearButton!.dispatchEvent(new MouseEvent('click'));
+
+    await page.waitForChanges();
+
+    expect(component.value).toBe('');
+    expect(changeSpy).toHaveBeenCalled();
+  });
 });

--- a/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
@@ -181,6 +181,47 @@ export const WithErrorFeedback: Story = {
   ...Template,
   args: { feedback: errorFeedback, required: true },
 };
+
+export const WithCustomIconSlot: Story = {
+  // prettier-ignore
+  render: (args) => html`
+<modus-wc-text-input
+  aria-label="Text input with custom icon"
+  auto-capitalize=${ifDefined(args['auto-capitalize'])}
+  auto-complete=${ifDefined(args['auto-complete'])}
+  auto-correct=${ifDefined(args['auto-correct'])}
+  ?bordered=${args.bordered}
+  clear-aria-label=${ifDefined(args['clear-aria-label'])}
+  custom-class=${ifDefined(args['custom-class'])}
+  ?disabled=${args.disabled}
+  enterkeyhint=${ifDefined(args.enterkeyhint)}
+  .feedback=${args.feedback}
+  include-clear=${ifDefined(args['include-clear'])}
+  include-search=${ifDefined(args['include-search'])}
+  input-id=${ifDefined(args['input-id'])}
+  inputmode=${ifDefined(args.inputmode)}
+  input-tab-index=${ifDefined(args['input-tab-index'])}
+  label=${ifDefined(args.label)}
+  max-length=${ifDefined(args['max-length'])}
+  min-length=${ifDefined(args['min-length'])}
+  name=${ifDefined(args.name)}
+  pattern=${ifDefined(args.pattern)}
+  placeholder=${ifDefined(args.placeholder)}
+  ?read-only=${args['read-only']}
+  ?required=${args.required}
+  size=${ifDefined(args.size)}
+  spellcheck=${ifDefined(args.spellcheck)}
+  type=${ifDefined(args.type)}
+  .value=${args.value}
+>
+  <modus-wc-icon slot="custom-icon" name="heart" size="sm"></modus-wc-icon>
+</modus-wc-text-input>
+  `,
+  args: {
+    placeholder: 'Enter text here...',
+  },
+};
+
 export const Migration: Story = {
   parameters: {
     docs: {

--- a/src/components/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.tsx
@@ -202,6 +202,7 @@ export class ModusWcTextInput {
   render() {
     const showClear = this.shouldIncludeClear();
     const effectiveId = this.inputId || this.generatedId;
+    const hasCustomIcon = !!this.el.querySelector('[slot="custom-icon"]');
 
     return (
       <Host>
@@ -214,8 +215,14 @@ export class ModusWcTextInput {
           />
         )}
         <label class={this.getClasses()}>
-          {this.includeSearch && (
-            <SearchSolidIcon className="modus-wc-text-input-icon modus-wc-text-input-icon-search" />
+          {hasCustomIcon ? (
+            <div class="modus-wc-text-input-icon modus-wc-text-input-icon-custom">
+              <slot name="custom-icon" />
+            </div>
+          ) : (
+            this.includeSearch && (
+              <SearchSolidIcon className="modus-wc-text-input-icon modus-wc-text-input-icon-search" />
+            )
           )}
           <input
             aria-required={this.required}

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -5661,7 +5661,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
+                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
               }
             },
             {
@@ -5721,7 +5721,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
+                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
               }
             },
             {

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -5661,7 +5661,7 @@
               "fieldName": "autoCapitalize",
               "description": "Controls automatic capitalization in inputted text.",
               "type": {
-                "text": "| 'off'\r\n    | 'none'\r\n    | 'on'\r\n    | 'sentences'\r\n    | 'words'\r\n    | 'characters'"
+                "text": "| 'off'\n    | 'none'\n    | 'on'\n    | 'sentences'\n    | 'words'\n    | 'characters'"
               }
             },
             {
@@ -5721,7 +5721,7 @@
               "fieldName": "enterkeyhint",
               "description": "A hint to the browser for which enter key to display.",
               "type": {
-                "text": "| 'enter'\r\n    | 'done'\r\n    | 'go'\r\n    | 'next'\r\n    | 'previous'\r\n    | 'search'\r\n    | 'send'"
+                "text": "| 'enter'\n    | 'done'\n    | 'go'\n    | 'next'\n    | 'previous'\n    | 'search'\n    | 'send'"
               }
             },
             {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This PR adds a `custom-icon` named slot to the `modus-wc-text-input` and `modus-wc-autocomplete` in order to support personalized icons for these components. 

**Note:**
When a custom icon has been slotted into these components the `include-search` prop (default search icon) is overridden and only the slotted content will show. 

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Manual and unit testing

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #447 
