### PR TITLE
Card: Revert body gap to unset

### DIFF
--- a/src/components/modus-wc-card/modus-wc-card.scss
+++ b/src/components/modus-wc-card/modus-wc-card.scss
@@ -23,7 +23,7 @@ modus-wc-card .modus-wc-card {
   }
 
   .modus-wc-card-body {
-    gap: 0.5rem;
+    gap: unset;
   }
 
   .modus-wc-card-actions {


### PR DESCRIPTION
## Summary
- Revert `.modus-wc-card-body` gap from `0.5rem` back to `unset`.

## Test plan
- [ ] Verify card body spacing in Storybook matches expected default layout
- [ ] Check classic and connect themes


Made with [Cursor](https://cursor.com)