### PR TITLE
fix: Address Copilot review feedback on PR preview comment step

### DIFF
--- a/.github/workflows/preview-storybook.yml
+++ b/.github/workflows/preview-storybook.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   packages: read
   pull-requests: write
+  issues: write
 
 concurrency:
   group: gh-pages-deploy-${{ github.ref }}
@@ -81,7 +82,7 @@ jobs:
             const marker = '<!-- storybook-preview-comment -->';
             const body = `${marker}\n## :rocket: Storybook Preview\n\nPreview is available at: ${previewUrl}`;
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,


### PR DESCRIPTION
## Summary

Addresses the 2 issues flagged by Copilot on #1177 for `preview-storybook.yml`:

- **Add `issues: write` permission** — the `github.rest.issues.*` API requires this permission. Without it the step could fail with a 403 "Resource not accessible by integration" error.
- **Use `github.paginate()`** — `listComments` defaults to 30 results per page. On PRs with many comments the marker comment may not be found, causing duplicate preview comments to be posted. Switching to `github.paginate()` fetches all pages before searching.

The Blazor workflow comments from Copilot are no longer relevant since #1177 also removed the `pull_request` trigger from that workflow entirely.

## Test Plan

- [x] Verify the Storybook preview comment is posted on a new PR
- [x] Verify no duplicate comments appear when a new commit is pushed to an existing PR

Made with [Cursor](https://cursor.com)