### PR TITLE
Remove hover color in disables state

### DIFF
--- a/src/components/modus-wc-tabs/modus-wc-tabs.scss
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.scss
@@ -73,6 +73,12 @@ modus-wc-tabs .modus-wc-tab {
     background-color: var(--modus-wc-color-base-page);
     color: inherit;
   }
+
+  &:disabled,
+  &[disabled],
+  &[aria-disabled='true'] {
+    pointer-events: none;
+  }
 }
 
 [data-theme='modus-classic-light'] modus-wc-tabs .modus-wc-tab {

--- a/src/components/modus-wc-tabs/modus-wc-tabs.scss
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.scss
@@ -74,9 +74,7 @@ modus-wc-tabs .modus-wc-tab {
     color: inherit;
   }
 
-  &:disabled,
-  &[disabled],
-  &[aria-disabled='true'] {
+  &:disabled {
     pointer-events: none;
   }
 }

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -86,7 +86,6 @@
 
   &-disabled:hover {
     background-color: inherit;
-    color: var(--modus-wc-color-base-200) !important;
   }
 
   &--active {


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Removing the hover wrapper for the disabled state of Tab elements

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #616
