### PR TITLE
fix: enforce semantic versioning via release drafter and publish workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,24 @@
-name-template: 'v$NEXT_PATCH_VERSION 🌈'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: 'v$NEXT_SEMVER_VERSION 🌈'
+tag-template: 'v$NEXT_SEMVER_VERSION'
 prerelease: true
 prerelease-identifier: 'alpha' # will create a prerelease with version number x.x.x-alpha.x
 exclude-labels:
   - 'skip-changelog'
+version-resolver:
+  major:
+    labels:
+      - 'breaking-change'
+  minor:
+    labels:
+      - 'new-feature'
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  default: patch
 categories:
   - title: '❗ Breaking Changes'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$NEXT_SEMVER_VERSION 🌈'
-tag-template: 'v$NEXT_SEMVER_VERSION'
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
 prerelease: true
 prerelease-identifier: 'alpha' # will create a prerelease with version number x.x.x-alpha.x
 exclude-labels:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,34 +44,36 @@ jobs:
 
       - name: Validate version bump follows SemVer
         run: |
-          node - <<'EOF'
-          const semver = require('semver');
-          const pkg = require('./package.json');
+          set -euo pipefail
 
-          const current = pkg.version;
-          // Normalize input by stripping a leading 'v' if present
-          const input = '${{ github.event.inputs.version }}'.replace(/^v/, '');
+          current="$(node -p "require('./package.json').version")"
 
-          if (!semver.valid(input)) {
-            console.error(`❌ '${input}' is not a valid SemVer version.`);
-            process.exit(1);
-          }
+          # Normalize input by stripping a leading 'v' if present
+          input='${{ github.event.inputs.version }}'
+          input="${input#v}"
 
-          const expectedMajor = semver.inc(current, 'major');
-          const expectedMinor = semver.inc(current, 'minor');
-          const expectedPatch = semver.inc(current, 'patch');
+          # Validate that the input is a valid SemVer version using the semver CLI
+          valid="$(npx --yes semver "$input" || true)"
+          if [ -z "$valid" ]; then
+            echo "❌ '$input' is not a valid SemVer version." >&2
+            exit 1
+          fi
 
-          if (input !== expectedMajor && input !== expectedMinor && input !== expectedPatch) {
-            console.error(`❌ Invalid version bump: '${input}' is not a valid SemVer increment from '${current}'.`);
-            console.error(`   Expected one of:`);
-            console.error(`     MAJOR: ${expectedMajor} (breaking changes)`);
-            console.error(`     MINOR: ${expectedMinor} (new features)`);
-            console.error(`     PATCH: ${expectedPatch} (bug fixes)`);
-            process.exit(1);
-          }
+          # Compute expected MAJOR / MINOR / PATCH increments from the current version
+          expectedMajor="$(npx --yes semver -i major "$current")"
+          expectedMinor="$(npx --yes semver -i minor "$current")"
+          expectedPatch="$(npx --yes semver -i patch "$current")"
 
