### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Modus Web Components 2.0 is a framework-agnostic UI library built with **Stencil JS**.
+The primary dev experience is **Storybook** (component playground/docs). There is no
+runtime backend or database. Standard commands are documented in `README.md` and the
+root `package.json` `scripts`; the notes below only cover non-obvious caveats.
+
+### Private registry auth is required to install (most important)
+
+`npm ci` / `npm install` pull three private packages and will fail without tokens:
+
+- `@trimble-oss/modus-stencil-razor-output-target` — GitHub Packages (`trimble-oss` org);
+  imported by `stencil.config.ts` (Blazor output target).
+- `@trimble-oss/custom-elements-manifest-analyzer` — GitHub Packages; listed under
+  `optionalDependencies` but is **effectively required**: it provides the
+  `custom-elements-manifest` CLI used by the `build:cem-json` wireit step, so
+  `npm run build` fails without it even though npm treats it as optional.
+- `@trimble-agentic-external-npm-local/agentic-platform-sdk-iframe-typescript` — Trimble
+  Artifactory; imported by the Storybook AI-chat addon (`.storybook/addons/ai-chat`).
+
+`.npmrc` reads two tokens from the environment, so set them as secrets (no local
+`~/.npmrc` needed here):
+
+- `GITHUB_AUTH_TOKEN` — needs `read:packages` **and** `trimble-oss` org access with SSO
+  authorized. The default Cursor `gh` installation token does NOT have package read on
+  `trimble-oss` (installs 403 with "Permission installation not allowed to Read
+  organization package").
+- `TRIMBLE_AGENTIC_NPM_TOKEN` — Trimble Artifactory token.
+
+Once both secrets are set, `npm ci` (the startup update script) installs cleanly.
+
+### Wireit deletes build outputs before running (gotcha)
+
+Wireit clears a step's declared `output` files before executing it. If `build:cem-json`
+fails (e.g. missing `custom-elements-manifest` CLI), it will have already deleted the
+tracked file `src/custom-elements.json`. Restore it with
+`git checkout -- src/custom-elements.json`.
+
+### Build regenerates tracked files
+
+`stencil build --docs` (run by `npm run build`) regenerates tracked artifacts:
+`src/components.d.ts`, every component `readme.md`, and `src/styles/modus-wc-variables.css`.
+Don't commit these incidental regenerations unless the change is intentional.
+
+### Environment / commands
+
+- Node `>=20` (repo Volta-pins `20.19.2`); the toolchain also builds/tests fine on Node 22.
+- `npm start` → Stencil watch + Storybook on port **6006** + lint (via wireit).
+- `npm run build:ci` builds the Stencil library only (faster than full `npm run build`,
+  which also builds Storybook).
+- `npm test` runs `stencil test --spec` (Jest + Puppeteer headless Chromium; coverage
+  threshold is 100%). `npm run lint` runs eslint + prettier + stylelint.
+- Framework integrations (React/Angular/Vue/Blazor/MAUI) and the `mcp/` package are
+  optional and each have their own install; they depend on the root `dist/` being built
+  first (`npm run build`). Blazor/MAUI additionally require the .NET SDK.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### :page_facing_up: Summary of Changes

Adds an `AGENTS.md` capturing durable, non-obvious guidance for setting up and running this repo in Cursor Cloud (and locally). No source/behavior changes — documentation only.

Key notes recorded:
- **Private registry auth is required to install.** Three private packages must be fetched during `npm ci`/`npm install`:
  - `@trimble-oss/modus-stencil-razor-output-target` (GitHub Packages) — used by `stencil.config.ts`.
  - `@trimble-oss/custom-elements-manifest-analyzer` (GitHub Packages) — listed as `optionalDependencies` but effectively required: it provides the `custom-elements-manifest` CLI used by the `build:cem-json` wireit step, so `npm run build` fails without it.
  - `@trimble-agentic-external-npm-local/agentic-platform-sdk-iframe-typescript` (Trimble Artifactory) — used by the Storybook AI-chat addon.
  - `.npmrc` reads `GITHUB_AUTH_TOKEN` (needs `read:packages` + `trimble-oss` org access with SSO) and `TRIMBLE_AGENTIC_NPM_TOKEN` from the environment. The default Cursor `gh` installation token does **not** have package read on `trimble-oss` (installs 403).
- **Wireit deletes a step's declared outputs before running it**, so a failed `build:cem-json` leaves `src/custom-elements.json` deleted (restore via `git checkout`).
- **`stencil build --docs` regenerates tracked files** (`components.d.ts`, component `readme.md`s, `modus-wc-variables.css`) — avoid committing incidental regenerations.
- Node `>=20` (Volta-pins `20.19.2`; Node 22 also works), Storybook on port `6006`, plus lint/test/build command pointers.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [x] Documentation change
- [ ] Other

### :clipboard: Test Plan

Environment verified end-to-end (with local stand-ins for the private packages, since org tokens were unavailable in this session):
- `npm run build:ci` — Stencil build succeeds, `dist/` generated.
- `npm run lint` — eslint + prettier + stylelint pass (with lockfile-pinned tooling).
- `npm test` — 57 suites / 1913 tests / 297 snapshots pass.
- `npm start` / `storybook dev -p 6006` — Storybook runs; verified the Button story renders and live Controls (variant, color, size, disabled) update the component and `buttonClick` fires.

### :white_check_mark: Self Code Review Checklist

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [x] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ef27980-9752-40fd-81a3-86c70a73a4d8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ef27980-9752-40fd-81a3-86c70a73a4d8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

