### PR TITLE
Modal: remove visible scrollbar gutter when modal is open

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,6 +34,24 @@ body {
   background-color: var(--modus-wc-color-base-page);
 }
 
+/*
+  Modal Scrollbar Behavior Override
+  Tailwind/DaisyUI applies `scrollbar-gutter: stable` to :root when a modal is open
+  (e.g., `:root:has(.modus-wc-modal-open, ...)`). This reserves space for the
+  scrollbar, leaving a visible empty gutter beside the content. We override it to
+  `auto` so the layout reflows naturally and the gutter disappears.
+*/
+:root:has(
+    :is(
+      .modus-wc-modal-open,
+      .modus-wc-modal:target,
+      .modus-wc-modal-toggle:checked + .modus-wc-modal,
+      .modus-wc-modal[open]
+    )
+  ) {
+  scrollbar-gutter: auto !important;
+}
+
 .modus-wc-border {
   border-color: var(--modus-wc-color-base-200);
   border-radius: 1px;


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Tailwind/DaisyUI applies `scrollbar-gutter: stable` to :root when a modal is open, leaving a visible empty gutter beside the content. we override it `auto` so the layout reflows naturally and the gutter disappears.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #663 
