### PR TITLE
[Feature] Table: Add checkbox disabled functionality

### DIFF
--- a/src/components/modus-wc-table/modus-wc-table.core.ts
+++ b/src/components/modus-wc-table/modus-wc-table.core.ts
@@ -5,6 +5,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   PaginationState,
+  Row,
   RowSelectionState,
   SortingState,
   Table as TanStackTable,
@@ -35,7 +36,7 @@ export function createModusTable<
   enableSorting?: boolean;
   manualSorting?: boolean;
   manualPagination?: boolean;
-  enableRowSelection?: boolean;
+  enableRowSelection?: boolean | ((row: Row<TData>) => boolean);
   rowSelection?: RowSelectionState;
   onRowSelectionChange?: (updater: Updater<RowSelectionState>) => void;
   getRowId?: (originalRow: TData, index: number, parent?: unknown) => string;

--- a/src/components/modus-wc-table/modus-wc-table.spec.tsx
+++ b/src/components/modus-wc-table/modus-wc-table.spec.tsx
@@ -3708,4 +3708,337 @@ describe('modus-wc-table', () => {
       expect(component['activeEditor']).toBeNull();
     });
   });
+
+  describe('isRowSelectable', () => {
+    const statusColumns: ITableColumn[] = [
+      { id: 'id', header: 'ID', accessor: 'id', width: '60px' },
+      { id: 'name', header: 'Name', accessor: 'name' },
+      { id: 'status', header: 'Status', accessor: 'status' },
+    ];
+
+    const statusData = [
+      { id: '1', name: 'John Doe', status: 'Active' },
+      { id: '2', name: 'Jane Smith', status: 'Locked' },
+      { id: '3', name: 'Bob Johnson', status: 'Active' },
+    ];
+
+    const isActiveRow = (row: Record<string, unknown>) =>
+      row.status !== 'Locked';
+
+    it('should return early from handleIsRowSelectableChange when table is not initialized', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="No table instance"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      expect(component['table']).toBeNull();
+      expect(() => component['handleIsRowSelectableChange']()).not.toThrow();
+    });
+
+    it('should return early from sanitizeRowSelection when table is not initialized', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Sanitize without table"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component['table'] = null;
+      component['internalRowSelection'] = { '1': true };
+
+      expect(() => component['sanitizeRowSelection']()).not.toThrow();
+      expect(component['internalRowSelection']).toEqual({ '1': true });
+    });
+
+    it('should build eligible selection from data before the table is initialized', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Pre-init selection"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+      component.isRowSelectable = isActiveRow;
+      component['table'] = null;
+
+      const selection = component['buildEligibleSelection']([
+        '1',
+        '2',
+        '3',
+        '99',
+      ]);
+
+      expect(selection).toEqual({ '1': true, '3': true });
+    });
+
+    it('should ignore unknown ids when building eligible selection from the table model', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Unknown id selection" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+      component.isRowSelectable = isActiveRow;
+
+      await page.waitForChanges();
+
+      const selection = component['buildEligibleSelection'](['1', '99']);
+
+      expect(selection).toEqual({ '1': true });
+    });
+
+    it('should filter selectedRowIds to eligible rows on first render', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Filtered init selection" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+      component.isRowSelectable = isActiveRow;
+      component.selectedRowIds = ['1', '2', '3'];
+
+      component.componentWillLoad();
+      await page.waitForChanges();
+
+      expect(component['internalRowSelection']).toEqual({
+        '1': true,
+        '3': true,
+      });
+    });
+
+    it('should filter selectedRowIds when the prop updates after initialization', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Filtered controlled selection" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+      component.isRowSelectable = isActiveRow;
+
+      await page.waitForChanges();
+
+      component.selectedRowIds = ['1', '2'];
+      await page.waitForChanges();
+
+      expect(component['internalRowSelection']).toEqual({ '1': true });
+    });
+
+    it('should disable checkbox and block row-click selection for ineligible rows', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Partial row selection" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+      component.isRowSelectable = isActiveRow;
+
+      await page.waitForChanges();
+
+      const rows = page.root!.querySelectorAll('tbody tr');
+      const lockedCheckbox = rows[1].querySelector('modus-wc-checkbox');
+      const activeCheckbox = rows[0].querySelector('modus-wc-checkbox');
+
+      expect(lockedCheckbox?.getAttribute('disabled')).not.toBeNull();
+      expect(activeCheckbox?.getAttribute('disabled')).toBeNull();
+      expect(rows[1].classList.contains('selectable')).toBe(false);
+      expect(rows[0].classList.contains('selectable')).toBe(true);
+
+      (rows[1] as HTMLTableRowElement).click();
+      await page.waitForChanges();
+      expect(component['internalRowSelection']).toEqual({});
+
+      (rows[0] as HTMLTableRowElement).click();
+      await page.waitForChanges();
+      expect(component['internalRowSelection']).toEqual({ '1': true });
+    });
+
+    it('should emit rowClick for ineligible rows without changing selection', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Row click on locked row" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+      component.isRowSelectable = isActiveRow;
+
+      await page.waitForChanges();
+
+      const rowClickSpy = jest.spyOn(component.rowClick, 'emit');
+      const lockedRow = component['table']!.getRowModel().rows[1];
+
+      component['handleRowClick'](lockedRow, 1);
+
+      expect(rowClickSpy).toHaveBeenCalledWith({
+        row: statusData[1],
+        index: 1,
+      });
+      expect(component['internalRowSelection']).toEqual({});
+    });
+
+    it('should sanitize selection when data makes a selected row ineligible', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Sanitize on data change" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = [...statusData];
+      component.isRowSelectable = isActiveRow;
+
+      await page.waitForChanges();
+
+      component.selectedRowIds = ['1'];
+      await page.waitForChanges();
+      expect(component['internalRowSelection']).toEqual({ '1': true });
+
+      const rowSelectionChangeSpy = jest.spyOn(
+        component.rowSelectionChange,
+        'emit'
+      );
+      const updatedData = [
+        { id: '1', name: 'John Doe', status: 'Locked' },
+        ...statusData.slice(1),
+      ];
+
+      component.handleDataChange(updatedData);
+      await page.waitForChanges();
+
+      expect(component['internalRowSelection']).toEqual({});
+      expect(rowSelectionChangeSpy).toHaveBeenCalledWith({
+        selectedRows: [],
+        selectedRowIds: [],
+      });
+    });
+
+    it('should sanitize selection when isRowSelectable becomes stricter', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Sanitize on predicate change" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+
+      await page.waitForChanges();
+
+      component.selectedRowIds = ['1', '3'];
+      await page.waitForChanges();
+
+      const setRowSelectionSpy = jest.spyOn(
+        component['table']!,
+        'setRowSelection'
+      );
+      component.isRowSelectable = () => false;
+      component['handleIsRowSelectableChange']();
+      await page.waitForChanges();
+
+      expect(setRowSelectionSpy).toHaveBeenCalledWith({});
+      expect(component['internalRowSelection']).toEqual({});
+    });
+
+    it('should remove orphaned selection when a row is deleted from data', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Sanitize deleted row" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = [...statusData];
+
+      await page.waitForChanges();
+
+      component.selectedRowIds = ['3'];
+      await page.waitForChanges();
+
+      component.handleDataChange(statusData.slice(0, 2));
+      await page.waitForChanges();
+
+      expect(component['internalRowSelection']).toEqual({});
+    });
+
+    it('should update TanStack enableRowSelection when isRowSelectable changes', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Enable row selection update" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+
+      await page.waitForChanges();
+
+      const setOptionsSpy = jest.spyOn(component['table']!, 'setOptions');
+      component.isRowSelectable = isActiveRow;
+      component['handleIsRowSelectableChange']();
+
+      expect(setOptionsSpy).toHaveBeenCalled();
+      const updaterFn = setOptionsSpy.mock.calls[0][0] as unknown as (prev: {
+        enableRowSelection?: unknown;
+      }) => { enableRowSelection?: unknown };
+      const nextOptions = updaterFn({
+        enableRowSelection: false,
+      });
+      const enableRowSelection = nextOptions.enableRowSelection as (
+        row: Row<Record<string, unknown>>
+      ) => boolean;
+
+      const lockedRow = component['table']!.getRowModel().rows[1];
+      const activeRow = component['table']!.getRowModel().rows[0];
+
+      expect(enableRowSelection(lockedRow)).toBe(false);
+      expect(enableRowSelection(activeRow)).toBe(true);
+    });
+
+    it('should skip ineligible rows when select-all is toggled', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Select all respects eligibility" selectable="multi"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      component.columns = statusColumns;
+      component.data = statusData;
+      component.isRowSelectable = isActiveRow;
+
+      await page.waitForChanges();
+
+      component['table']!.toggleAllRowsSelected(true);
+      await page.waitForChanges();
+
+      expect(component['internalRowSelection']).toEqual({
+        '1': true,
+        '3': true,
+      });
+    });
+
+    it('should invoke isRowSelectable via checkIsRowSelectable', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTable],
+        html: `<modus-wc-table aria-label="Predicate invocation"></modus-wc-table>`,
+      });
+
+      const component = page.rootInstance as ModusWcTable;
+      const predicate = jest.fn(isActiveRow);
+      component.isRowSelectable = predicate;
+
+      expect(component['checkIsRowSelectable'](statusData[0])).toBe(true);
+      expect(component['checkIsRowSelectable'](statusData[1])).toBe(false);
+      expect(predicate).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/components/modus-wc-table/modus-wc-table.stories.ts
+++ b/src/components/modus-wc-table/modus-wc-table.stories.ts
@@ -11,6 +11,7 @@ import { Density } from '../types';
 interface TableStoryArgs {
   'custom-class'?: string;
   'current-page'?: number;
+  'is-row-selectable'?: (row: Record<string, unknown>) => boolean;
   'page-size-options'?: number[];
   'selected-row-ids'?: string[];
   'show-page-size-selector'?: boolean;
@@ -162,6 +163,14 @@ const meta: Meta<TableStoryArgs> = {
         'Enable cell editing. Either a boolean (all rows) or a predicate per row.',
       defaultValue: false,
     },
+    'is-row-selectable': {
+      control: false,
+      description:
+        'Per-row predicate function controlling row selection eligibility.',
+      table: {
+        type: { summary: '(row: Record<string, unknown>) => boolean' },
+      },
+    },
   },
 };
 
