### PR TITLE
Updating release actions

### DIFF
--- a/.github/workflows/azure-static-web-apps-gentle-mushroom-083c46a10.yml
+++ b/.github/workflows/azure-static-web-apps-gentle-mushroom-083c46a10.yml
@@ -1,10 +1,8 @@
 name: Azure Static Web Apps CI/CD
 
 on:
-  release:
-    types:
-      - published
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -7,6 +7,12 @@ on:
         description: 'Version to publish'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -51,7 +57,7 @@ jobs:
         id: check-version
         working-directory: .
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ inputs.version || github.event.inputs.version }}"
           BASE_VERSION="1.0.6"
 
           # Guard: base version must always live in mcp/versions/base only.
@@ -74,7 +80,7 @@ jobs:
         if: steps.check-version.outputs.generate == 'true'
         working-directory: .
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ inputs.version || github.event.inputs.version }}"
           TMPDIR=$(mktemp -d)
 
           # Extract full docs to temp dir
@@ -134,7 +140,7 @@ jobs:
 
       - name: Update package.json version
         run: |
-          jq --arg version "${{ github.event.inputs.version }}" \
+          jq --arg version "${{ inputs.version || github.event.inputs.version }}" \
           '.version = $version' package.json > package.json.tmp && \
           mv package.json.tmp package.json
 
@@ -147,7 +153,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: mcp-distribution-v${{ github.event.inputs.version }}
+          name: mcp-distribution-v${{ inputs.version || github.event.inputs.version }}
           path: 'mcp/*.tgz'
 
       - name: Clean up tgz files
@@ -171,7 +177,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${{ github.event.inputs.version }}"
+          VERSION="${{ inputs.version || github.event.inputs.version }}"
           BRANCH="chore/mcp-docs-v${VERSION}"
           DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
 
@@ -205,7 +211,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: mcp-distribution-v${{ github.event.inputs.version }}
+          name: mcp-distribution-v${{ inputs.version || github.event.inputs.version }}
           path: .
 
       - name: Find the release asset
@@ -219,7 +225,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: moduswebcomponents-mcp-${{ github.event.inputs.version }}
-          name: Modus Web Components MCP ${{ github.event.inputs.version }}
+          tag_name: moduswebcomponents-mcp-${{ inputs.version || github.event.inputs.version }}
+          name: Modus Web Components MCP ${{ inputs.version || github.event.inputs.version }}
           files: |
             **/package-mcp.tgz

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,12 @@
 # It will update the package.json version, build the packages, publish them to the Artifactory NPM registry, as well as create a GitHub release.
 # The packages consist of:
 # - The Web Components package
+# - The MCP package (published first after build, before framework packages)
 # - The React package
 # - The Angular package
 # - The Vue package
+# - The Blazor package
+# - Storybook deploy to Azure (after GitHub release, before n8n notify)
 # This is triggered by a manual run with a specified version number.
 
 name: Publish & Release
@@ -136,8 +139,15 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-  trigger-angular-publish:
+  publish-mcp:
     needs: build-and-publish-wc
+    uses: ./.github/workflows/publish-mcp.yml
+    with:
+      version: ${{ github.event.inputs.version }}
+    secrets: inherit
+
+  trigger-angular-publish:
+    needs: publish-mcp
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Angular Publish Workflow
@@ -147,7 +157,7 @@ jobs:
           inputs: '{"version": "${{ github.event.inputs.version }}"}'
 
   trigger-react-publish:
-    needs: build-and-publish-wc
+    needs: publish-mcp
     runs-on: ubuntu-latest
     steps:
       - name: Trigger React Publish Workflow
@@ -157,7 +167,7 @@ jobs:
           inputs: '{"version": "${{ github.event.inputs.version }}"}'
 
   trigger-vue-publish:
-    needs: build-and-publish-wc
+    needs: publish-mcp
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Vue Publish Workflow
@@ -166,18 +176,8 @@ jobs:
           workflow: publish-vue.yml
           inputs: '{"version": "${{ github.event.inputs.version }}"}'
 
-  trigger-mcp-publish:
-    needs: build-and-publish-wc
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger MCP Publish Workflow
-        uses: benc-uk/workflow-dispatch@v1.3
-        with:
-          workflow: publish-mcp.yml
-          inputs: '{"version": "${{ github.event.inputs.version }}"}'
-
   trigger-blazor-publish:
-    needs: build-and-publish-wc
+    needs: publish-mcp
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Blazor Publish Workflow
@@ -236,8 +236,13 @@ jobs:
           files: |
             package.tgz
 
-  notify-n8n:
+  deploy-storybook:
     needs: release-wc
+    uses: ./.github/workflows/azure-static-web-apps-gentle-mushroom-083c46a10.yml
+    secrets: inherit
+
+  notify-n8n:
+    needs: deploy-storybook
     runs-on: ubuntu-latest
     if: github.repository == 'trimble-oss/modus-wc-2.0'
     steps:


### PR DESCRIPTION
## Summary
- Publish MCP synchronously first after WC build; framework releases wait on MCP success
- Deploy Storybook to Azure after GitHub release, before n8n notify
- Add workflow_call to MCP and Azure Storybook workflows

## Test plan
- [ ] Merge PR
- [ ] Run Publish & Release workflow on next release

Made with [Cursor](https://cursor.com)