### PR TITLE
fix: restore Storybook build with esbuild 0.28

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -26,11 +26,24 @@ const config: StorybookConfig = {
   async viteFinal(config, { configType }) {
     const { mergeConfig } = await import('vite');
 
+    // esbuild 0.28+ errors when downleveling destructuring for targets that
+    // include Safari <14.1 (Storybook defaults include safari14). Tell esbuild
+    // destructuring is supported — same workaround Vite/Angular adopted.
+    // See https://github.com/evanw/esbuild/issues/4436
+    const esbuildCompat = {
+      esbuild: {
+        supported: {
+          destructuring: true,
+        },
+      },
+    };
+
     if (configType !== 'DEVELOPMENT') {
-      return config;
+      return mergeConfig(config, esbuildCompat);
     }
 
     return mergeConfig(config, {
+      ...esbuildCompat,
       build: {
         // this is set to 'dist' by default which causes hot-reloading for stencil components to break
         // see: https://vitejs.dev/config/server-options.html#server-watch

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -29,11 +29,19 @@ const config: StorybookConfig = {
     // esbuild 0.28+ errors when downleveling destructuring for targets that
     // include Safari <14.1 (Storybook defaults include safari14). Tell esbuild
     // destructuring is supported — same workaround Vite/Angular adopted.
+    // Cover both Vite build transpile and optimizeDeps (dev server).
     // See https://github.com/evanw/esbuild/issues/4436
     const esbuildCompat = {
       esbuild: {
         supported: {
           destructuring: true,
+        },
+      },
+      optimizeDeps: {
+        esbuildOptions: {
+          supported: {
+            destructuring: true,
+          },
         },
       },
     };


### PR DESCRIPTION
## Summary
- After #1320 forced `esbuild@^0.28.1`, Storybook production builds fail with `Transforming destructuring to the configured target environment ... is not supported yet`.
- Add the standard Vite/esbuild workaround in `.storybook/main.ts` (`esbuild.supported.destructuring: true`).

## Test plan
- [x] `npm ci` → esbuild 0.28.1
- [x] `npx storybook build` succeeds locally
- [ ] CI `build-and-deploy` / Storybook build green


Made with [Cursor](https://cursor.com)