### PR TITLE
Dropdown Menu: Fix structural ordering to support button-group join styling

### DIFF
--- a/src/components/modus-wc-dropdown-menu/__snapshots__/modus-wc-dropdown-menu.spec.tsx.snap
+++ b/src/components/modus-wc-dropdown-menu/__snapshots__/modus-wc-dropdown-menu.spec.tsx.snap
@@ -3,6 +3,13 @@
 exports[`modus-wc-dropdown-menu should render with custom props 1`] = `
 <modus-wc-dropdown-menu button-size="sm" button-variant="borderless" class="modus-wc-dropdown-menu test-class" custom-class="test-class" disabled="{true}" menu-bordered="{false}" menu-offset="0" menu-placement="right" menu-size="sm" menu-visible="{true}">
   <!---->
+  <div class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: visible; opacity: 1; pointer-events: auto;">
+    <modus-wc-menu>
+      <!---->
+      <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-sm modus-wc-w-full" role="menu">
+      </ul>
+    </modus-wc-menu>
+  </div>
   <modus-wc-button>
     <!---->
     <button aria-expanded="true" aria-haspopup="true" class="modus-wc-btn modus-wc-btn-borderless modus-wc-btn-disabled modus-wc-btn-primary modus-wc-btn-sm" disabled="" tabindex="-1" type="button">
@@ -11,19 +18,19 @@ exports[`modus-wc-dropdown-menu should render with custom props 1`] = `
       </div>
     </button>
   </modus-wc-button>
-  <div class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: visible; opacity: 1; pointer-events: auto;">
-    <modus-wc-menu>
-      <!---->
-      <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-sm modus-wc-w-full" role="menu">
-      </ul>
-    </modus-wc-menu>
-  </div>
 </modus-wc-dropdown-menu>
 `;
 
 exports[`modus-wc-dropdown-menu should render with default props 1`] = `
 <modus-wc-dropdown-menu class="modus-wc-dropdown-menu">
   <!---->
+  <div aria-hidden="" class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: hidden; opacity: 0; pointer-events: none;">
+    <modus-wc-menu>
+      <!---->
+      <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-md modus-wc-w-full" role="menu">
+      </ul>
+    </modus-wc-menu>
+  </div>
   <modus-wc-button>
     <!---->
     <button aria-expanded="false" aria-haspopup="true" class="modus-wc-btn modus-wc-btn-filled modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
@@ -32,27 +39,12 @@ exports[`modus-wc-dropdown-menu should render with default props 1`] = `
       </div>
     </button>
   </modus-wc-button>
-  <div aria-hidden="" class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: hidden; opacity: 0; pointer-events: none;">
-    <modus-wc-menu>
-      <!---->
-      <ul aria-orientation="vertical" class="modus-wc-menu modus-wc-menu--bordered modus-wc-menu-md modus-wc-w-full" role="menu">
-      </ul>
-    </modus-wc-menu>
-  </div>
 </modus-wc-dropdown-menu>
 `;
 
 exports[`modus-wc-dropdown-menu should render with menu items 1`] = `
 <modus-wc-dropdown-menu class="modus-wc-dropdown-menu" menu-visible="{true}">
   <!---->
-  <modus-wc-button>
-    <!---->
-    <button aria-expanded="true" aria-haspopup="true" class="modus-wc-btn modus-wc-btn-filled modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
-      <div slot="button">
-        Button
-      </div>
-    </button>
-  </modus-wc-button>
   <div class="menu-wrapper" style="position: absolute; top: 0px; left: 0px; z-index: 1000; visibility: visible; opacity: 1; pointer-events: auto;">
     <modus-wc-menu>
       <!---->
@@ -90,5 +82,13 @@ exports[`modus-wc-dropdown-menu should render with menu items 1`] = `
       </ul>
     </modus-wc-menu>
   </div>
+  <modus-wc-button>
+    <!---->
+    <button aria-expanded="true" aria-haspopup="true" class="modus-wc-btn modus-wc-btn-filled modus-wc-btn-md modus-wc-btn-primary" tabindex="0" type="button">
+      <div slot="button">
+        Button
+      </div>
+    </button>
+  </modus-wc-button>
 </modus-wc-dropdown-menu>
 `;

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.spec.tsx
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.spec.tsx
@@ -80,7 +80,9 @@ describe('modus-wc-dropdown-menu', () => {
     });
 
     // Open the menu
-    const button = page.root!.querySelector('button');
+    const button = page.root!.querySelector(
+      'modus-wc-button button'
+    ) as HTMLButtonElement;
     expect(button?.textContent).toBe('Button');
     button?.click();
 
@@ -115,7 +117,9 @@ describe('modus-wc-dropdown-menu', () => {
     });
 
     // Open the menu
-    const button = page.root!.querySelector('button');
+    const button = page.root!.querySelector(
+      'modus-wc-button button'
+    ) as HTMLButtonElement;
     expect(button?.textContent).toBe('Button');
     button?.click();
 
@@ -156,7 +160,9 @@ describe('modus-wc-dropdown-menu', () => {
     const dropdownMenu = page.root!.querySelector('modus-wc-dropdown-menu')!;
     expect(dropdownMenu.menuVisible).toBe(false);
 
-    const button = page.root!.querySelector('button')!;
+    const button = dropdownMenu.querySelector(
+      'modus-wc-button button'
+    ) as HTMLButtonElement;
 
     button.click();
     await page.waitForChanges();

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
@@ -139,19 +139,6 @@ export class ModusWcDropdownMenu {
   render() {
     return (
       <Host class={this.getClasses()} {...this.inheritedAttributes}>
-        <modus-wc-button
-          aria-expanded={this.menuVisible.toString()}
-          aria-haspopup="true"
-          aria-label={this.buttonAriaLabel}
-          color={this.buttonColor}
-          disabled={this.disabled}
-          onButtonClick={this.handleButtonClick}
-          size={this.buttonSize}
-          variant={this.buttonVariant}
-        >
-          <slot name="button" />
-        </modus-wc-button>
-
         <div
           aria-hidden={!this.menuVisible}
           class="menu-wrapper"
@@ -172,6 +159,19 @@ export class ModusWcDropdownMenu {
             <slot name="menu" />
           </modus-wc-menu>
         </div>
+
+        <modus-wc-button
+          aria-expanded={this.menuVisible.toString()}
+          aria-haspopup="true"
+          aria-label={this.buttonAriaLabel}
+          color={this.buttonColor}
+          disabled={this.disabled}
+          onButtonClick={this.handleButtonClick}
+          size={this.buttonSize}
+          variant={this.buttonVariant}
+        >
+          <slot name="button" />
+        </modus-wc-button>
       </Host>
     );
   }

--- a/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
+++ b/src/components/modus-wc-dropdown-menu/modus-wc-dropdown-menu.tsx
@@ -139,6 +139,11 @@ export class ModusWcDropdownMenu {
   render() {
     return (
       <Host class={this.getClasses()} {...this.inheritedAttributes}>
+        {/* 
+          NOTE: menu-wrapper is rendered before modus-wc-button to ensure proper 
+          :last-child CSS selector behavior when used in modus-wc-button-group.
+          The absolutely positioned menu-wrapper should not interfere with join styling.
+        */}
         <div
           aria-hidden={!this.menuVisible}
           class="menu-wrapper"

--- a/src/components/modus-wc-dropdown-menu/readme.md
+++ b/src/components/modus-wc-dropdown-menu/readme.md
@@ -39,14 +39,14 @@ The component supports a 'button' and 'menu' `<slot>` for injecting custom HTML 
 
 ### Depends on
 
-- [modus-wc-button](../modus-wc-button)
 - [modus-wc-menu](../modus-wc-menu)
+- [modus-wc-button](../modus-wc-button)
 
 ### Graph
 ```mermaid
 graph TD;
-  modus-wc-dropdown-menu --> modus-wc-button
   modus-wc-dropdown-menu --> modus-wc-menu
+  modus-wc-dropdown-menu --> modus-wc-button
   style modus-wc-dropdown-menu fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- The structure of modus-wc-dropdown-menu was changed so that the menu-wrapper div is rendered before the modus-wc-button in the DOM.
- This ensures the button is the true last child, so join styling applies correctly.
- Unit tests were updated to use more specific selectors (modus-wc-button button) to avoid confusion with menu item buttons.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #717 
