### PR TITLE
Fix: Resolve policy compliance violations for issue #1115

### DIFF
--- a/integrations/angular/ng17/package-lock.json
+++ b/integrations/angular/ng17/package-lock.json
@@ -8306,16 +8306,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/karma/node_modules/tmp": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/karma/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -9813,16 +9803,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/p-limit": {
@@ -12205,16 +12185,13 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/integrations/angular/ng17/package.json
+++ b/integrations/angular/ng17/package.json
@@ -37,6 +37,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "overrides": {
+    "tmp": "^0.2.6"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/integrations/angular/ng18/package-lock.json
+++ b/integrations/angular/ng18/package-lock.json
@@ -8585,16 +8585,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/karma/node_modules/tmp": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
-      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.14"
-      }
-    },
     "node_modules/karma/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -10449,15 +10439,6 @@
       "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.2.tgz",
       "integrity": "sha512-JTo+4+4Fw7FreyAvlSLjb1BBVaxEQAacmjD3jjuyPZclpbEghTvQZbXBb2qPd2LeIMxiHwXBZUcpmG2Gl/mDEA==",
       "dev": true
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/p-limit": {
       "version": "4.0.0",
@@ -12565,15 +12546,13 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/integrations/angular/ng18/package.json
+++ b/integrations/angular/ng18/package.json
@@ -37,6 +37,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "overrides": {
+    "tmp": "^0.2.6"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/integrations/angular/ng19/package.json
+++ b/integrations/angular/ng19/package.json
@@ -37,6 +37,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "overrides": {
+    "tmp": "^0.2.6"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/integrations/angular/test-ng19/package-lock.json
+++ b/integrations/angular/test-ng19/package-lock.json
@@ -33,11 +33,14 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
         "typescript": "~5.7.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "../../../dist": {
       "name": "@trimble-oss/moduswebcomponents",
-      "version": "1.3.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
@@ -47,9 +50,10 @@
       "devDependencies": {
         "@eslint/js": "^9.26.0",
         "@stencil/angular-output-target": "^0.10.2",
-        "@stencil/core": "4.31.0",
-        "@stencil/react-output-target": "^0.7.4",
+        "@stencil/core": "^4.35.3",
+        "@stencil/react-output-target": "^1.2.0",
         "@stencil/sass": "^3.2.3",
+        "@stencil/ssr": "^0.3.1",
         "@stencil/store": "^2.2.2",
         "@stencil/vue-output-target": "^0.13.1",
         "@storybook/addon-a11y": "^8.6.12",
@@ -76,13 +80,14 @@
         "globals": "^16.2.0",
         "jest": "^29.7.0",
         "jest-cli": "^29.7.0",
+        "lit": "^3.3.2",
         "marked": "^15.0.11",
         "prettier": "3.8.1",
         "puppeteer": "^23.5.3",
         "stencil-tailwind-plugin": "^1.8.0",
         "stylelint": "16.26.1",
         "stylelint-config-standard-scss": "16.0.0",
-        "stylelint-order": "6.0.4",
+        "stylelint-order": "8.1.1",
         "tailwindcss": "^3.4.14",
         "ts-loader": "^9.5.7",
         "typescript": "^5.6.2",
@@ -13618,9 +13623,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/integrations/angular/test-ng19/package.json
+++ b/integrations/angular/test-ng19/package.json
@@ -40,7 +40,8 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.4",
     "fast-uri": "^3.1.2",
     "serialize-javascript": "^7.0.3",
-    "tar": "^7.5.11"
+    "tar": "^7.5.11",
+    "tmp": "^0.2.6"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Addresses the Dependabot high-severity `tmp` vulnerability (GHSA-ph9p-34f9-6g65 / CVE-2026-44705) flagged in [issue #1115](https://github.com/trimble-oss/modus-wc-2.0/issues/1115).

- Added npm `overrides` forcing `tmp@^0.2.6` in all four Angular integration workspaces:
  - `integrations/angular/ng17`
  - `integrations/angular/ng18`
  - `integrations/angular/ng19`
  - `integrations/angular/test-ng19`
- Regenerated `package-lock.json` files so `tmp` resolves to `0.2.7` (patched version)

**Related (separate branch):** The secret scanning alert from issue #1115 was addressed by rewriting git history on `release-notes-update` to remove the exposed Google Chat webhook URL from commit `14b783c47` and force-pushing the branch.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

- Ran `npm install` in each affected Angular workspace and verified lockfiles resolve `tmp` to `>=0.2.6` (`0.2.7`).
- Confirmed no lockfile entries remain for vulnerable `tmp` versions (`0.0.33`, `0.2.5`).

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #1115

Made with [Cursor](https://cursor.com)