### PR TITLE
fix: Allow test n8n notify workflow to read draft releases

### DIFF
--- a/.github/scripts/notify-n8n-release.sh
+++ b/.github/scripts/notify-n8n-release.sh
@@ -55,11 +55,18 @@ find_release() {
 release="$(find_release "$VERSION_HINT")"
 
 if [ "$release" = "null" ] || [ -z "$release" ]; then
+  draft_count="$(gh api "repos/${REPO}/releases" --jq '[.[] | select(.draft == true)] | length' 2>/dev/null || echo 0)"
   if [ -n "$VERSION_HINT" ]; then
-    echo "No GitHub release found for ${TAG_PREFIX}${VERSION_HINT}, skipping n8n notification."
+    echo "No GitHub release found for ${TAG_PREFIX}${VERSION_HINT}." >&2
   else
-    echo "No GitHub draft release found, skipping n8n notification."
+    echo "No GitHub draft release found." >&2
   fi
+  echo "Visible draft releases from this token: ${draft_count}." >&2
+  echo "Ensure the workflow has contents: write (drafts are hidden from contents: read)." >&2
+  if [ "$EVENT" = "test" ]; then
+    exit 1
+  fi
+  echo "Skipping n8n notification."
   exit 0
 fi
 
@@ -82,7 +89,11 @@ if [ -z "$NAME" ] || [ "$NAME" = "null" ]; then
 fi
 
 if [ -z "$body" ]; then
-  echo "Release notes body is empty for ${TAG}, skipping n8n notification."
+  echo "Release notes body is empty for ${TAG}." >&2
+  if [ "$EVENT" = "test" ]; then
+    exit 1
+  fi
+  echo "Skipping n8n notification."
   exit 0
 fi
 

--- a/.github/workflows/test-n8n-notify.yml
+++ b/.github/workflows/test-n8n-notify.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Require n8n secrets
         env:

--- a/.github/workflows/test-n8n-notify.yml
+++ b/.github/workflows/test-n8n-notify.yml
@@ -13,7 +13,8 @@ on:
         type: string
 
 permissions:
-  contents: read
+  # Draft releases are not visible to GITHUB_TOKEN with contents: read only.
+  contents: write
 
 jobs:
   test-notify-n8n:


### PR DESCRIPTION
## Summary
- Grant `contents: write` on **Test n8n Release Notify** so `GITHUB_TOKEN` can read draft releases via the GitHub API (drafts are hidden with `contents: read` only).
- Fail the test workflow when no draft/body is found instead of exiting successfully without calling n8n.

## Context
Manual **Test n8n Release Notify** runs were green but logged `No GitHub draft release found, skipping n8n notification` — n8n and Google Chat never received a payload even though drafts exist on the Releases page.

## Test plan
- [ ] Merge is **not** required — run **Actions → Test n8n Release Notify** from branch `fix-test-n8n-notify-draft-access`
- [ ] Leave version empty or pass `1.6.1`
- [ ] Confirm log shows `Notified n8n for moduswebcomponents-...`
- [ ] Confirm n8n execution and Google Chat review card appear


Made with [Cursor](https://cursor.com)