### PR TITLE
fix: Restore PR preview URL comments for Storybook and Blazor workflows

### DIFF
--- a/.github/workflows/preview-blazor-story.yml
+++ b/.github/workflows/preview-blazor-story.yml
@@ -106,10 +106,37 @@ jobs:
           BRANCH="${{ github.event.inputs.branch || 'main' }}"
           echo "Deployed to: https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/${BRANCH}/blazor/"
 
-      - name: Print PR preview URL
+      - name: Post Blazor preview URL comment
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.preview-deploy.outcome == 'success'
-        run: |
-          echo "PR preview: https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/pr-preview/pr-${{ github.event.number }}/blazor/"
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-preview/pr-${context.issue.number}/blazor/`;
+            const marker = '<!-- blazor-preview-comment -->';
+            const body = `${marker}\n## :rocket: Blazor Story Preview\n\nPreview is available at: ${previewUrl}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
       - name: Print failure message
         if: failure()

--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -72,10 +72,37 @@ jobs:
           target-folder: ${{ github.event.inputs.branch || 'main' }}
           clean-exclude: blazor
 
-      - name: Print preview URL
+      - name: Post preview URL comment
         if: github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && steps.preview-deploy.outcome == 'success'
-        run: |
-          echo "Storybook preview: https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#*/}/pr-preview/pr-${{ github.event.number }}/"
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const previewUrl = `https://${context.repo.owner}.github.io/${context.repo.repo}/pr-preview/pr-${context.issue.number}/`;
+            const marker = '<!-- storybook-preview-comment -->';
+            const body = `${marker}\n## :rocket: Storybook Preview\n\nPreview is available at: ${previewUrl}`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
       - name: Print deployment URL
         if: (github.event_name == 'workflow_dispatch' || github.event_name == 'push') && steps.deploy.outcome == 'success'


### PR DESCRIPTION
## Summary

PR preview URL comments stopped being posted on all open PRs after #1151, because the `rossjrw/pr-preview-action` (which auto-posted PR comments) was replaced with `JamesIves/github-pages-deploy-action` (which only deploys files).

## Changes

- **`preview-storybook.yml`**: Replaced the plain `echo` step with an `actions/github-script` step that posts (or updates) a PR comment with the Storybook preview URL after a successful deploy.
- **`preview-blazor-story.yml`**: Same fix for the Blazor preview URL comment.

Both comments use an HTML marker so they are updated in-place on subsequent pushes rather than creating duplicates.

## Test Plan

- [ ] Merge this PR and verify a comment with the Storybook preview URL appears on the next open PR
- [ ] Verify pushing a new commit to an existing PR updates the comment rather than creating a new one
- [ ] Verify the Blazor preview comment also appears

Made with [Cursor](https://cursor.com)