### PR TITLE
feat(blazor): Blazor/MAUI integration — NuGet RCL, BlazingStory, interop, MCP docs

### DIFF
--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   a11y-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/a11y-check.yml
+++ b/.github/workflows/a11y-check.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: ${{ vars.NODE_VERSION }}
+          cache: 'npm'
 
       # - uses: google/wireit@setup-github-actions-caching/v2
 
@@ -28,6 +29,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Stencil components
         run: npm run build:ci

--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -39,70 +39,48 @@ jobs:
       - name: Build React v17 integration
         working-directory: integrations/react/v17
         run: npm ci && npm run build
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build React v18 integration
         working-directory: integrations/react/v18
         run: npm ci && npm run build
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build React v19 integration
         working-directory: integrations/react/v19
         run: npm ci && npm run build
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Vue integration
         working-directory: integrations/vue/v-latest
         run: npm ci && npm run build
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # --- Install remaining integration deps ---
 
       - name: Install Angular ng17 dependencies
         working-directory: integrations/angular/ng17
         run: npm ci
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Angular ng18 dependencies
         working-directory: integrations/angular/ng18
         run: npm ci
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Angular ng19 dependencies
         working-directory: integrations/angular/ng19
         run: npm ci
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install React test app v17 dependencies
         working-directory: integrations/react/test-react-v17
         run: npm ci
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install React test app v18 dependencies
         working-directory: integrations/react/test-react-v18
         run: npm ci
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install React test app v19 dependencies
         working-directory: integrations/react/test-react-v19
         run: npm ci
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Vue test app dependencies
         working-directory: integrations/vue/test-app
         run: npm ci
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # --- Audit phase ---
 

--- a/.github/workflows/audit-fix.yml
+++ b/.github/workflows/audit-fix.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: write
+  packages: read
   pull-requests: write
 
 jobs:
@@ -33,52 +34,75 @@ jobs:
         run: npm ci && npm run build:ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build React v17 integration
         working-directory: integrations/react/v17
         run: npm ci && npm run build
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build React v18 integration
         working-directory: integrations/react/v18
         run: npm ci && npm run build
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build React v19 integration
         working-directory: integrations/react/v19
         run: npm ci && npm run build
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Vue integration
         working-directory: integrations/vue/v-latest
         run: npm ci && npm run build
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # --- Install remaining integration deps ---
 
       - name: Install Angular ng17 dependencies
         working-directory: integrations/angular/ng17
         run: npm ci
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Angular ng18 dependencies
         working-directory: integrations/angular/ng18
         run: npm ci
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Angular ng19 dependencies
         working-directory: integrations/angular/ng19
         run: npm ci
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install React test app v17 dependencies
         working-directory: integrations/react/test-react-v17
         run: npm ci
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install React test app v18 dependencies
         working-directory: integrations/react/test-react-v18
         run: npm ci
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install React test app v19 dependencies
         working-directory: integrations/react/test-react-v19
         run: npm ci
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Vue test app dependencies
         working-directory: integrations/vue/test-app
         run: npm ci
+        env:
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # --- Audit phase ---
 

--- a/.github/workflows/azure-static-web-apps-gentle-mushroom-083c46a10.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-mushroom-083c46a10.yml
@@ -8,11 +8,13 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   build_and_deploy_job:
     permissions:
       contents: read # for actions/checkout to fetch code
+      packages: read # for npm ci to access GitHub Package Registry
     if: github.repository == 'trimble-oss/modus-wc-2.0'
     runs-on: ubuntu-22.04
     name: Build and Deploy Job
@@ -32,6 +34,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build project
         run: npm run build

--- a/.github/workflows/build-angular.yml
+++ b/.github/workflows/build-angular.yml
@@ -34,6 +34,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Stencil components
         run: npm run build:ci