-          console.log(`✅ Version bump from ${current} to ${input} is valid.`);
-          EOF
+          if [ "$input" != "$expectedMajor" ] && [ "$input" != "$expectedMinor" ] && [ "$input" != "$expectedPatch" ]; then
+            echo "❌ Invalid version bump: '$input' is not a valid SemVer increment from '$current'." >&2
+            echo "   Expected one of:" >&2
+            echo "     MAJOR: $expectedMajor (breaking changes)" >&2
+            echo "     MINOR: $expectedMinor (new features)" >&2
+            echo "     PATCH: $expectedPatch (bug fixes)" >&2
+            exit 1
+          fi
+
+          echo "✅ Version bump from $current to $input is valid."
 
       - name: Update package.json version
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,30 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Validate version bump follows SemVer
+        run: |
+          CURRENT=$(jq -r '.version' package.json)
+          INPUT="${{ github.event.inputs.version }}"
+
+          CURRENT_MAJOR=$(echo $CURRENT | cut -d. -f1)
+          CURRENT_MINOR=$(echo $CURRENT | cut -d. -f2)
+          CURRENT_PATCH=$(echo $CURRENT | cut -d. -f3)
+
+          EXPECTED_MAJOR="$((CURRENT_MAJOR + 1)).0.0"
+          EXPECTED_MINOR="${CURRENT_MAJOR}.$((CURRENT_MINOR + 1)).0"
+          EXPECTED_PATCH="${CURRENT_MAJOR}.${CURRENT_MINOR}.$((CURRENT_PATCH + 1))"
+
+          if [ "$INPUT" != "$EXPECTED_MAJOR" ] && [ "$INPUT" != "$EXPECTED_MINOR" ] && [ "$INPUT" != "$EXPECTED_PATCH" ]; then
+            echo "❌ Invalid version bump: '$INPUT' is not a valid SemVer increment from '$CURRENT'."
+            echo "   Expected one of:"
+            echo "     MAJOR: $EXPECTED_MAJOR (breaking changes)"
+            echo "     MINOR: $EXPECTED_MINOR (new features)"
+            echo "     PATCH: $EXPECTED_PATCH (bug fixes)"
+            exit 1
+          fi
+
+          echo "✅ Version bump from $CURRENT to $INPUT is valid."
+
       - name: Update package.json version
         run: |
           jq --arg version "${{ github.event.inputs.version }}" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,27 +44,34 @@ jobs:
 
       - name: Validate version bump follows SemVer
         run: |
-          CURRENT=$(jq -r '.version' package.json)
-          INPUT="${{ github.event.inputs.version }}"
+          node - <<'EOF'
+          const semver = require('semver');
+          const pkg = require('./package.json');
 
-          CURRENT_MAJOR=$(echo $CURRENT | cut -d. -f1)
-          CURRENT_MINOR=$(echo $CURRENT | cut -d. -f2)
-          CURRENT_PATCH=$(echo $CURRENT | cut -d. -f3)
+          const current = pkg.version;
+          // Normalize input by stripping a leading 'v' if present
+          const input = '${{ github.event.inputs.version }}'.replace(/^v/, '');
 
-          EXPECTED_MAJOR="$((CURRENT_MAJOR + 1)).0.0"
-          EXPECTED_MINOR="${CURRENT_MAJOR}.$((CURRENT_MINOR + 1)).0"
-          EXPECTED_PATCH="${CURRENT_MAJOR}.${CURRENT_MINOR}.$((CURRENT_PATCH + 1))"
+          if (!semver.valid(input)) {
+            console.error(`❌ '${input}' is not a valid SemVer version.`);
+            process.exit(1);
+          }
 
-          if [ "$INPUT" != "$EXPECTED_MAJOR" ] && [ "$INPUT" != "$EXPECTED_MINOR" ] && [ "$INPUT" != "$EXPECTED_PATCH" ]; then
-            echo "❌ Invalid version bump: '$INPUT' is not a valid SemVer increment from '$CURRENT'."
-            echo "   Expected one of:"
-            echo "     MAJOR: $EXPECTED_MAJOR (breaking changes)"
-            echo "     MINOR: $EXPECTED_MINOR (new features)"
-            echo "     PATCH: $EXPECTED_PATCH (bug fixes)"
-            exit 1
-          fi
+          const expectedMajor = semver.inc(current, 'major');
+          const expectedMinor = semver.inc(current, 'minor');
+          const expectedPatch = semver.inc(current, 'patch');
 
-          echo "✅ Version bump from $CURRENT to $INPUT is valid."
+          if (input !== expectedMajor && input !== expectedMinor && input !== expectedPatch) {
+            console.error(`❌ Invalid version bump: '${input}' is not a valid SemVer increment from '${current}'.`);
+            console.error(`   Expected one of:`);
+            console.error(`     MAJOR: ${expectedMajor} (breaking changes)`);
+            console.error(`     MINOR: ${expectedMinor} (new features)`);
+            console.error(`     PATCH: ${expectedPatch} (bug fixes)`);
+            process.exit(1);
+          }
+
+          console.log(`✅ Version bump from ${current} to ${input} is valid.`);
+          EOF
 
       - name: Update package.json version
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,12 +67,24 @@ jobs:
           expectedMinor="$(npx --yes semver@7 -i minor "$current")"
           expectedPatch="$(npx --yes semver@7 -i patch "$current")"
 
