### PR TITLE
fix: restore Blazor RCL icon font path for Story CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@storybook/web-components": "^8.6.12",
         "@storybook/web-components-vite": "^8.6.12",
         "@tailwindcss/typography": "^0.5.20",
+        "@trimble-oss/modus-icons": "^1.21.0",
         "@types/jest": "^29.5.13",
         "@typescript-eslint/eslint-plugin": "^8.61.1",
         "@typescript-eslint/parser": "^8.61.1",
@@ -4616,6 +4617,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/@trimble-oss/modus-icons": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@trimble-oss/modus-icons/-/modus-icons-1.21.0.tgz",
+      "integrity": "sha512-W02mF0pV5G2DaozqkCyq/HM/YeDpiGlYizCAaM/YW0Ra4Zx/aPrNut0TsPu9fd3vEZ9s51TTp70dmWNnTtm6vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@ts-morph/common": {
       "version": "0.23.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@storybook/web-components": "^8.6.12",
     "@storybook/web-components-vite": "^8.6.12",
     "@tailwindcss/typography": "^0.5.20",
+    "@trimble-oss/modus-icons": "^1.21.0",
     "@types/jest": "^29.5.13",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.61.1",


### PR DESCRIPTION
## Summary
- Blazor Story failed after moving the private Razor plugin out of the root install: the generated RCL looks for `@trimble-oss/modus-icons` under **repo-root** `node_modules`.
- Add that package as a **public npm** `devDependency` (no GitHub Packages) so `dotnet build` can copy `modus-icons.woff2`.

Fixes the [Publish Blazor Story](https://github.com/trimble-oss/modus-wc-2.0/actions/runs/32329490627) failure on main. Related to #1375.

## Test plan
- [ ] Confirm this PR did **not** push to `main`
- [ ] Publish Blazor Story / `build-blazor-integration` installs root deps without `GITHUB_AUTH_TOKEN`
- [ ] `dotnet build integrations/blazor/stencil-generated/ModusWebComponents.Blazor` finds the icon font
- [ ] Root `npm ci` still works without GitHub Packages or Artifactory


Made with [Cursor](https://cursor.com)