### PR TITLE
fix(mcp): skip Blazor doc extraction when stencil output is missing

### DIFF
--- a/mcp/scripts/extract-blazor-docs.ts
+++ b/mcp/scripts/extract-blazor-docs.ts
@@ -314,8 +314,10 @@ async function main() {
   const { blazorDir, docsDir } = parseArgs();
 
   if (!existsSync(blazorDir)) {
-    console.error(`Blazor components directory not found: ${blazorDir}`);
-    process.exit(1);
+    console.warn(
+      `Blazor components directory not found: ${blazorDir} — skipping Blazor augmentation.`,
+    );
+    return;
   }
   if (!existsSync(docsDir)) {
     console.error(`Docs directory not found: ${docsDir}`);


### PR DESCRIPTION
## Summary
- Make `extract-blazor-docs.ts` warn and return when the Blazor stencil-generated directory is missing in CI
- Unblocks the MCP publish workflow, which previously failed with exit code 1

## Test plan
- [ ] Merge this PR
- [ ] Run `Publish & Release - MCP` for versions 1.7.0 and 1.8.0

Made with [Cursor](https://cursor.com)