### PR TITLE
fix: expose aria-selected on tabs

### DIFF
--- a/src/components/modus-wc-tabs/__snapshots__/modus-wc-tabs.spec.ts.snap
+++ b/src/components/modus-wc-tabs/__snapshots__/modus-wc-tabs.spec.ts.snap
@@ -35,7 +35,7 @@ exports[`modus-wc-tabs should render with custom props 1`] = `
         Tab 1
       </span>
     </button>
-    <button aria-disabled="" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
+    <button aria-disabled="true" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
       <span>
         Tab 2
       </span>
@@ -89,7 +89,7 @@ exports[`modus-wc-tabs should render with default props (with tab data) 1`] = `
         Tab 1
       </span>
     </button>
-    <button aria-disabled="" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
+    <button aria-disabled="true" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
       <span>
         Tab 2
       </span>
@@ -135,7 +135,7 @@ exports[`modus-wc-tabs should render with default props (with tab panel) 1`] = `
         Tab 1
       </span>
     </button>
-    <button aria-disabled="" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
+    <button aria-disabled="true" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
       <span>
         Tab 2
       </span>

--- a/src/components/modus-wc-tabs/__snapshots__/modus-wc-tabs.spec.ts.snap
+++ b/src/components/modus-wc-tabs/__snapshots__/modus-wc-tabs.spec.ts.snap
@@ -4,12 +4,12 @@ exports[`modus-wc-tabs should render tabs with slotName property 1`] = `
 <modus-wc-tabs>
   <!---->
   <div aria-label="Tab Group with Slots" class="modus-wc-tabs modus-wc-tabs-bordered modus-wc-tabs-md" role="tablist">
-    <button class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
+    <button aria-selected="true" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
       <div slot="custom-tab-slot-1">
         Custom Tab Content
       </div>
     </button>
-    <button aria-label="Regular Tab" class="modus-wc-tab" id="tab-1" role="tab">
+    <button aria-label="Regular Tab" aria-selected="false" class="modus-wc-tab" id="tab-1" role="tab">
       <span>
         Regular Tab
       </span>
@@ -30,32 +30,32 @@ exports[`modus-wc-tabs should render with custom props 1`] = `
 <modus-wc-tabs custom-class="test-class" size="sm" tab-style="boxed">
   <!---->
   <div aria-label="Custom Tab Group" class="modus-wc-tabs modus-wc-tabs-boxed modus-wc-tabs-sm test-class" role="tablist">
-    <button aria-label="Tab 1" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
+    <button aria-label="Tab 1" aria-selected="true" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
       <span>
         Tab 1
       </span>
     </button>
-    <button aria-disabled="" aria-label="Tab 2" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
+    <button aria-disabled="" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
       <span>
         Tab 2
       </span>
     </button>
-    <button aria-label="home" class="modus-wc-tab" id="tab-2" role="tab">
+    <button aria-label="home" aria-selected="false" class="modus-wc-tab" id="tab-2" role="tab">
       <modus-wc-icon name="home" size="sm"></modus-wc-icon>
     </button>
-    <button aria-label="Settings" class="modus-wc-tab" id="tab-3" role="tab">
+    <button aria-label="Settings" aria-selected="false" class="modus-wc-tab" id="tab-3" role="tab">
       <modus-wc-icon name="settings" size="sm"></modus-wc-icon>
       <span>
         Settings
       </span>
     </button>
-    <button aria-label="Alerts" class="modus-wc-tab" id="tab-4" role="tab">
+    <button aria-label="Alerts" aria-selected="false" class="modus-wc-tab" id="tab-4" role="tab">
       <span>
         Alerts
       </span>
       <modus-wc-icon name="alert" size="sm"></modus-wc-icon>
     </button>
-    <button aria-label="Custom Tab" class="custom-tab-class modus-wc-tab" id="tab-5" role="tab">
+    <button aria-label="Custom Tab" aria-selected="false" class="custom-tab-class modus-wc-tab" id="tab-5" role="tab">
       <span>
         Custom Tab
       </span>
@@ -84,32 +84,32 @@ exports[`modus-wc-tabs should render with default props (with tab data) 1`] = `
 <modus-wc-tabs>
   <!---->
   <div aria-label="Tab Group" class="modus-wc-tabs modus-wc-tabs-bordered modus-wc-tabs-md" role="tablist">
-    <button aria-label="Tab 1" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
+    <button aria-label="Tab 1" aria-selected="true" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
       <span>
         Tab 1
       </span>
     </button>
-    <button aria-disabled="" aria-label="Tab 2" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
+    <button aria-disabled="" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
       <span>
         Tab 2
       </span>
     </button>
-    <button aria-label="home" class="modus-wc-tab" id="tab-2" role="tab">
+    <button aria-label="home" aria-selected="false" class="modus-wc-tab" id="tab-2" role="tab">
       <modus-wc-icon name="home" size="md"></modus-wc-icon>
     </button>
-    <button aria-label="Settings" class="modus-wc-tab" id="tab-3" role="tab">
+    <button aria-label="Settings" aria-selected="false" class="modus-wc-tab" id="tab-3" role="tab">
       <modus-wc-icon name="settings" size="md"></modus-wc-icon>
       <span>
         Settings
       </span>
     </button>
-    <button aria-label="Alerts" class="modus-wc-tab" id="tab-4" role="tab">
+    <button aria-label="Alerts" aria-selected="false" class="modus-wc-tab" id="tab-4" role="tab">
       <span>
         Alerts
       </span>
       <modus-wc-icon name="alert" size="md"></modus-wc-icon>
     </button>
