### PR TITLE
Fix Storybook Modus CSS when opened from a non-localhost URL

### DIFF
--- a/.cursor/rules/storybook-remote-access.mdc
+++ b/.cursor/rules/storybook-remote-access.mdc
@@ -1,0 +1,13 @@
+---
+alwaysApply: true
+---
+
+# Storybook on Cloud / iPad / VM
+
+Users often open this repo from **iPad** or **Cursor Cloud**. `localhost:6006` is not reachable on their device.
+
+When asked to open, start, or share Storybook:
+
+- Give a **public HTTPS URL** into the VM (port-forward / tunnel to Storybook on port 6006), not `http://localhost:6006`.
+- Confirm Modus CSS actually loads on that URL before sending it. `/src/styles/output.css` or `/public/output.css` must return 200, and the canvas must show themed Modus components (not unstyled native controls).
+- Do not treat `hostname === localhost` as the way to choose stylesheet paths. Tunneled and forwarded hosts are not localhost; they still need Vite `output.css` (or the static `public/output.css` fallback). See `.storybook/preview-head.html` and `.storybook/manager-head.html`.

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -8,13 +8,23 @@
 />
 <script type="module" src="./modus-wc/modus-wc.esm.js"></script>
 <script>
-  // Load Modus styles in the manager context
-  const isLocal = window.location.hostname.includes('localhost');
-  const cssPath = isLocal ? '../src/styles/output.css' : 'public/output.css';
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = cssPath;
-  document.head.appendChild(link);
+  // Load Modus styles in the manager context. Prefer the Vite path, then
+  // the static-deploy copy. Hostname checks miss tunneled / forwarded hosts.
+  (function () {
+    const candidates = ['/src/styles/output.css', 'public/output.css'];
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    let index = 0;
+    const loadNext = function () {
+      if (index >= candidates.length) {
+        return;
+      }
+      link.href = candidates[index++];
+    };
+    link.addEventListener('error', loadNext);
+    document.head.appendChild(link);
+    loadNext();
+  })();
 </script>
 <style>
   html,

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,11 +1,22 @@
 <script>
-  // Determine if we're running locally or deployed
-  const isLocal = window.location.hostname.includes('localhost');
-  const cssPath = isLocal ? '../src/styles/output.css' : 'public/output.css';
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = cssPath;
-  document.head.appendChild(link);
+  // Vite dev serves compiled Tailwind at /src/styles/output.css.
+  // Static Storybook deploys copy it to public/output.css. Do not key this
+  // off hostname === localhost — forwarded/tunneled hosts need the same CSS.
+  (function () {
+    const candidates = ['/src/styles/output.css', 'public/output.css'];
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    let index = 0;
+    const loadNext = function () {
+      if (index >= candidates.length) {
+        return;
+      }
+      link.href = candidates[index++];
+    };
+    link.addEventListener('error', loadNext);
+    document.head.appendChild(link);
+    loadNext();
+  })();
 </script>
 <style>
   html,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ Don't commit these incidental regenerations unless the change is intentional.
 
 - Node `>=20` (repo Volta-pins `20.19.2`); the toolchain also builds/tests fine on Node 22.
 - `npm start` → Stencil watch + Storybook on port **6006** + lint (via wireit).
+- **iPad / Cloud users cannot open `localhost`.** When sharing Storybook, expose port 6006 over a public HTTPS URL (tunnel/forward) and send that link. Verify Modus CSS loads on that host (`/src/styles/output.css` or `/public/output.css` returns 200). Do not gate Storybook stylesheets on `hostname` containing `localhost` (see `.cursor/rules/storybook-remote-access.mdc`).
 - `npm run build:ci` builds the Stencil library only (faster than full `npm run build`,
   which also builds Storybook).
 - `npm test` runs `stencil test --spec` (Jest + Puppeteer headless Chromium; coverage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### :page_facing_up: Summary of Changes

Storybook manager and preview loaded Modus/Tailwind CSS only when `window.location.hostname` contained `localhost`. Any other host (port forwarding, Cloudflare tunnels, Codespaces, iPad) requested `public/output.css`, which is not present on the Vite dev server, so the UI loaded without Modus styles.

Both `preview-head.html` and `manager-head.html` now try `/src/styles/output.css` first (Vite) and fall back to `public/output.css` (static Azure/Storybook deploy).

Also added an always-on Cursor rule (`.cursor/rules/storybook-remote-access.mdc`) and a matching `AGENTS.md` note: share Storybook as a public VM HTTPS URL (not localhost), and verify Modus CSS on that host.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

- Open Storybook on `localhost:6006` and confirm Modus theme CSS still applies (Button docs, theme switcher).
- Open the same Storybook through a non-localhost host (tunnel or forwarded URL) and confirm `/src/styles/output.css` or `/public/output.css` returns 200 and components are themed.
- Confirm static deploy path `public/output.css` remains the fallback (CI already copies `src/styles/output.css` into `storybook-static/public/output.css`).

Verified on the live tunneled Storybook: Button docs shows a styled Modus primary button and Trimble sidebar (not unstyled native controls). `/src/styles/output.css` and `/public/output.css` both return HTTP 200 through the tunnel.

[Tunneled Storybook with Modus CSS](https://cursor.com/agents/bc-019fff2b-4259-7a95-9bb6-15543f26e527/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorybook_tunnel_modus_css.webp)

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [x] I have made Storybook changes including usage documentation (if applicable)
- [x] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue # (none — follow-up from iPad/tunneled Storybook session)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fff2b-4259-7a95-9bb6-15543f26e527?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fff2b-4259-7a95-9bb6-15543f26e527&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

