### PR TITLE
Fix publish workflow startup failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,7 @@ permissions:
   contents: write
   actions: write
   packages: write
+  pull-requests: write
 
 jobs:
   build-and-publish-wc:


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` to the top-level permissions in `publish.yml`.
- Fixes the Publish & Release workflow startup failure caused by calling `publish-mcp.yml`, which requires PR write access to open MCP docs PRs.

## Context
Run https://github.com/trimble-oss/modus-wc-2.0/actions/runs/28182165949 failed at startup with:
> The workflow is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.

Reusable workflows inherit the caller's permission ceiling, so the parent must grant what the child requests.

## Test plan
- [ ] Merge and re-run Publish & Release workflow manually
- [ ] Confirm workflow passes startup validation and `publish-mcp` job runs


Made with [Cursor](https://cursor.com)