--- a/.github/workflows/build-blazor.yml
+++ b/.github/workflows/build-blazor.yml
@@ -1,0 +1,40 @@
+name: Build Blazor Integration
+
+on:
+  workflow_call:
+    secrets:
+      TRIMBLE_AGENTIC_NPM_TOKEN:
+        required: true
+
+jobs:
+  build-blazor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Stencil components (generates Blazor RCL)
+        run: npm run build:ci
+
+      - name: Build Blazor RCL
+        run: dotnet build integrations/blazor/stencil-generated/ModusWebComponents.Blazor -c Release

--- a/.github/workflows/build-blazor.yml
+++ b/.github/workflows/build-blazor.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'npm'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.x'
 

--- a/.github/workflows/build-blazor.yml
+++ b/.github/workflows/build-blazor.yml
@@ -23,7 +23,7 @@ jobs:
           cache: 'npm'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.x'
 

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -34,6 +34,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Stencil components
         run: npm run build:ci

--- a/.github/workflows/build-vue.yml
+++ b/.github/workflows/build-vue.yml
@@ -30,6 +30,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Stencil components
         run: npm run build:ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   run:
@@ -32,12 +33,14 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
+          node-version: ${{ vars.NODE_VERSION }}
           cache: npm
 
       - name: Install npm dependencies
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests
         run: npm run lint:stylelint

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   merge-gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -29,6 +29,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run ESLint
         id: lint
@@ -71,4 +72,9 @@ jobs:
     uses: ./.github/workflows/build-vue.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+
+  build-blazor-integration:
+    uses: ./.github/workflows/build-blazor.yml
+    secrets:
       TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  packages: read
   pull-requests: write
 
 jobs:
@@ -36,6 +37,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Storybook
         run: npm run build

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -56,6 +56,7 @@ jobs:
         working-directory: .
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Base Web Components
         run: npm run build:ci

--- a/.github/workflows/publish-angular.yml
+++ b/.github/workflows/publish-angular.yml
@@ -106,7 +106,7 @@ jobs:
         run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
 
       - name: Publish distribution
-        run: npm publish *.tgz
+        run: npm publish *.tgz --registry=https://registry.npmjs.org
 
       - name: Set GitHub Registry Auth Token
         run: npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-blazor.yml
+++ b/.github/workflows/publish-blazor.yml
@@ -35,7 +35,7 @@ jobs:
           cache: 'npm'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
           dotnet-version: '10.x'
 

--- a/.github/workflows/publish-blazor.yml
+++ b/.github/workflows/publish-blazor.yml
@@ -35,7 +35,7 @@ jobs:
           cache: 'npm'
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: '10.x'
 

--- a/.github/workflows/publish-blazor.yml
+++ b/.github/workflows/publish-blazor.yml
@@ -1,0 +1,95 @@
+# This publishes the Blazor Razor Class Library generated from the Stencil output target.
+# It builds the Stencil components, packs the generated RCL as a NuGet package, publishes it
+# to GitHub Packages (NuGet), and creates a GitHub release.
+# This is triggered by running the main 'Publish & Release' workflow.
+
+name: Publish & Release - Blazor
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  actions: write
+  packages: write
+
+jobs:
+  build-and-publish-blazor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version: ${{ vars.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Install Web Component dependencies
+        run: npm ci
+        env:
+          TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Base Web Components (generates Blazor RCL)
+        run: npm run build:ci
+
+      - name: Pack Blazor RCL
+        run: |
+          dotnet pack integrations/blazor/stencil-generated/ModusWebComponents.Blazor \
+            -c Release \
+            -p:Version="${{ github.event.inputs.version }}" \
+            --output ./nuget-output
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: blazor-distribution-v${{ github.event.inputs.version }}
+          path: nuget-output/*.nupkg
+
+      - name: Publish to GitHub Packages (NuGet)
+        run: |
+          dotnet nuget push ./nuget-output/*.nupkg \
+            --source "https://nuget.pkg.github.com/trimble-oss/index.json" \
+            --api-key "${{ secrets.GITHUB_TOKEN }}"
+
+  release-blazor:
+    needs: build-and-publish-blazor
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v6
+        with:
+          name: blazor-distribution-v${{ github.event.inputs.version }}
+          path: .
+
+      - name: Find the release asset
+        id: find-asset
+        run: echo "asset_path=$(find . -name '*.nupkg')" >> $GITHUB_OUTPUT
+
+      - name: Rename release asset
+        run: mv ${{ steps.find-asset.outputs.asset_path }} package-blazor.nupkg
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: moduswebcomponents-blazor-${{ github.event.inputs.version }}
+          name: Modus Web Components Blazor ${{ github.event.inputs.version }}
+          files: |
+            **/package-blazor.nupkg

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -45,6 +45,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if version data already exists
         id: check-version

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -150,7 +150,7 @@ jobs:
         run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN_MCP }}
 
       - name: Publish to npm