@@ -211,6 +220,76 @@ const createDemoData = (count = 5): Record<string, any>[] => {
   }
   return data;
 };
+
+const createStatusColumns = (): ITableColumn[] => [
+  {
+    id: 'id',
+    header: 'ID',
+    accessor: 'id',
+    width: '60px',
+  },
+  {
+    id: 'name',
+    header: 'Name',
+    accessor: 'name',
+    width: '140px',
+  },
+  {
+    id: 'email',
+    header: 'Email',
+    accessor: 'email',
+  },
+  {
+    id: 'status',
+    header: 'Status',
+    accessor: 'status',
+    width: '120px',
+    cellRenderer: (value) => {
+      const span = document.createElement('span');
+      const label = typeof value === 'string' ? value : '';
+      span.textContent = label;
+      span.style.fontWeight = label === 'Locked' ? '600' : '400';
+      span.style.color =
+        label === 'Locked'
+          ? 'var(--modus-wc-color-danger, #da212c)'
+          : 'var(--modus-wc-color-base-content, inherit)';
+      return span;
+    },
+  },
+];
+
+const createStatusSelectionData = (): Record<string, unknown>[] => [
+  {
+    id: '1',
+    name: 'John Doe',
+    email: 'john.doe@example.com',
+    status: 'Active',
+  },
+  {
+    id: '2',
+    name: 'Jane Smith',
+    email: 'jane.smith@example.com',
+    status: 'Locked',
+  },
+  {
+    id: '3',
+    name: 'Bob Johnson',
+    email: 'bob.johnson@example.com',
+    status: 'Active',
+  },
+  {
+    id: '4',
+    name: 'Carol White',
+    email: 'carol.white@example.com',
+    status: 'Locked',
+  },
+  {
+    id: '5',
+    name: 'David Lee',
+    email: 'david.lee@example.com',
+    status: 'Active',
+  },
+];
 
 export const Default: Story = {
   render: (args) => {
@@ -602,6 +681,115 @@ export const CheckBoxRowSelection: Story = {
   },
   args: {
     density: 'comfortable',
+    selectable: 'multi',
+  },
+};
+
+export const PartialRowSelection: Story = {
+  render: (args) => {
+    const columns = createStatusColumns();
+    const data = createStatusSelectionData();
+    const statusOptions = [
+      { label: 'Active', value: 'Active' },
+      { label: 'Locked', value: 'Locked' },
+    ];
+
+    return html`
+      <style>
+        .partial-select {
+          margin-bottom: var(--modus-wc-size-xl);
+          max-width: fit-content;
+        }
+      </style>
+      <modus-wc-select
+        custom-class="partial-select"
+        id="partial-row-status-select"
+        label="Non-selectable rows"
+        .options=${statusOptions}
+        value="Locked"
+      ></modus-wc-select>
+      <modus-wc-table
+        id="partial-row-selection-table"
+        .columns=${columns}
+        .data=${data}
+        .density=${args.density}
+        .hover=${args.hover ?? true}
+        .sortable=${args.sortable}
+        .paginated=${args.paginated}
+        .showPageSizeSelector=${args['show-page-size-selector']}
+        .customClass=${args['custom-class']}
+        .selectable=${args.selectable}
+        .zebra=${args.zebra}
+        .currentPage=${args['current-page']}
+        .pageSizeOptions=${args['page-size-options']}
+        .selectedRowIds=${args['selected-row-ids']}
+        caption="Team members with partial row selection"
+        @rowClick=${action('rowClick')}
+        @rowSelectionChange=${action('rowSelectionChange')}
+      ></modus-wc-table>
+      <script>
+        (() => {
+          const select = document.getElementById('partial-row-status-select');
+          const table = document.getElementById('partial-row-selection-table');
+          if (!select || !table) {
+            return;
+          }
+
+          const applyIsRowSelectable = () => {
+            const status = select.value || 'Locked';
+            table.isRowSelectable = (row) => row.status !== status;
+          };
+
+          select.addEventListener('inputChange', applyIsRowSelectable);
+          applyIsRowSelectable();
+        })();
+      </script>
+    `;
+  },
+  parameters: {
+    controls: {
+      include: [
+        'selectable',
+        'selected-row-ids',
+        'density',
+        'hover',
+        'sortable',
+        'zebra',
+      ],
+    },
+    docs: {
+      description: {
+        story: `
+Use \`isRowSelectable\` to control which rows can be selected when \`selectable\` is \`single\` or \`multi\`.
+
+**Type:** \`(row: Record<string, unknown>) => boolean\`
+
+**Default:** All rows are selectable when the prop is omitted.
+
+**Usage:**
+
+\`\`\`js
+table.isRowSelectable = (row) => row.status !== 'Locked';
+\`\`\`
+
+Return \`true\` when the row may be selected; return \`false\` to disable its selection checkbox. Ineligible rows stay interactive—cell clicks and \`rowClick\` still work, but row clicks do not toggle selection. Select-all and \`selectedRowIds\` ignore ineligible rows automatically.
+
+Storybook Controls cannot edit function props, so this story uses a **Non-selectable status** dropdown to pick which status is excluded (\`Active\` or \`Locked\`). That maps to:
+
+\`\`\`js
+isRowSelectable = (row) => row.status !== selectedStatus;
+\`\`\`
+
+Use Controls for **selectable** mode and **selected-row-ids**.
+        `,
+      },
+    },
+  },
+  args: {
+    density: 'comfortable',
+    hover: true,
+    sortable: true,
+    paginated: false,
     selectable: 'multi',
   },
 };

--- a/src/components/modus-wc-table/modus-wc-table.tsx
+++ b/src/components/modus-wc-table/modus-wc-table.tsx
@@ -962,6 +962,7 @@ export class ModusWcTable {
                 {displayData.length > 0 ? (
                   rows.map((rowObj, index) => {
                     const row = rowObj.original;
+                    const isRowSelectable = this.checkIsRowSelectable(row);
 
                     return (
                       <tr
@@ -971,8 +972,7 @@ export class ModusWcTable {
                             !!this.internalRowSelection[String(rowObj.id)] ||
                             rowObj.getIsSelected?.(),
                           selectable:
-                            this.selectable !== 'none' &&
-                            this.checkIsRowSelectable(row),
+                            this.selectable !== 'none' && isRowSelectable,
                           editable: this.isRowEditable(row),
                         }}
                         onClick={() => this.handleRowClick(rowObj, index)}
@@ -986,7 +986,7 @@ export class ModusWcTable {
                               aria-label="Select row"
                               size="sm"
                               value={rowObj.getIsSelected?.() ?? false}
-                              disabled={!this.checkIsRowSelectable(row)}
+                              disabled={!isRowSelectable}
                             ></modus-wc-checkbox>
                           </td>
                         )}

--- a/src/components/modus-wc-table/modus-wc-table.tsx
+++ b/src/components/modus-wc-table/modus-wc-table.tsx
@@ -128,6 +128,9 @@ export class ModusWcTable {
   /** Row selection mode: 'none' for no selection, 'single' for single row, 'multi' for multiple rows. */
   @Prop() selectable?: 'none' | 'single' | 'multi' = 'none';
 
+  /** Per-row predicate function controlling row selection eligibility. */
+  @Prop() isRowSelectable?: (row: Record<string, unknown>) => boolean;
+
   /** Array of selected row IDs. Used for controlled selection state. */
   @Prop() selectedRowIds?: string[];
 
@@ -202,10 +205,22 @@ export class ModusWcTable {
   handleDataChange(newData: Record<string, unknown>[]) {
     if (this.table) {
       this.table.setOptions((prev) => ({ ...prev, data: [...newData] }));
+      this.sanitizeRowSelection();
     } else if (newData && this.columns) {
       // If table doesn't exist yet but we have both data and columns, initialize
       this.initializeTable();
     }
+  }
+
+  @Watch('isRowSelectable')
+  handleIsRowSelectableChange() {
+    if (!this.table) return;
+
+    this.table.setOptions((prev) => ({
+      ...prev,
+      enableRowSelection: this.getEnableRowSelection(),
+    }));
+    this.sanitizeRowSelection();
   }
 
   @Watch('columns')
@@ -248,8 +263,7 @@ export class ModusWcTable {
   handleSelectedRowIdsChange(newIds: string[] | undefined) {
     if (!this.table) return;
     if (Array.isArray(newIds)) {
-      const selection: RowSelectionState = {};
-      newIds.forEach((id) => (selection[id] = true));
+      const selection = this.buildEligibleSelection(newIds);
       this.internalRowSelection = selection;
       this.table.setRowSelection(selection);
     }
@@ -269,11 +283,9 @@ export class ModusWcTable {
       pageIndex: this.currentPage - 1,
       pageSize: this.pageSizeOptions[0],
     };
-    // Initialize row selection from selectedRowIds prop
-    const rowSelection: RowSelectionState = Object.fromEntries(
-      this.selectedRowIds?.map((id) => [id, true]) ?? []
-    );
-    if (rowSelection && Object.keys(rowSelection).length > 0) {
+    // Initialize row selection from selectedRowIds prop (eligible rows only)
+    const rowSelection = this.buildEligibleSelection(this.selectedRowIds);
+    if (Object.keys(rowSelection).length > 0) {
       this.internalRowSelection = rowSelection;
     }
     this.inheritedAttributes = inheritAriaAttributes(this.el);
@@ -391,7 +403,7 @@ export class ModusWcTable {
       data: dataForTable, // Use the copied data
       columns: this.tanStackColumns,
       rowSelection: this.internalRowSelection,
-      enableRowSelection: this.selectable !== 'none',
+      enableRowSelection: this.getEnableRowSelection(),
       pagination: this.internalPagination,
       enableSorting: this.sortable,
       manualPagination: !this.paginated,
@@ -399,10 +411,7 @@ export class ModusWcTable {
       onSortingChange: this.handleSortingChange,
       onPaginationChange: this.handlePaginationChange,
       onRowSelectionChange: this.handleRowSelectionChange,
-      getRowId: (orig: Record<string, unknown>, idx) =>
-        orig && orig['id'] !== undefined && orig['id'] !== null
-          ? String(orig['id'] as string | number)
-          : String(idx),
+      getRowId: (orig, idx) => this.getRowIdForData(orig, idx),
     });
 
     // If we already have a sorting state, apply it immediately
@@ -430,9 +439,12 @@ export class ModusWcTable {
     rowObj: Row<Record<string, unknown>>,
     index: number
   ) => {
-    if (this.selectable !== 'none' && this.table) {
+    const isSelectable = this.checkIsRowSelectable(rowObj.original);
+
+    if (this.selectable !== 'none' && this.table && isSelectable) {
       this.toggleRowSelection(rowObj);
     }
+
     this.rowClick.emit({ row: rowObj.original, index });
   };
 
@@ -591,6 +603,85 @@ export class ModusWcTable {
   private isRowEditable(row: Record<string, unknown>): boolean {
     if (typeof this.editable === 'function') return this.editable(row);
     return Boolean(this.editable);
+  }
+
+  private checkIsRowSelectable(row: Record<string, unknown>): boolean {
+    if (typeof this.isRowSelectable === 'function') {
+      return this.isRowSelectable(row);
+    }
+    return true;
+  }
+
+  private getRowIdForData(orig: Record<string, unknown>, idx: number): string {
+    return orig && orig['id'] !== undefined && orig['id'] !== null
+      ? String(orig['id'] as string | number)
+      : String(idx);
+  }
+
+  private getEnableRowSelection():
+    | boolean
+    | ((row: Row<Record<string, unknown>>) => boolean) {
+    return this.selectable !== 'none'
+      ? (row) => this.checkIsRowSelectable(row.original)
+      : false;
+  }
+
+  private buildEligibleSelection(ids?: string[]): RowSelectionState {
+    if (!ids?.length) return {};
+
+    const selection: RowSelectionState = {};
+
+    ids.forEach((id) => {
+      if (this.table) {
+        try {
+          const rowInstance = this.table.getRow(id);
+          if (rowInstance && this.checkIsRowSelectable(rowInstance.original)) {
+            selection[id] = true;
+          }
+        } catch {
+          // Row id is not in the current table model — skip.
+        }
+        return;
+      }
+
+      if (this.data) {
+        const rowIndex = this.data.findIndex(
+          (row, index) => this.getRowIdForData(row, index) === id
+        );
+        if (rowIndex >= 0 && this.checkIsRowSelectable(this.data[rowIndex])) {
+          selection[id] = true;
+        }
+      }
+    });
+
+    return selection;
+  }
+
+  private sanitizeRowSelection(): void {
+    if (!this.table) return;
+
+    const currentSelections = { ...this.internalRowSelection };
+    let stateChanged = false;
+
+    Object.keys(currentSelections).forEach((id) => {
+      let rowInstance: Row<Record<string, unknown>> | undefined;
+      try {
+        rowInstance = this.table!.getRow(id);
+      } catch {
+        delete currentSelections[id];
+        stateChanged = true;
+        return;
+      }
+
+      if (!rowInstance || !this.checkIsRowSelectable(rowInstance.original)) {
+        delete currentSelections[id];
+        stateChanged = true;
+      }
+    });
+
+    if (stateChanged) {
+      this.table.setRowSelection(currentSelections);
+    }
   }
 
   /**
@@ -879,7 +970,9 @@ export class ModusWcTable {
                           selected:
                             !!this.internalRowSelection[String(rowObj.id)] ||
                             rowObj.getIsSelected?.(),
-                          selectable: this.selectable !== 'none',
+                          selectable:
+                            this.selectable !== 'none' &&
+                            this.checkIsRowSelectable(row),
                           editable: this.isRowEditable(row),
                         }}
                         onClick={() => this.handleRowClick(rowObj, index)}
@@ -893,6 +986,7 @@ export class ModusWcTable {
                               aria-label="Select row"
                               size="sm"
                               value={rowObj.getIsSelected?.() ?? false}
+                              disabled={!this.checkIsRowSelectable(row)}
                             ></modus-wc-checkbox>
                           </td>
                         )}


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

[Feature] Table: Add checkbox disabled functionality

- Added isRowSelectable prop to modus-wc-table for per-row selection eligibility via an optional (row) => boolean predicate.
- Ineligible rows get disabled checkboxes; row clicks do not select them, but rowClick still fires and other cells stay interactive.
- Integrated with TanStack selection so select-all, selectedRowIds, and predicate/data changes respect and sanitize eligibility.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #697 
