### PR TITLE
Card: Fix body gap spacing

### DIFF
--- a/src/components/modus-wc-card/modus-wc-card.scss
+++ b/src/components/modus-wc-card/modus-wc-card.scss
@@ -23,7 +23,7 @@ modus-wc-card .modus-wc-card {
   }
 
   .modus-wc-card-body {
-    gap: unset;
+    gap: 0.5rem;
   }
 
   .modus-wc-card-actions {


### PR DESCRIPTION
## Summary
- Set `.modus-wc-card-body` gap to `0.5rem` instead of `unset` for consistent spacing between card body children.

## Test plan
- [x] Check classic light/dark and connect light/dark themes

- [x] Verify card body content has expected spacing in Storybook

Made with [Cursor](https://cursor.com)