-    <button aria-label="Custom Tab" class="custom-tab-class modus-wc-tab" id="tab-5" role="tab">
+    <button aria-label="Custom Tab" aria-selected="false" class="custom-tab-class modus-wc-tab" id="tab-5" role="tab">
       <span>
         Custom Tab
       </span>
@@ -130,32 +130,32 @@ exports[`modus-wc-tabs should render with default props (with tab panel) 1`] = `
 <modus-wc-tabs>
   <!---->
   <div aria-label="Tab Group" class="modus-wc-tabs modus-wc-tabs-bordered modus-wc-tabs-md" role="tablist">
-    <button aria-label="Tab 1" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
+    <button aria-label="Tab 1" aria-selected="true" class="modus-wc-tab modus-wc-tab-active" id="tab-0" role="tab">
       <span>
         Tab 1
       </span>
     </button>
-    <button aria-disabled="" aria-label="Tab 2" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
+    <button aria-disabled="" aria-label="Tab 2" aria-selected="false" class="modus-wc-tab modus-wc-tab-disabled" disabled="" id="tab-1" role="tab">
       <span>
         Tab 2
       </span>
     </button>
-    <button aria-label="home" class="modus-wc-tab" id="tab-2" role="tab">
+    <button aria-label="home" aria-selected="false" class="modus-wc-tab" id="tab-2" role="tab">
       <modus-wc-icon name="home" size="md"></modus-wc-icon>
     </button>
-    <button aria-label="Settings" class="modus-wc-tab" id="tab-3" role="tab">
+    <button aria-label="Settings" aria-selected="false" class="modus-wc-tab" id="tab-3" role="tab">
       <modus-wc-icon name="settings" size="md"></modus-wc-icon>
       <span>
         Settings
       </span>
     </button>
-    <button aria-label="Alerts" class="modus-wc-tab" id="tab-4" role="tab">
+    <button aria-label="Alerts" aria-selected="false" class="modus-wc-tab" id="tab-4" role="tab">
       <span>
         Alerts
       </span>
       <modus-wc-icon name="alert" size="md"></modus-wc-icon>
     </button>
-    <button aria-label="Custom Tab" class="custom-tab-class modus-wc-tab" id="tab-5" role="tab">
+    <button aria-label="Custom Tab" aria-selected="false" class="custom-tab-class modus-wc-tab" id="tab-5" role="tab">
       <span>
         Custom Tab
       </span>

--- a/src/components/modus-wc-tabs/modus-wc-tabs.spec.ts
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.spec.ts
@@ -48,6 +48,27 @@ describe('modus-wc-tabs', () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it('should expose the active tab with aria-selected', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcTabs],
+      html: '<modus-wc-tabs aria-label="Tab Group"></modus-wc-tabs>',
+    });
+
+    const component = page.rootInstance as ModusWcTabs;
+    component.tabs = defaultTabs;
+
+    await page.waitForChanges();
+
+    const tabs = page.root!.querySelectorAll('[role="tab"]');
+
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true');
+    expect(
+      Array.from(tabs)
+        .slice(1)
+        .every((tab) => tab.getAttribute('aria-selected') === 'false')
+    ).toBe(true);
+  });
+
   it('should render with default props (with tab panel)', async () => {
     const page = await newSpecPage({
       components: [ModusWcTabs],
@@ -139,6 +160,10 @@ describe('modus-wc-tabs', () => {
       previousTab: 0,
       newTab: 2,
     });
+    expect(thirdTab.getAttribute('aria-selected')).toBe('true');
+    expect(
+      page.root!.querySelector('[role="tab"]')?.getAttribute('aria-selected')
+    ).toBe('false');
   });
 
   it('should not emit tabChange event when a disabled tab is clicked', async () => {

--- a/src/components/modus-wc-tabs/modus-wc-tabs.tsx
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.tsx
@@ -144,6 +144,7 @@ export class ModusWcTabs {
         role="tab"
         aria-disabled={tab.disabled}
         aria-label={tab.label ?? tab.icon}
+        aria-selected={index === this.activeTabIndex ? 'true' : 'false'}
         class={this.getTabClasses(tab, index)}
         disabled={tab.disabled}
         id={`tab-${index}`}

--- a/src/components/modus-wc-tabs/modus-wc-tabs.tsx
+++ b/src/components/modus-wc-tabs/modus-wc-tabs.tsx
@@ -142,7 +142,7 @@ export class ModusWcTabs {
     const tabs = this.tabs.map((tab, index) => (
       <button
         role="tab"
-        aria-disabled={tab.disabled}
+        aria-disabled={tab.disabled ? 'true' : undefined}
         aria-label={tab.label ?? tab.icon}
         aria-selected={index === this.activeTabIndex ? 'true' : 'false'}
         class={this.getTabClasses(tab, index)}


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

- Added an explicit `aria-selected="true"` or `aria-selected="false"` to every tab rendered by `modus-wc-tabs`.

This is mainly for easier verification in our QA processes, along with helping assistive readers figure out which tab is selected. Currently, we have to use `modus-wc-tab-active` css class.

I also added a fix to the disabled tabs, so they expose a valid ARIA state instead of an invalid empty token.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

- [x] Tabs spec passes with updated snapshots.
- [x] Prettier check passes for changed files.
- [x] ESLint passes for changed TypeScript files.
- [x] `git diff --check` passes.

### :white_check_mark: Self Code Review Checklist

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #716864