-          if [ "$input" != "$expectedMajor" ] && [ "$input" != "$expectedMinor" ] && [ "$input" != "$expectedPatch" ]; then
+          # Also allow prerelease increments (e.g. 1.3.0-alpha.1) to align with release-drafter prerelease config
+          expectedPremajor="$(npx --yes semver@7 -i premajor --preid alpha "$current")"
+          expectedPreminor="$(npx --yes semver@7 -i preminor --preid alpha "$current")"
+          expectedPrepatch="$(npx --yes semver@7 -i prepatch --preid alpha "$current")"
+          expectedPrerelease="$(npx --yes semver@7 -i prerelease --preid alpha "$current" || true)"
+
+          if [ "$input" != "$expectedMajor" ] && [ "$input" != "$expectedMinor" ] && [ "$input" != "$expectedPatch" ] && \
+             [ "$input" != "$expectedPremajor" ] && [ "$input" != "$expectedPreminor" ] && [ "$input" != "$expectedPrepatch" ] && \
+             [ "$input" != "$expectedPrerelease" ]; then
             echo "❌ Invalid version bump: '$input' is not a valid SemVer increment from '$current'." >&2
             echo "   Expected one of:" >&2
-            echo "     MAJOR: $expectedMajor (breaking changes)" >&2
-            echo "     MINOR: $expectedMinor (new features)" >&2
-            echo "     PATCH: $expectedPatch (bug fixes)" >&2
+            echo "     MAJOR:      $expectedMajor (breaking changes)" >&2
+            echo "     MINOR:      $expectedMinor (new features)" >&2
+            echo "     PATCH:      $expectedPatch (bug fixes)" >&2
+            echo "     PREMAJOR:   $expectedPremajor (breaking prerelease)" >&2
+            echo "     PREMINOR:   $expectedPreminor (feature prerelease)" >&2
+            echo "     PREPATCH:   $expectedPrepatch (fix prerelease)" >&2
+            echo "     PRERELEASE: $expectedPrerelease (next prerelease iteration)" >&2
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,16 +56,16 @@ jobs:
           fi
 
           # Validate that the input is a valid SemVer version using the semver CLI
-          valid="$(npx --yes semver "$input" || true)"
+          valid="$(npx --yes semver@7 "$input" || true)"
           if [ -z "$valid" ]; then
             echo "❌ '$input' is not a valid SemVer version." >&2
             exit 1
           fi
 
           # Compute expected MAJOR / MINOR / PATCH increments from the current version
-          expectedMajor="$(npx --yes semver -i major "$current")"
-          expectedMinor="$(npx --yes semver -i minor "$current")"
-          expectedPatch="$(npx --yes semver -i patch "$current")"
+          expectedMajor="$(npx --yes semver@7 -i major "$current")"
+          expectedMinor="$(npx --yes semver@7 -i minor "$current")"
+          expectedPatch="$(npx --yes semver@7 -i patch "$current")"
 
           if [ "$input" != "$expectedMajor" ] && [ "$input" != "$expectedMinor" ] && [ "$input" != "$expectedPatch" ]; then
             echo "❌ Invalid version bump: '$input' is not a valid SemVer increment from '$current'." >&2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,9 +48,12 @@ jobs:
 
           current="$(node -p "require('./package.json').version")"
 
-          # Normalize input by stripping a leading 'v' if present
+          # Capture the raw input version and ensure it does not start with 'v'
           input='${{ github.event.inputs.version }}'
-          input="${input#v}"
+          if [ "${input#v}" != "$input" ]; then
+            echo "❌ Version '$input' must not start with 'v'. Please provide a bare SemVer like '1.2.3'." >&2
+            exit 1
+          fi
 
           # Validate that the input is a valid SemVer version using the semver CLI
           valid="$(npx --yes semver "$input" || true)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,11 +146,19 @@ The release notes can be viewed on the [GitHub Releases](https://github.com/trim
 This project uses the following semantic versioning convention for the repository and changelog entries.
 Given a version number [MAJOR.MINOR.PATCH], increment the following:
 