-        run: npm publish
+        run: npm publish --registry=https://registry.npmjs.org
 
       - name: Set GitHub Registry Auth Token
         run: npm set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-react.yml
+++ b/.github/workflows/publish-react.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json

--- a/.github/workflows/publish-react.yml
+++ b/.github/workflows/publish-react.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Publish distribution
         working-directory: integrations/react/v${{ matrix.react-version }}/dist
-        run: npm publish
+        run: npm publish --registry=https://registry.npmjs.org
 
       - name: Set GitHub Registry Auth Token
         working-directory: integrations/react/v${{ matrix.react-version }}/dist

--- a/.github/workflows/publish-vue.yml
+++ b/.github/workflows/publish-vue.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           cache: 'npm'
           cache-dependency-path: |
             package-lock.json

--- a/.github/workflows/publish-vue.yml
+++ b/.github/workflows/publish-vue.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Publish distribution
         working-directory: integrations/vue/v-latest/dist
-        run: npm publish
+        run: npm publish --registry=https://registry.npmjs.org
 
       - name: Set GitHub Registry Auth Token
         working-directory: integrations/vue/v-latest/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Publish npm Package Publicly
         working-directory: dist
-        run: npm publish
+        run: npm publish --registry=https://registry.npmjs.org
 
       - name: Set GitHub Registry Auth Token
         working-directory: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,7 @@ jobs:
         run: npm ci
         env:
           TRIMBLE_AGENTIC_NPM_TOKEN: ${{ secrets.TRIMBLE_AGENTIC_NPM_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate version bump follows SemVer
         run: |
@@ -185,6 +186,16 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.2
         with:
           workflow: publish-mcp.yml
+          inputs: '{"version": "${{ github.event.inputs.version }}"}'
+
+  trigger-blazor-publish:
+    needs: build-and-publish-wc
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Blazor Publish Workflow
+        uses: benc-uk/workflow-dispatch@v1.2
+        with:
+          workflow: publish-blazor.yml
           inputs: '{"version": "${{ github.event.inputs.version }}"}'
 
   release-wc:

--- a/.npmrc
+++ b/.npmrc
@@ -3,5 +3,7 @@
 @trimble-agentic-external-npm-local:registry=https://artifactory.trimble.tools/artifactory/api/npm/trimble-agentic-external-npm-local/
 //artifactory.trimble.tools/artifactory/api/npm/trimble-agentic-external-npm-local/:_authToken=${TRIMBLE_AGENTIC_NPM_TOKEN}
 
+# GitHub Packages trimble-oss org registry for Blazor Stencil output.
+# Set GITHUB_AUTH_TOKEN in your environment or ~/.npmrc to install locally.
 @trimble-oss:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,6 @@
 # Set TRIMBLE_AGENTIC_NPM_TOKEN in your environment or ~/.npmrc to install locally.
 @trimble-agentic-external-npm-local:registry=https://artifactory.trimble.tools/artifactory/api/npm/trimble-agentic-external-npm-local/
 //artifactory.trimble.tools/artifactory/api/npm/trimble-agentic-external-npm-local/:_authToken=${TRIMBLE_AGENTIC_NPM_TOKEN}
+
+@trimble-oss:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_AUTH_TOKEN}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@storybook/web-components-vite": "^8.6.12",
         "@tailwindcss/typography": "^0.5.15",
         "@trimble-agentic-external-npm-local/agentic-platform-sdk-iframe-typescript": "^1.0.1-rc.3",
+        "@trimble-oss/modus-stencil-razor-output-target": "^1.0.3",
         "@types/jest": "^29.5.13",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",
@@ -3644,6 +3645,24 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/@trimble-oss/modus-icons": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-icons/-/modus-icons-1.21.0.tgz",
+      "integrity": "sha512-W02mF0pV5G2DaozqkCyq/HM/YeDpiGlYizCAaM/YW0Ra4Zx/aPrNut0TsPu9fd3vEZ9s51TTp70dmWNnTtm6vg==",
+      "license": "MIT"
+    },
+    "node_modules/@trimble-oss/modus-stencil-razor-output-target": {
+      "version": "1.0.3",
+      "resolved": "https://npm.pkg.github.com/@trimble-oss/modus-stencil-razor-output-target/-/modus-stencil-razor-output-target-1.0.3.tgz",
+      "integrity": "sha512-i4HuWsGhDzvx2y4k4S7rE1zPO0CYP+8kqbk9q+BI9pK3YppuBqrVs6i2P2nBCR6yGbSVZVKDdU5pBMq6JQaL9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@trimble-oss/modus-icons": "^1.19.0"
+      },
+      "peerDependencies": {
+        "@stencil/core": ">=4.0.0"
       }
     },
     "node_modules/@ts-morph/common": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3651,11 +3651,14 @@
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/@trimble-oss/modus-icons/-/modus-icons-1.21.0.tgz",
       "integrity": "sha512-W02mF0pV5G2DaozqkCyq/HM/YeDpiGlYizCAaM/YW0Ra4Zx/aPrNut0TsPu9fd3vEZ9s51TTp70dmWNnTtm6vg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@trimble-oss/modus-stencil-razor-output-target": {
       "version": "1.0.10",
-      "resolved": "https://npm.pkg.github.com/@trimble-oss/modus-stencil-razor-output-target/-/modus-stencil-razor-output-target-1.0.10.tgz",
+      "resolved": "https://npm.pkg.github.com/download/@trimble-oss/modus-stencil-razor-output-target/1.0.10/128400587656b9c3542562b196d5ad1a7cf9d79c",
+      "integrity": "sha512-kL7/Y1B4GcUTVjYBTgE3LaDa3a3tkWkFEWD+V8UwYMhGNwZQXnH2m6ssOydB+yt+3kcgi4O2r31gymwL3TxUew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@trimble-oss/modus-icons": "^1.19.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@storybook/web-components-vite": "^8.6.12",
         "@tailwindcss/typography": "^0.5.15",
         "@trimble-agentic-external-npm-local/agentic-platform-sdk-iframe-typescript": "^1.0.1-rc.3",
-        "@trimble-oss/modus-stencil-razor-output-target": "^1.0.3",
+        "@trimble-oss/modus-stencil-razor-output-target": "^1.0.10",
         "@types/jest": "^29.5.13",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",
@@ -3654,9 +3654,8 @@
       "license": "MIT"
     },
     "node_modules/@trimble-oss/modus-stencil-razor-output-target": {
-      "version": "1.0.3",
-      "resolved": "https://npm.pkg.github.com/@trimble-oss/modus-stencil-razor-output-target/-/modus-stencil-razor-output-target-1.0.3.tgz",
-      "integrity": "sha512-i4HuWsGhDzvx2y4k4S7rE1zPO0CYP+8kqbk9q+BI9pK3YppuBqrVs6i2P2nBCR6yGbSVZVKDdU5pBMq6JQaL9g==",
+      "version": "1.0.10",
+      "resolved": "https://npm.pkg.github.com/@trimble-oss/modus-stencil-razor-output-target/-/modus-stencil-razor-output-target-1.0.10.tgz",
       "license": "MIT",
       "dependencies": {
         "@trimble-oss/modus-icons": "^1.19.0"

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@storybook/web-components-vite": "^8.6.12",
     "@tailwindcss/typography": "^0.5.15",
     "@trimble-agentic-external-npm-local/agentic-platform-sdk-iframe-typescript": "^1.0.1-rc.3",
+    "@trimble-oss/modus-stencil-razor-output-target": "^1.0.3",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",

--- a/package.json
+++ b/package.json
@@ -230,7 +230,8 @@
         "integrations/react/stencil-generated/**",
         "integrations/angular/ng18/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/**",
         "integrations/angular/ng17/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/**",
-        "integrations/angular/ng19/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/**"
+        "integrations/angular/ng19/projects/trimble-oss/moduswebcomponents-angular/src/lib/stencil-generated/**",
+        "integrations/blazor/stencil-generated/**"
       ]
     },
     "stencil:watch": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@storybook/web-components-vite": "^8.6.12",
     "@tailwindcss/typography": "^0.5.15",
     "@trimble-agentic-external-npm-local/agentic-platform-sdk-iframe-typescript": "^1.0.1-rc.3",
