### PR TITLE
chore: allowlisted Action to attach existing QA routing labels

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -90,6 +90,7 @@
     "piltzer",
     "popperjs",
     "preid",
+    "Prabhu",
     "progressbar",
     "pwsh",
     "quadri",

--- a/.github/workflows/automation-label-router.yml
+++ b/.github/workflows/automation-label-router.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   route:
@@ -44,19 +43,19 @@ jobs:
 
           matched=0
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-full(\b|$)'; then
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-full([^[:alnum:]_-]|$)'; then
             remove_label qa-skip
             add_label qa-full
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-skip(\b|$)'; then
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-skip([^[:alnum:]_-]|$)'; then
             remove_label qa-full
             add_label qa-skip
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])(QA-rerun:[[:space:]]*add|Routing:[[:space:]]*qa-rerun)(\b|$)'; then
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])(QA-rerun:[[:space:]]*add|Routing:[[:space:]]*qa-rerun)([^[:alnum:]_-]|$)'; then
             remove_label qa-rerun
             add_label qa-rerun
             matched=1

--- a/.github/workflows/automation-label-router.yml
+++ b/.github/workflows/automation-label-router.yml
@@ -1,0 +1,77 @@
+name: Automation label router
+
+# Attaches existing qa-* / needs-human labels from PR comments.
+# Does not create labels. Allowlisted commenters only.
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  route:
+    if: >
+      github.repository == 'trimble-oss/modus-wc-2.0' &&
+      github.event.issue.pull_request &&
+      (github.event.comment.user.login == 'cursor[bot]' ||
+       github.event.comment.user.login == 'ElishaSamPeterPrabhu')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_BODY: ${{ github.event.comment.body }}
+    steps:
+      - name: Attach existing labels from comment
+        run: |
+          set -euo pipefail
+
+          add_label() {
+            local name="$1"
+            printf '{"labels":["%s"]}' "${name}" | \
+              gh api --method POST "repos/${GH_REPO}/issues/${ISSUE_NUMBER}/labels" --input - >/dev/null
+            echo "attached ${name}"
+          }
+
+          remove_label() {
+            local name="$1"
+            gh api --method DELETE "repos/${GH_REPO}/issues/${ISSUE_NUMBER}/labels/${name}" >/dev/null 2>&1 \
+              || true
+          }
+
+          matched=0
+
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-full(\b|$)'; then
+            remove_label qa-skip
+            add_label qa-full
+            matched=1
+          fi
+
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-skip(\b|$)'; then
+            remove_label qa-full
+            add_label qa-skip
+            matched=1
+          fi
+
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])(QA-rerun:[[:space:]]*add|Routing:[[:space:]]*qa-rerun)(\b|$)'; then
+            remove_label qa-rerun
+            add_label qa-rerun
+            matched=1
+          fi
+
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '^##[[:space:]]*QA FAILED'; then
+            add_label qa-failed
+            matched=1
+          fi
+
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '^##[[:space:]]*(NEED CLARIFICATION|NOT FEASIBLE)'; then
+            add_label needs-human
+            matched=1
+          fi
+
+          if [ "${matched}" -eq 0 ]; then
+            echo "no routing signal in comment; skip"
+          fi

--- a/.github/workflows/automation-label-router.yml
+++ b/.github/workflows/automation-label-router.yml
@@ -43,30 +43,30 @@ jobs:
 
           matched=0
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-full([[:space:]]|$)'; then
+          if grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-full([[:space:]]|$)' <<<"${COMMENT_BODY}"; then
             remove_label qa-skip
             add_label qa-full
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-skip([[:space:]]|$)'; then
+          if grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-skip([[:space:]]|$)' <<<"${COMMENT_BODY}"; then
             remove_label qa-full
             add_label qa-skip
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])(QA-rerun:[[:space:]]*add|Routing:[[:space:]]*qa-rerun)([[:space:]]|$)'; then
+          if grep -qE '(^|[[:space:]])(QA-rerun:[[:space:]]*add|Routing:[[:space:]]*qa-rerun)([[:space:]]|$)' <<<"${COMMENT_BODY}"; then
             remove_label qa-rerun
             add_label qa-rerun
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '^##[[:space:]]*QA FAILED'; then
+          if grep -qE '^##[[:space:]]*QA FAILED' <<<"${COMMENT_BODY}"; then
             add_label qa-failed
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '^##[[:space:]]*(NEED CLARIFICATION|NOT FEASIBLE)'; then
+          if grep -qE '^##[[:space:]]*(NEED CLARIFICATION|NOT FEASIBLE)' <<<"${COMMENT_BODY}"; then
             add_label needs-human
             matched=1
           fi

--- a/.github/workflows/automation-label-router.yml
+++ b/.github/workflows/automation-label-router.yml
@@ -43,19 +43,19 @@ jobs:
 
           matched=0
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-full([^[:alnum:]_-]|$)'; then
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-full([[:space:]]|$)'; then
             remove_label qa-skip
             add_label qa-full
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-skip([^[:alnum:]_-]|$)'; then
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])Routing:[[:space:]]*qa-skip([[:space:]]|$)'; then
             remove_label qa-full
             add_label qa-skip
             matched=1
           fi
 
-          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])(QA-rerun:[[:space:]]*add|Routing:[[:space:]]*qa-rerun)([^[:alnum:]_-]|$)'; then
+          if printf '%s\n' "${COMMENT_BODY}" | grep -qE '(^|[[:space:]])(QA-rerun:[[:space:]]*add|Routing:[[:space:]]*qa-rerun)([[:space:]]|$)'; then
             remove_label qa-rerun
             add_label qa-rerun
             matched=1


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Adds `.github/workflows/automation-label-router.yml`. On PR comments from `cursor[bot]` or `ElishaSamPeterPrabhu`, it attaches **existing** labels only:

- `Routing: qa-full` → `qa-full` (removes `qa-skip`)
- `Routing: qa-skip` → `qa-skip` (removes `qa-full`)
- `QA-rerun: add` or `Routing: qa-rerun` → remove then add `qa-rerun`
- `## QA FAILED` → `qa-failed`
- `## NEED CLARIFICATION` or `## NOT FEASIBLE` → `needs-human`

Does not create labels. Comments from anyone else are ignored.

### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

- After merge to `main`, comment `Routing: qa-full` on a draft PR as an allowlisted user; confirm `qa-full` is attached by `github-actions[bot]`.
- Comment the same text from a non-allowlisted account; confirm no label change.
- Confirm `gh label create` is not used.

### :white_check_mark: Self Code Review Checklist

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Cursor automation label routing (no product issue).

Made with [Cursor](https://cursor.com)