-1. Major: to make incompatible API changes - updates containing new dependencies.
-2. Minor: to add functionality in a backwards compatible manner.
-3. Patch: to make backwards compatible bug fixes.
-   Example: Version 1.0.0 has a function added in accordance with a minor version update. The new version will be 1.1.0.
-   See: [semver.org](https://semver.org/spec/v2.0.0.html).
+| Bump | When | PR Label | Example |
+|------|------|----------|---------|
+| **MAJOR** | Incompatible/breaking API changes (e.g. removing a prop, renaming an event, changing a prop type) | `breaking-change` | `1.2.3` → `2.0.0` |
+| **MINOR** | New backward-compatible functionality (e.g. adding a new optional prop, new component, new event) | `new-feature`, `feature`, `enhancement` | `1.2.3` → `1.3.0` |
+| **PATCH** | Backward-compatible bug fixes only | `fix`, `bugfix`, `bug` | `1.2.3` → `1.2.4` |
+
+- When a release contains both new features and bug fixes, use the **highest** applicable bump (MINOR).
+- When a release contains a breaking change alongside anything else, always use **MAJOR**.
+- PATCH resets to `0` on a MINOR bump. Both MINOR and PATCH reset to `0` on a MAJOR bump.
+
+**Important:** Every PR must have one of the labels above applied before merging. The release drafter will automatically suggest the correct next version based on these labels.
+
+See: [semver.org](https://semver.org/spec/v2.0.0.html).
 
 ## Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ Given a version number [MAJOR.MINOR.PATCH], increment the following:
 - When a release contains a breaking change alongside anything else, always use **MAJOR**.
 - PATCH resets to `0` on a MINOR bump. Both MINOR and PATCH reset to `0` on a MAJOR bump.
 
-**Important:** Every PR must have one of the labels above applied before merging. The release drafter will automatically suggest the correct next version based on these labels.
+**Important:** To keep release notes accurate, each PR should have one of the labels above applied before merging. If no version-bump label is present, the release drafter will fall back to a PATCH bump by default when suggesting the next version.
 
 See: [semver.org](https://semver.org/spec/v2.0.0.html).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,11 +146,11 @@ The release notes can be viewed on the [GitHub Releases](https://github.com/trim
 This project uses the following semantic versioning convention for the repository and changelog entries.
 Given a version number [MAJOR.MINOR.PATCH], increment the following:
 
-| Bump | When | PR Label | Example |
-|------|------|----------|---------|
-| **MAJOR** | Incompatible/breaking API changes (e.g. removing a prop, renaming an event, changing a prop type) | `breaking-change` | `1.2.3` → `2.0.0` |
+| Bump      | When                                                                                              | PR Label                                | Example           |
+| --------- | ------------------------------------------------------------------------------------------------- | --------------------------------------- | ----------------- |
+| **MAJOR** | Incompatible/breaking API changes (e.g. removing a prop, renaming an event, changing a prop type) | `breaking-change`                       | `1.2.3` → `2.0.0` |
 | **MINOR** | New backward-compatible functionality (e.g. adding a new optional prop, new component, new event) | `new-feature`, `feature`, `enhancement` | `1.2.3` → `1.3.0` |
-| **PATCH** | Backward-compatible bug fixes only | `fix`, `bugfix`, `bug` | `1.2.3` → `1.2.4` |
+| **PATCH** | Backward-compatible bug fixes only                                                                | `fix`, `bugfix`, `bug`                  | `1.2.3` → `1.2.4` |
 
 - When a release contains both new features and bug fixes, use the **highest** applicable bump (MINOR).
 - When a release contains a breaking change alongside anything else, always use **MAJOR**.


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Fixed `release-drafter.yml` to use `$RESOLVED_VERSION` with a `version-resolver` block so the correct MAJOR/MINOR/PATCH version is automatically suggested based on PR labels
- Added a SemVer validation step in `publish.yml` that fails the workflow if the entered version is not a valid increment from the current version
- Updated `CONTRIBUTING.md` with a clear versioning table, corrected the MAJOR definition, and added PR label guidance

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #
