### PR TITLE
feat: add clearClick events to text and autocomplete inputs

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2093,6 +2093,7 @@ declare global {
     interface HTMLModusWcAutocompleteElementEventMap {
         "chipRemove": IAutocompleteItem;
         "chipsExpansionChange": { expanded: boolean };
+        "clearClick": any;
         "inputBlur": FocusEvent;
         "inputChange": Event;
         "inputFocus": FocusEvent;
@@ -2414,7 +2415,10 @@ declare global {
         new (): HTMLModusWcMenuElement;
     };
     interface HTMLModusWcMenuItemElementEventMap {
-        "itemSelect": { value: string };
+        "itemSelect": {
+    value: string;
+    selected?: boolean;
+  };
     }
     /**
      * A customizable menu item component used to display the item portion of a menu
@@ -2737,6 +2741,7 @@ declare global {
         new (): HTMLModusWcTabsElement;
     };
     interface HTMLModusWcTextInputElementEventMap {
+        "clearClick": any;
         "inputBlur": FocusEvent;
         "inputChange": InputEvent;
         "inputFocus": FocusEvent;
@@ -3101,6 +3106,10 @@ declare namespace LocalJSX {
           * Event emitted when chips expansion state changes.
          */
         "onChipsExpansionChange"?: (event: ModusWcAutocompleteCustomEvent<{ expanded: boolean }>) => void;
+        /**
+          * Event emitted when the clear button is clicked.
+         */
+        "onClearClick"?: (event: ModusWcAutocompleteCustomEvent<any>) => void;
         /**
           * Event emitted when the input loses focus.
          */
@@ -3886,7 +3895,10 @@ declare namespace LocalJSX {
         /**
           * Event emitted when a menu item is selected.
          */
-        "onItemSelect"?: (event: ModusWcMenuItemCustomEvent<{ value: string }>) => void;
+        "onItemSelect"?: (event: ModusWcMenuItemCustomEvent<{
+    value: string;
+    selected?: boolean;
+  }>) => void;
         /**
           * The selected state of the menu item.
          */
@@ -4792,6 +4804,10 @@ declare namespace LocalJSX {
           * Name of the form control. Submitted with the form as part of a name/value pair.
          */
         "name"?: string;
+        /**
+          * Event emitted when the clear button is clicked.
+         */
+        "onClearClick"?: (event: ModusWcTextInputCustomEvent<any>) => void;
         /**
           * Event emitted when the input loses focus.
          */

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -2093,7 +2093,7 @@ declare global {
     interface HTMLModusWcAutocompleteElementEventMap {
         "chipRemove": IAutocompleteItem;
         "chipsExpansionChange": { expanded: boolean };
-        "clearClick": any;
+        "clearClick": void;
         "inputBlur": FocusEvent;
         "inputChange": Event;
         "inputFocus": FocusEvent;
@@ -2741,7 +2741,7 @@ declare global {
         new (): HTMLModusWcTabsElement;
     };
     interface HTMLModusWcTextInputElementEventMap {
-        "clearClick": any;
+        "clearClick": void;
         "inputBlur": FocusEvent;
         "inputChange": InputEvent;
         "inputFocus": FocusEvent;
@@ -3109,7 +3109,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when the clear button is clicked.
          */
-        "onClearClick"?: (event: ModusWcAutocompleteCustomEvent<any>) => void;
+        "onClearClick"?: (event: ModusWcAutocompleteCustomEvent<void>) => void;
         /**
           * Event emitted when the input loses focus.
          */
@@ -4807,7 +4807,7 @@ declare namespace LocalJSX {
         /**
           * Event emitted when the clear button is clicked.
          */
-        "onClearClick"?: (event: ModusWcTextInputCustomEvent<any>) => void;
+        "onClearClick"?: (event: ModusWcTextInputCustomEvent<void>) => void;
         /**
           * Event emitted when the input loses focus.
          */

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
@@ -712,6 +712,7 @@ interface RenderInputParams {
   customIconSlot?: boolean;
   onBlur: (event: CustomEvent<FocusEvent>) => void;
   onChange: (event: CustomEvent<Event>) => void;
+  onClear?: () => void; // The clear button is rendered separately for multiSelect
   onFocus: (event: CustomEvent<FocusEvent>) => void;
 }
 
@@ -725,6 +726,7 @@ export function renderInput(params: RenderInputParams): JSX.Element {
       inputId={params.inputId}
       inputTabIndex={params.inputTabIndex}
       name={params.name}
+      onClearClick={params.onClear}
       onInputBlur={params.onBlur}
       onInputChange={params.onChange}
       onInputFocus={params.onFocus}

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
@@ -712,7 +712,7 @@ interface RenderInputParams {
   customIconSlot?: boolean;
   onBlur: (event: CustomEvent<FocusEvent>) => void;
   onChange: (event: CustomEvent<Event>) => void;
-  onClear?: () => void; // The clear button is rendered separately for multiSelect
+  onClear?: () => void; // Optional handler for clear button click; not used in multiSelect mode where clear button is rendered separately
   onFocus: (event: CustomEvent<FocusEvent>) => void;
 }
 

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete-core.tsx
@@ -712,7 +712,7 @@ interface RenderInputParams {
   customIconSlot?: boolean;
   onBlur: (event: CustomEvent<FocusEvent>) => void;
   onChange: (event: CustomEvent<Event>) => void;
-  onClear?: () => void; // Optional handler for clear button click; not used in multiSelect mode where clear button is rendered separately
+  onClear?: (event: CustomEvent<void>) => void; // Optional handler for clear button click; not used in multiSelect mode where clear button is rendered separately
   onFocus: (event: CustomEvent<FocusEvent>) => void;
 }
 

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -2523,6 +2523,37 @@ describe('modus-wc-autocomplete', () => {
   });
 
   // Test clear button click
+  it('should clear selection when clear button is clicked', async () => {
+    const page = await newSpecPage({
+      components: [
+        ModusWcAutocomplete,
+        ModusWcTextInput,
+        ModusWcButton,
+        ModusWcChip,
+      ],
+      html: `<modus-wc-autocomplete aria-label="Clear test" include-clear="true"></modus-wc-autocomplete>`,
+    });
+
+    const autocomplete = page.rootInstance as ModusWcAutocomplete;
+    autocomplete.value = 'test';
+    await page.waitForChanges();
+
+    // Find and click the clear button
+    const clearButton = page.root?.querySelector(
+      'svg.modus-wc-text-input-icon-clear'
+    );
+    expect(clearButton).toBeTruthy();
+
+    const clearClickSpy = jest.spyOn(autocomplete.clearClick, 'emit');
+
+    // Simulate click
+    const clickEvent = new MouseEvent('click');
+    clearButton?.dispatchEvent(clickEvent);
+    await page.waitForChanges();
+
+    expect(clearClickSpy).toHaveBeenCalled();
+  });
+
   it('should clear all selections when clear button is clicked', async () => {
     const page = await newSpecPage({
       components: [

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -2549,11 +2549,14 @@ describe('modus-wc-autocomplete', () => {
     );
     expect(clearButton).toBeTruthy();
 
+    const clearClickSpy = jest.spyOn(autocomplete.clearClick, 'emit');
+
     // Simulate click
     const clickEvent = new MouseEvent('click');
     clearButton?.dispatchEvent(clickEvent);
     await page.waitForChanges();
 
+    expect(clearClickSpy).toHaveBeenCalled();
     expect(autocomplete.value).toBe('');
     expect(autocomplete['selectionOrder']).toEqual([]);
     expect(autocomplete.items[0].selected).toBe(false);

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -269,6 +269,7 @@ const meta: Meta<AutocompleteArgs> = {
       handles: [
         'chipRemove',
         'chipsExpansionChange',
+        'clearClick',
         'inputBlur',
         'inputChange',
         'inputFocus',
@@ -455,7 +456,7 @@ const Template: Story = {
 <script>
 // Add Autocomplete items
 ${Items}
-// Adding this block to show how to set items via JS  
+// Adding this block to show how to set items via JS
 // const autocomplete = document.querySelector('modus-wc-autocomplete');
 // autocomplete.items = autocompleteItems;
 </script>
@@ -506,7 +507,7 @@ export const WithCustomIconSlot: Story = {
 <script>
 // Add Autocomplete items
 ${Items}
-// Adding this block to show how to set items via JS  
+// Adding this block to show how to set items via JS
 // const autocomplete = document.querySelector('modus-wc-autocomplete');
 // autocomplete.items = autocompleteItems;
 </script>
@@ -713,7 +714,7 @@ export const MultiSelect: Story = {
           // const autocomplete = document.getElementById('fruit-autocomplete');
           // if (autocomplete) {
           //   autocomplete.items = itemsWithSelection;
-          // } 
+          // }
         </script>
     `;
   },
@@ -843,7 +844,7 @@ export const WithSpinner: Story = {
         //   autocomplete.removeEventListener('inputChange', handleInputChange);
         //   autocomplete.addEventListener('inputChange', handleInputChange);
         // }
-        
+
       </script>
     `;
   },

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -163,7 +163,7 @@ export class ModusWcAutocomplete {
   @StencilEvent() chipsExpansionChange!: EventEmitter<{ expanded: boolean }>;
 
   /** Event emitted when the clear button is clicked. */
-  @StencilEvent() clearClick!: EventEmitter;
+  @StencilEvent() clearClick!: EventEmitter<void>;
 
   /** Event emitted when the input loses focus. */
   @StencilEvent() inputBlur!: EventEmitter<FocusEvent>;

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -162,6 +162,9 @@ export class ModusWcAutocomplete {
   /** Event emitted when chips expansion state changes. */
   @StencilEvent() chipsExpansionChange!: EventEmitter<{ expanded: boolean }>;
 
+  /** Event emitted when the clear button is clicked. */
+  @StencilEvent() clearClick!: EventEmitter;
+
   /** Event emitted when the input loses focus. */
   @StencilEvent() inputBlur!: EventEmitter<FocusEvent>;
 
@@ -779,8 +782,13 @@ export class ModusWcAutocomplete {
     }
   };
 
+  private handleClear = () => {
+    this.clearClick.emit();
+  };
+
   private handleClearAll = () => {
     void this.clearInput();
+    this.clearClick.emit();
   };
 
   private toggleChipsExpansion = () => {
@@ -907,6 +915,7 @@ export class ModusWcAutocomplete {
               customIconSlot: hasSlottedCustomIcon,
               onBlur: this.handleBlur,
               onChange: this.handleChange,
+              onClear: this.handleClear,
               onFocus: this.handleFocus,
             })}
           </Fragment>

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -782,11 +782,11 @@ export class ModusWcAutocomplete {
     }
   };
 
-  private handleClear = () => {
-    this.clearClick.emit();
-  };
+  private handleClearAll = (event?: CustomEvent<void>) => {
+    // This method is called by the text input and a button, stop propagation of the text input event
+    // istanbul ignore next
+    event?.stopPropagation();
 
-  private handleClearAll = () => {
     void this.clearInput();
     this.clearClick.emit();
   };
@@ -915,7 +915,7 @@ export class ModusWcAutocomplete {
               customIconSlot: hasSlottedCustomIcon,
               onBlur: this.handleBlur,
               onChange: this.handleChange,
-              onClear: this.handleClear,
+              onClear: this.handleClearAll,
               onFocus: this.handleFocus,
             })}
           </Fragment>

--- a/src/components/modus-wc-autocomplete/readme.md
+++ b/src/components/modus-wc-autocomplete/readme.md
@@ -49,7 +49,7 @@ A customizable autocomplete component used to create searchable text inputs.
 | ---------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | `chipRemove`           | Event emitted when a selected item chip is removed.                                               | `CustomEvent<IAutocompleteItem>`      |
 | `chipsExpansionChange` | Event emitted when chips expansion state changes.                                                 | `CustomEvent<{ expanded: boolean; }>` |
-| `clearClick`           | Event emitted when the clear button is clicked.                                                   | `CustomEvent<any>`                    |
+| `clearClick`           | Event emitted when the clear button is clicked.                                                   | `CustomEvent<void>`                   |
 | `inputBlur`            | Event emitted when the input loses focus.                                                         | `CustomEvent<FocusEvent>`             |
 | `inputChange`          | Event emitted when the input value changes. This event is debounced based on the debounceMs prop. | `CustomEvent<Event>`                  |
 | `inputFocus`           | Event emitted when the input gains focus.                                                         | `CustomEvent<FocusEvent>`             |

--- a/src/components/modus-wc-autocomplete/readme.md
+++ b/src/components/modus-wc-autocomplete/readme.md
@@ -49,6 +49,7 @@ A customizable autocomplete component used to create searchable text inputs.
 | ---------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------- |
 | `chipRemove`           | Event emitted when a selected item chip is removed.                                               | `CustomEvent<IAutocompleteItem>`      |
 | `chipsExpansionChange` | Event emitted when chips expansion state changes.                                                 | `CustomEvent<{ expanded: boolean; }>` |
+| `clearClick`           | Event emitted when the clear button is clicked.                                                   | `CustomEvent<any>`                    |
 | `inputBlur`            | Event emitted when the input loses focus.                                                         | `CustomEvent<FocusEvent>`             |
 | `inputChange`          | Event emitted when the input value changes. This event is debounced based on the debounceMs prop. | `CustomEvent<Event>`                  |
 | `inputFocus`           | Event emitted when the input gains focus.                                                         | `CustomEvent<FocusEvent>`             |
@@ -153,7 +154,6 @@ graph TD;
   modus-wc-input-feedback --> modus-wc-icon
   modus-wc-menu-item --> modus-wc-checkbox
   modus-wc-menu-item --> modus-wc-tooltip
-  modus-wc-menu-item --> modus-wc-icon
   modus-wc-checkbox --> modus-wc-input-label
   style modus-wc-autocomplete fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/src/components/modus-wc-icon/readme.md
+++ b/src/components/modus-wc-icon/readme.md
@@ -33,7 +33,6 @@ A customizable icon component used to render Modus icons.
  - [modus-wc-date](../modus-wc-date)
  - [modus-wc-file-dropzone](../modus-wc-file-dropzone)
  - [modus-wc-input-feedback](../modus-wc-input-feedback)
- - [modus-wc-menu-item](../modus-wc-menu-item)
  - [modus-wc-table](../modus-wc-table)
  - [modus-wc-tabs](../modus-wc-tabs)
 
@@ -47,7 +46,6 @@ graph TD;
   modus-wc-date --> modus-wc-icon
   modus-wc-file-dropzone --> modus-wc-icon
   modus-wc-input-feedback --> modus-wc-icon
-  modus-wc-menu-item --> modus-wc-icon
   modus-wc-table --> modus-wc-icon
   modus-wc-tabs --> modus-wc-icon
   style modus-wc-icon fill:#f9f,stroke:#333,stroke-width:4px

--- a/src/components/modus-wc-menu-item/readme.md
+++ b/src/components/modus-wc-menu-item/readme.md
@@ -31,9 +31,9 @@ A customizable menu item component used to display the item portion of a menu
 
 ## Events
 
-| Event        | Description                                 | Type                              |
-| ------------ | ------------------------------------------- | --------------------------------- |
-| `itemSelect` | Event emitted when a menu item is selected. | `CustomEvent<{ value: string; }>` |
+| Event        | Description                                 | Type                                                               |
+| ------------ | ------------------------------------------- | ------------------------------------------------------------------ |
+| `itemSelect` | Event emitted when a menu item is selected. | `CustomEvent<{ value: string; selected?: boolean \| undefined; }>` |
 
 
 ## Methods
@@ -60,14 +60,12 @@ Type: `Promise<void>`
 
 - [modus-wc-checkbox](../modus-wc-checkbox)
 - [modus-wc-tooltip](../modus-wc-tooltip)
-- [modus-wc-icon](../modus-wc-icon)
 
 ### Graph
 ```mermaid
 graph TD;
   modus-wc-menu-item --> modus-wc-checkbox
   modus-wc-menu-item --> modus-wc-tooltip
-  modus-wc-menu-item --> modus-wc-icon
   modus-wc-checkbox --> modus-wc-input-label
   modus-wc-autocomplete --> modus-wc-menu-item
   modus-wc-navbar --> modus-wc-menu-item

--- a/src/components/modus-wc-navbar/readme.md
+++ b/src/components/modus-wc-navbar/readme.md
@@ -75,7 +75,6 @@ graph TD;
   modus-wc-navbar --> modus-wc-card
   modus-wc-menu-item --> modus-wc-checkbox
   modus-wc-menu-item --> modus-wc-tooltip
-  modus-wc-menu-item --> modus-wc-icon
   modus-wc-checkbox --> modus-wc-input-label
   modus-wc-text-input --> modus-wc-input-label
   modus-wc-text-input --> modus-wc-input-feedback

--- a/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
@@ -126,7 +126,7 @@ const meta: Meta<TextInputArgs> = {
   decorators: [withActions],
   parameters: {
     actions: {
-      handles: ['inputBlur', 'inputChange', 'inputFocus'],
+      handles: ['clearClick', 'inputBlur', 'inputChange', 'inputFocus'],
     },
   },
 };

--- a/src/components/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.tsx
@@ -123,6 +123,9 @@ export class ModusWcTextInput {
   /** The value of the control. */
   @Prop({ mutable: true, reflect: true }) value: string = '';
 
+  /** Event emitted when the clear button is clicked. */
+  @StencilEvent() clearClick!: EventEmitter;
+
   /** Event emitted when the input loses focus. */
   @StencilEvent() inputBlur!: EventEmitter<FocusEvent>;
 
@@ -182,6 +185,7 @@ export class ModusWcTextInput {
   private handleClearText = (event: MouseEvent | KeyboardEvent) => {
     this.value = '';
     this.inputChange.emit(event as unknown as InputEvent);
+    this.clearClick.emit();
   };
 
   private handleFocus = (event: FocusEvent) => {

--- a/src/components/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.tsx
@@ -124,7 +124,7 @@ export class ModusWcTextInput {
   @Prop({ mutable: true, reflect: true }) value: string = '';
 
   /** Event emitted when the clear button is clicked. */
-  @StencilEvent() clearClick!: EventEmitter;
+  @StencilEvent() clearClick!: EventEmitter<void>;
 
   /** Event emitted when the input loses focus. */
   @StencilEvent() inputBlur!: EventEmitter<FocusEvent>;

--- a/src/components/modus-wc-text-input/readme.md
+++ b/src/components/modus-wc-text-input/readme.md
@@ -43,7 +43,7 @@ A customizable input component used to create text inputs with types.
 
 | Event         | Description                                     | Type                      |
 | ------------- | ----------------------------------------------- | ------------------------- |
-| `clearClick`  | Event emitted when the clear button is clicked. | `CustomEvent<any>`        |
+| `clearClick`  | Event emitted when the clear button is clicked. | `CustomEvent<void>`       |
 | `inputBlur`   | Event emitted when the input loses focus.       | `CustomEvent<FocusEvent>` |
 | `inputChange` | Event emitted when the input value changes.     | `CustomEvent<InputEvent>` |
 | `inputFocus`  | Event emitted when the input gains focus.       | `CustomEvent<FocusEvent>` |

--- a/src/components/modus-wc-text-input/readme.md
+++ b/src/components/modus-wc-text-input/readme.md
@@ -41,11 +41,12 @@ A customizable input component used to create text inputs with types.
 
 ## Events
 
-| Event         | Description                                 | Type                      |
-| ------------- | ------------------------------------------- | ------------------------- |
-| `inputBlur`   | Event emitted when the input loses focus.   | `CustomEvent<FocusEvent>` |
-| `inputChange` | Event emitted when the input value changes. | `CustomEvent<InputEvent>` |
-| `inputFocus`  | Event emitted when the input gains focus.   | `CustomEvent<FocusEvent>` |
+| Event         | Description                                     | Type                      |
+| ------------- | ----------------------------------------------- | ------------------------- |
+| `clearClick`  | Event emitted when the clear button is clicked. | `CustomEvent<any>`        |
+| `inputBlur`   | Event emitted when the input loses focus.       | `CustomEvent<FocusEvent>` |
+| `inputChange` | Event emitted when the input value changes.     | `CustomEvent<InputEvent>` |
+| `inputFocus`  | Event emitted when the input gains focus.       | `CustomEvent<FocusEvent>` |
 
 
 ## Dependencies

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1163,6 +1163,14 @@
             },
             {
               "kind": "field",
+              "name": "clearClick",
+              "type": {
+                "text": "EventEmitter"
+              },
+              "description": "Event emitted when the clear button is clicked."
+            },
+            {
+              "kind": "field",
               "name": "inputBlur",
               "type": {
                 "text": "EventEmitter<FocusEvent>"
@@ -3611,7 +3619,7 @@
               "kind": "field",
               "name": "itemSelect",
               "type": {
-                "text": "EventEmitter<{ value: string }>"
+                "text": "EventEmitter<{\r\n    value: string;\r\n    selected?: boolean;\r\n  }>"
               },
               "description": "Event emitted when a menu item is selected."
             }

--- a/src/custom-elements.json
+++ b/src/custom-elements.json
@@ -1165,7 +1165,7 @@
               "kind": "field",
               "name": "clearClick",
               "type": {
-                "text": "EventEmitter"
+                "text": "EventEmitter<void>"
               },
               "description": "Event emitted when the clear button is clicked."
             },
@@ -6341,6 +6341,14 @@
           ],
           "tagName": "modus-wc-text-input",
           "events": [
+            {
+              "kind": "field",
+              "name": "clearClick",
+              "type": {
+                "text": "EventEmitter<void>"
+              },
+              "description": "Event emitted when the clear button is clicked."
+            },
             {
               "kind": "field",
               "name": "inputBlur",


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Adds a new event `clearClick` to the text and autocomplete form inputs. This is to make it easier for developers to track when the clear buttons have been clicked. Before this change the only way to determine this was to check for an `undefined` value in the `inputChange` event.

In the text input the event is emitted when the clear button is clicked.

In the autocomplete input the event is emitted when the clear button is clicked for either the text input clear button or multiSelect clear button.

Also includes some auto generated changes from running a build and the `format` command.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

Test added

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [x] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #754 