-    "@trimble-oss/modus-stencil-razor-output-target": "^1.0.3",
+    "@trimble-oss/modus-stencil-razor-output-target": "^1.0.10",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -98,7 +98,8 @@ export const config: Config = {
       customElementsDir: 'components',
     }),
     blazorOutputTarget({
-      outDir: './integrations/blazor/stencil-generated/ModusWebComponents.Blazor',
+      outDir:
+        './integrations/blazor/stencil-generated/ModusWebComponents.Blazor',
       packageName: 'ModusWebComponents.Blazor',
       namespace: 'ModusWebComponents.Blazor',
     }),

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -8,6 +8,7 @@ import tailwind, {
 } from 'stencil-tailwind-plugin';
 import tailwindConfig from './tailwind.config';
 import { vueOutputTarget } from '@stencil/vue-output-target';
+import { blazorOutputTarget } from '@trimble-oss/modus-stencil-razor-output-target';
 
 const tailwindOpts = {
   // enableDebug: true,
@@ -95,6 +96,11 @@ export const config: Config = {
       componentCorePackage: '@trimble-oss/moduswebcomponents',
       proxiesFile: './integrations/vue/stencil-generated/components.ts',
       customElementsDir: 'components',
+    }),
+    blazorOutputTarget({
+      outDir: './integrations/blazor/stencil-generated/ModusWebComponents.Blazor',
+      packageName: 'ModusWebComponents.Blazor',
+      namespace: 'ModusWebComponents.Blazor',
     }),
   ],
   plugins: [


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

This branch adds a complete **Blazor / .NET MAUI integration** for Modus Web Components, covering:

#### 1. NuGet RCL (`ModusWebComponents.Blazor`)
- Generator driven by **`@trimble-oss/modus-stencil-razor-output-target@1.0.16`** (Wireit-integrated in `integrations/blazor/`)
- Generates `.razor` + `.razor.cs` partial classes for all 51 Modus WC components
- Multi-targets `net8.0;net9.0;net10.0`
- Version synced to root `package.json` (currently `1.4.0`)
- `ModusWcEventArgs` emitted by the generator — wraps event detail with a `Value: object?` property so BlazingStory Actions tab serialises correctly
- Doc comments stripped of HTML entity escaping (`&lt;slot&gt;` → `slot`) for clean C# XML docs

#### 2. BlazingStory web app (`integrations/blazor/blazing-story/`)
- Blazor WASM storybook using [BlazingStory](https://github.com/jsakamoto/blazingstory)
- Stories are **generated separately** via `npm run generate:blazor-stories` (runs `scripts/generate-blazor-stories.js`) — this is **not** part of `npx stencil build`
- The `Stories/` directories (`blazing-story/Stories/` and `maui-app/Stories/`) are **gitignored** — they must be regenerated locally after every stencil build or component change
- Correct script load order: Stencil ESM → `interop.js` → Blazor bootstrap
- Stories served from the RCL's `modus-wc.esm.js` bundle (not the loader)
- Actions tab wired up: `EventCallback` serialises event details correctly via `ModusWcEventArgs`

#### 3. Interop layer (`integrations/blazor/maui-app/wwwroot/js/interop.js`)
- Registers DOM event listeners for all Stencil custom events
- Extracts scalar values from native `InputEvent`/`change` targets (avoids serialising non-transferable DOM objects)
- Projects `Element` properties (e.g. button group click detail) to plain JSON
- Dispatches `componentaction` events for BlazingStory Actions panel

#### 4. MAUI app — Android & iOS (`integrations/blazor/maui-app/`)
- **Android:** localhost WebView bypass (`http://10.0.2.2:`) to work around BlazorWebView iframe restrictions; edge-to-edge mode; `BlazorScrollFix` touch handler; cleartext traffic allowed for dev
- **iOS:** `NSAllowsArbitraryLoads` for dev; safe-area inset CSS; status-bar padding
- `EmbedAssembliesIntoApk=true` for debug builds
- `MainApplication.cs` with proper Android bootstrap
- `MauiProgram.cs` configures Blazing.Mvvm with `BlazorHostingModelType.HybridMaui`

#### 5. MCP documentation (`mcp/`)
- `mcp/versions/base/docs/blazor.mdx` — comprehensive Blazor integration guide: correct script paths, `ModusWcEventArgs` event handling, MAUI-specific setup (Android/iOS), design tokens, troubleshooting
- `mcp/scripts/extract-blazor-docs.ts` — script that augments component-docs JSON with a `blazor` section (C# parameter names/types, events, slots, usage examples) parsed from the generated `.razor.cs` wrappers
- **`publish-mcp.yml` updated** to run `extract-blazor-docs.ts` immediately after `extract-docs.ts` — ensures the `versions/<X.Y.Z>/` delta dir generated at publish time includes Blazor sections for all components
- **`mcp/versions/base/` is NOT augmented with Blazor data** — `base/` represents the v1.0.6 baseline; Blazor data first appears in `versions/1.4.0/` when `publish-mcp.yml` is run post-merge

#### 6. Infrastructure / DX
- `.gitattributes` enforcing LF line endings for all source files (prevents CRLF diff noise from cross-platform builds)
- `maui-app/.gitignore` excludes `wwwroot/iframe.html` build artifact
- CI workflows updated: `actions/setup-dotnet@v5.2.0`, `GITHUB_AUTH_TOKEN` for GitHub registry access, Wireit output declarations for Blazor step
- `eslint` globals updated for `node` environment in new script files

---

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)
- [X] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [X] Documentation change

### :clipboard: Test Plan

- `GITHUB_AUTH_TOKEN=$(gh auth token) npm ci && npm run build:ci` regenerates all 51 component wrappers and emits `ModusWcEventArgs.cs`; `dotnet build` succeeds with 0 errors/warnings
- `npm run generate:blazor-stories` generates 51 stories into `blazing-story/Stories/` and `maui-app/Stories/` (gitignored — must be run after every stencil build)
- BlazingStory (`dotnet run` in `integrations/blazor/blazing-story/`, served at `localhost:5200`) renders all 51 components; Actions tab shows event detail values (not `{}`)
- Android emulator loads BlazingStory via `10.0.2.2:5200` WebView bypass
- iOS simulator loads via `localhost:5200`
- `dotnet pack -p:Version=1.4.0` produces correct `ModusWebComponents.Blazor.1.4.0.nupkg` with all static assets including `modus-wc-styles.css`

### :rocket: Post-merge steps (manual)

> These workflows are `workflow_dispatch` only — they must be triggered manually after merge:

1. **Publish Blazor NuGet**: run `publish-blazor.yml` with `version=1.4.0` → publishes `ModusWebComponents.Blazor.1.4.0.nupkg` to GitHub Packages
2. **Publish MCP**: run `publish-mcp.yml` with `version=1.4.0` → generates `mcp/versions/1.4.0/` component docs **with Blazor sections** (via the `extract-blazor-docs.ts` step added in this PR) and opens an auto-PR to commit that data

### :white_check_mark: Self Code Review Checklist

- [X] My code is clean and readable
- [X] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [X] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Part of Phase 1 of trimble-oss/modus-wc-2.0#1008
