### PR TITLE
Update GitHub links to modus-wc-2.0 repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Stencil web component implementation details can be found in their [Framework In
 ## Submitting Issues
 
 Whether you're contributing directly to the code or have suggestions, submitting an issue through GitHub is needed
-for referencing changes. Please submit change items as an Issue [here](https://github.com/trimble-oss/modus-web-components/issues).
+for referencing changes. Please submit change items as an Issue [here](https://github.com/trimble-oss/modus-wc-2.0/issues).
 
 If the issue's considered a bug, add the 'bug' label to the issue.
 

--- a/src/stories/accessibility.mdx
+++ b/src/stories/accessibility.mdx
@@ -13,7 +13,7 @@ Features:
 - Screen reader accessible.
 - Supports the [prefers-reduced-motion media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) to minimize the amount of non-essential motion.
 
-Found an accessibility issue? Please [report it at GitHub](https://github.com/trimble-oss/modus-web-components/issues/new?assignees=&labels=accessibility&template=accessibility-issue-report.md&title=).
+Found an accessibility issue? Please [report it at GitHub](https://github.com/trimble-oss/modus-wc-2.0/issues/new?assignees=&labels=accessibility&template=accessibility-issue-report.md&title=).
 
 ## For contributors
 

--- a/src/stories/getting-started.mdx
+++ b/src/stories/getting-started.mdx
@@ -87,5 +87,5 @@ const handleEvent = (e: ModusWcSelectCustomEvent<ISelectOption>) => {}
 
 ---
 
-Need help? Check out our [GitHub repository](https://github.com/trimble-oss/modus-web-components)
-or [raise an issue](https://github.com/trimble-oss/modus-web-components/issues).
+Need help? Check out our [GitHub repository](https://github.com/trimble-oss/modus-wc-2.0)
+or [raise an issue](https://github.com/trimble-oss/modus-wc-2.0/issues).

--- a/src/stories/styling.mdx
+++ b/src/stories/styling.mdx
@@ -103,5 +103,5 @@ these overrides aren't exhaustive. If you need additional style adjustments, you
 
 ---
 
-Need help? Check out our [GitHub repository](https://github.com/trimble-oss/modus-web-components)
-or [raise an issue](https://github.com/trimble-oss/modus-web-components/issues).
+Need help? Check out our [GitHub repository](https://github.com/trimble-oss/modus-wc-2.0)
+or [raise an issue](https://github.com/trimble-oss/modus-wc-2.0/issues).


### PR DESCRIPTION
Changed all references from 'modus-web-components' to 'modus-wc-2.0' in CONTRIBUTING.md and story files to reflect the new repository location for issues and documentation.