### PR TITLE
Add new Image component

### DIFF
--- a/src/components/modus-wc-icon/readme.md
+++ b/src/components/modus-wc-icon/readme.md
@@ -38,6 +38,7 @@ A customizable icon component used to render Modus icons.
  - [modus-wc-dock](../modus-wc-dock)
  - [modus-wc-file-dropzone](../modus-wc-file-dropzone)
  - [modus-wc-handle](../modus-wc-handle)
+ - [modus-wc-image](../modus-wc-image)
  - [modus-wc-input-feedback](../modus-wc-input-feedback)
  - [modus-wc-menu-item](../modus-wc-menu-item)
  - [modus-wc-profile-menu](../modus-wc-profile-menu)
@@ -61,6 +62,7 @@ graph TD;
   modus-wc-dock --> modus-wc-icon
   modus-wc-file-dropzone --> modus-wc-icon
   modus-wc-handle --> modus-wc-icon
+  modus-wc-image --> modus-wc-icon
   modus-wc-input-feedback --> modus-wc-icon
   modus-wc-menu-item --> modus-wc-icon
   modus-wc-profile-menu --> modus-wc-icon

--- a/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
+++ b/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modus-wc-image should apply fit class for fit="contain" 1`] = `
+<modus-wc-image alt="Test" fit="contain" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--contain modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply fit class for fit="cover" 1`] = `
+<modus-wc-image alt="Test" fit="cover" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--cover modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply fit class for fit="none" 1`] = `
+<modus-wc-image alt="Test" fit="none" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--loading modus-wc-image--md modus-wc-image--none modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply fit class for fit="scale-down" 1`] = `
+<modus-wc-image alt="Test" fit="scale-down" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--loading modus-wc-image--md modus-wc-image--scale-down modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply shape class for shape="rounded" 1`] = `
+<modus-wc-image alt="Test" fit="default" shape="rounded" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--rounded modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply shape class for shape="square" 1`] = `
+<modus-wc-image alt="Test" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply size class modus-wc-image--lg 1`] = `
+<modus-wc-image alt="Test" fit="default" shape="square" size="lg" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--lg modus-wc-image--loading modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply size class modus-wc-image--md 1`] = `
+<modus-wc-image alt="Test" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply size class modus-wc-image--sm 1`] = `
+<modus-wc-image alt="Test" fit="default" shape="square" size="sm" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--sm modus-wc-image--square modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should apply size class modus-wc-image--xl 1`] = `
+<modus-wc-image alt="Test" fit="default" shape="square" size="xl" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--square modus-wc-image--xl modus-wc-image-container">
+    <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should render with default props 1`] = `
+<modus-wc-image alt="Test image" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+    <img alt="Test image" class="modus-wc-image-img" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should render with empty alt as a decorative image 1`] = `
+<modus-wc-image alt="" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+    <img alt="" aria-hidden="true" class="modus-wc-image-img" role="presentation" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should render with no alt as a decorative image 1`] = `
+<modus-wc-image fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+    <img alt="" aria-hidden="true" class="modus-wc-image-img" role="presentation" src="https://example.com/image.jpg">
+  </div>
+</modus-wc-image>
+`;
+
+exports[`modus-wc-image should show fallback when image fails to load 1`] = `
+<modus-wc-image alt="Missing image" fit="default" shape="square" size="md" src="https://example.com/bad.jpg">
+  <div aria-label="Missing image" class="modus-wc-image--default modus-wc-image--error modus-wc-image--md modus-wc-image--square modus-wc-image-container" role="img">
+    <div class="modus-wc-image-fallback">
+      <svg aria-hidden="true" class="modus-wc-image-fallback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M21 5v6.59l-3-3.01-4 4.01-4-4-4 4-3-3.01V5c0-1.1.9-2 2-2h14c1.1 0 2 .9 2 2zm-3 6.42 3 3.01V19c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2v-6.58l3 2.99 4-4 4 4 4-3.99z"></path>
+      </svg>
+    </div>
+  </div>
+</modus-wc-image>
+`;

--- a/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
+++ b/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
@@ -8,9 +8,9 @@ exports[`modus-wc-image should apply fit class for fit="contain" 1`] = `
 </modus-wc-image>
 `;
 
-exports[`modus-wc-image should apply fit class for fit="cover" 1`] = `
-<modus-wc-image alt="Test" fit="cover" shape="square" size="md" src="https://example.com/image.jpg">
-  <div class="modus-wc-image--cover modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
+exports[`modus-wc-image should apply fit class for fit="default" 1`] = `
+<modus-wc-image alt="Test" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+  <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
 </modus-wc-image>

--- a/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
+++ b/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-image should apply fit class for fit="contain" 1`] = `
-<modus-wc-image alt="Test" fit="contain" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" fit="contain" src="https://example.com/image.jpg">
   <div class="modus-wc-image--contain modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -9,7 +9,7 @@ exports[`modus-wc-image should apply fit class for fit="contain" 1`] = `
 `;
 
 exports[`modus-wc-image should apply fit class for fit="default" 1`] = `
-<modus-wc-image alt="Test" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" fit="default" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -17,7 +17,7 @@ exports[`modus-wc-image should apply fit class for fit="default" 1`] = `
 `;
 
 exports[`modus-wc-image should apply fit class for fit="none" 1`] = `
-<modus-wc-image alt="Test" fit="none" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" fit="none" src="https://example.com/image.jpg">
   <div class="modus-wc-image--loading modus-wc-image--md modus-wc-image--none modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -25,7 +25,7 @@ exports[`modus-wc-image should apply fit class for fit="none" 1`] = `
 `;
 
 exports[`modus-wc-image should apply fit class for fit="scale-down" 1`] = `
-<modus-wc-image alt="Test" fit="scale-down" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" fit="scale-down" src="https://example.com/image.jpg">
   <div class="modus-wc-image--loading modus-wc-image--md modus-wc-image--scale-down modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -33,7 +33,7 @@ exports[`modus-wc-image should apply fit class for fit="scale-down" 1`] = `
 `;
 
 exports[`modus-wc-image should apply shape class for shape="rounded" 1`] = `
-<modus-wc-image alt="Test" fit="default" shape="rounded" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" shape="rounded" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--rounded modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -41,7 +41,7 @@ exports[`modus-wc-image should apply shape class for shape="rounded" 1`] = `
 `;
 
 exports[`modus-wc-image should apply shape class for shape="square" 1`] = `
-<modus-wc-image alt="Test" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" shape="square" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -49,7 +49,7 @@ exports[`modus-wc-image should apply shape class for shape="square" 1`] = `
 `;
 
 exports[`modus-wc-image should apply size class modus-wc-image--lg 1`] = `
-<modus-wc-image alt="Test" fit="default" shape="square" size="lg" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" size="lg" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--lg modus-wc-image--loading modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -57,7 +57,7 @@ exports[`modus-wc-image should apply size class modus-wc-image--lg 1`] = `
 `;
 
 exports[`modus-wc-image should apply size class modus-wc-image--md 1`] = `
-<modus-wc-image alt="Test" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" size="md" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -65,7 +65,7 @@ exports[`modus-wc-image should apply size class modus-wc-image--md 1`] = `
 `;
 
 exports[`modus-wc-image should apply size class modus-wc-image--sm 1`] = `
-<modus-wc-image alt="Test" fit="default" shape="square" size="sm" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" size="sm" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--sm modus-wc-image--square modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -73,7 +73,7 @@ exports[`modus-wc-image should apply size class modus-wc-image--sm 1`] = `
 `;
 
 exports[`modus-wc-image should apply size class modus-wc-image--xl 1`] = `
-<modus-wc-image alt="Test" fit="default" shape="square" size="xl" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test" size="xl" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--square modus-wc-image--xl modus-wc-image-container">
     <img alt="Test" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -81,7 +81,7 @@ exports[`modus-wc-image should apply size class modus-wc-image--xl 1`] = `
 `;
 
 exports[`modus-wc-image should render with default props 1`] = `
-<modus-wc-image alt="Test image" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="Test image" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="Test image" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
@@ -89,7 +89,7 @@ exports[`modus-wc-image should render with default props 1`] = `
 `;
 
 exports[`modus-wc-image should render with empty alt as a decorative image 1`] = `
-<modus-wc-image alt="" fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image alt="" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="" aria-hidden="true" class="modus-wc-image-img" role="presentation" src="https://example.com/image.jpg">
   </div>
@@ -97,7 +97,7 @@ exports[`modus-wc-image should render with empty alt as a decorative image 1`] =
 `;
 
 exports[`modus-wc-image should render with no alt as a decorative image 1`] = `
-<modus-wc-image fit="default" shape="square" size="md" src="https://example.com/image.jpg">
+<modus-wc-image src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
     <img alt="" aria-hidden="true" class="modus-wc-image-img" role="presentation" src="https://example.com/image.jpg">
   </div>
@@ -105,12 +105,10 @@ exports[`modus-wc-image should render with no alt as a decorative image 1`] = `
 `;
 
 exports[`modus-wc-image should show fallback when image fails to load 1`] = `
-<modus-wc-image alt="Missing image" fit="default" shape="square" size="md" src="https://example.com/bad.jpg">
+<modus-wc-image alt="Missing image" src="https://example.com/bad.jpg">
   <div aria-label="Missing image" class="modus-wc-image--default modus-wc-image--error modus-wc-image--md modus-wc-image--square modus-wc-image-container" role="img">
     <div class="modus-wc-image-fallback">
-      <svg aria-hidden="true" class="modus-wc-image-fallback-icon" fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path d="M21 5v6.59l-3-3.01-4 4.01-4-4-4 4-3-3.01V5c0-1.1.9-2 2-2h14c1.1 0 2 .9 2 2zm-3 6.42 3 3.01V19c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2v-6.58l3 2.99 4-4 4 4 4-3.99z"></path>
-      </svg>
+      <modus-wc-icon class="modus-wc-image-fallback-icon" decorative="" name="image_disabled"></modus-wc-icon>
     </div>
   </div>
 </modus-wc-image>

--- a/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
+++ b/src/components/modus-wc-image/__snapshots__/modus-wc-image.spec.ts.snap
@@ -91,7 +91,7 @@ exports[`modus-wc-image should render with default props 1`] = `
 exports[`modus-wc-image should render with empty alt as a decorative image 1`] = `
 <modus-wc-image alt="" src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
-    <img alt="" aria-hidden="true" class="modus-wc-image-img" role="presentation" src="https://example.com/image.jpg">
+    <img alt="" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
 </modus-wc-image>
 `;
@@ -99,7 +99,7 @@ exports[`modus-wc-image should render with empty alt as a decorative image 1`] =
 exports[`modus-wc-image should render with no alt as a decorative image 1`] = `
 <modus-wc-image src="https://example.com/image.jpg">
   <div class="modus-wc-image--default modus-wc-image--loading modus-wc-image--md modus-wc-image--square modus-wc-image-container">
-    <img alt="" aria-hidden="true" class="modus-wc-image-img" role="presentation" src="https://example.com/image.jpg">
+    <img alt="" class="modus-wc-image-img" src="https://example.com/image.jpg">
   </div>
 </modus-wc-image>
 `;

--- a/src/components/modus-wc-image/modus-wc-image.scss
+++ b/src/components/modus-wc-image/modus-wc-image.scss
@@ -28,7 +28,7 @@ modus-wc-image {
     // Strict Box Mode: fit="cover" | fit="contain" | fit="none"
     // Hard-locked width × height per size token; image is clipped to the box.
     // ─────────────────────────────────────────────────────────────────────────
-    &.modus-wc-image--cover,
+    &.modus-wc-image--default,
     &.modus-wc-image--contain,
     &.modus-wc-image--none {
       &.modus-wc-image--sm {
@@ -57,7 +57,7 @@ modus-wc-image {
       }
     }
 
-    &.modus-wc-image--cover .modus-wc-image-img {
+    &.modus-wc-image--default .modus-wc-image-img {
       object-fit: cover;
       object-position: center;
     }

--- a/src/components/modus-wc-image/modus-wc-image.scss
+++ b/src/components/modus-wc-image/modus-wc-image.scss
@@ -1,0 +1,157 @@
+/**
+ * This component uses Tailwind CSS and DaisyUI.
+ * Only add styles here that should not be applied by Tailwind, Daisy, or the theme.
+ */
+
+modus-wc-image {
+  display: inline-flex;
+
+  .modus-wc-image-container {
+    overflow: hidden;
+    position: relative;
+
+    // Loading placeholder — prevents layout flash before the image resolves
+    &.modus-wc-image--loading {
+      background-color: var(--modus-wc-color-base-200);
+    }
+
+    // Shape modifiers
+    &.modus-wc-image--square {
+      border-radius: 0;
+    }
+
+    &.modus-wc-image--rounded {
+      border-radius: 16px;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Strict Box Mode: fit="cover" | fit="contain" | fit="none"
+    // Hard-locked width × height per size token; image is clipped to the box.
+    // ─────────────────────────────────────────────────────────────────────────
+    &.modus-wc-image--cover,
+    &.modus-wc-image--contain,
+    &.modus-wc-image--none {
+      &.modus-wc-image--sm {
+        height: 128px;
+        width: 128px;
+      }
+
+      &.modus-wc-image--md {
+        height: 192px;
+        width: 288px;
+      }
+
+      &.modus-wc-image--lg {
+        height: 256px;
+        width: 384px;
+      }
+
+      &.modus-wc-image--xl {
+        height: 384px;
+        width: 1486px;
+      }
+
+      .modus-wc-image-img {
+        height: 100%;
+        width: 100%;
+      }
+    }
+
+    &.modus-wc-image--cover .modus-wc-image-img {
+      object-fit: cover;
+      object-position: center;
+    }
+
+    &.modus-wc-image--contain .modus-wc-image-img {
+      object-fit: contain;
+      object-position: center;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Fluid Natural Aspect Ratio Mode: fit="scale-down"
+    // Container uses max constraints; image retains intrinsic dimensions.
+    // ─────────────────────────────────────────────────────────────────────────
+    &.modus-wc-image--scale-down {
+      &.modus-wc-image--sm {
+        max-height: 128px;
+        max-width: 128px;
+      }
+
+      &.modus-wc-image--md {
+        max-height: 192px;
+        max-width: 288px;
+      }
+
+      &.modus-wc-image--lg {
+        max-height: 256px;
+        max-width: 384px;
+      }
+
+      &.modus-wc-image--xl {
+        max-height: 384px;
+        max-width: 1486px;
+      }
+    }
+
+    &.modus-wc-image--scale-down .modus-wc-image-img {
+      display: block;
+      height: auto;
+      max-height: inherit;
+      max-width: inherit;
+      object-fit: scale-down;
+      width: 100%;
+    }
+
+    // fit="none": fixed box dimensions (same as cover/contain), image renders
+    // at its intrinsic size and is clipped by overflow: hidden on the container.
+    &.modus-wc-image--none .modus-wc-image-img {
+      display: block;
+      object-fit: none;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Error / Fallback State
+    // Forces fixed dimensions for all fit modes so the fallback placeholder
+    // has a defined bounding box regardless of natural image size.
+    // ─────────────────────────────────────────────────────────────────────────
+    &.modus-wc-image--error {
+      background-color: var(--modus-wc-color-base-200);
+
+      &.modus-wc-image--sm {
+        height: 128px;
+        width: 128px;
+      }
+
+      &.modus-wc-image--md {
+        height: 192px;
+        width: 288px;
+      }
+
+      &.modus-wc-image--lg {
+        height: 256px;
+        width: 384px;
+      }
+
+      &.modus-wc-image--xl {
+        height: 384px;
+        width: 1486px;
+      }
+    }
+  }
+
+  // Fallback icon centered inside the error container
+  .modus-wc-image-fallback {
+    align-items: center;
+    color: var(--modus-wc-color-base-content);
+    display: flex;
+    height: 100%;
+    justify-content: center;
+    opacity: 0.4;
+    width: 100%;
+
+    .modus-wc-image-fallback-icon {
+      height: 48px;
+      width: 48px;
+    }
+  }
+}

--- a/src/components/modus-wc-image/modus-wc-image.scss
+++ b/src/components/modus-wc-image/modus-wc-image.scss
@@ -25,7 +25,7 @@ modus-wc-image {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // Strict Box Mode: fit="cover" | fit="contain" | fit="none"
+    // Strict Box Mode: fit="default" | fit="contain" | fit="none"
     // Hard-locked width × height per size token; image is clipped to the box.
     // ─────────────────────────────────────────────────────────────────────────
     &.modus-wc-image--default,

--- a/src/components/modus-wc-image/modus-wc-image.scss
+++ b/src/components/modus-wc-image/modus-wc-image.scss
@@ -146,12 +146,14 @@ modus-wc-image {
     display: flex;
     height: 100%;
     justify-content: center;
-    opacity: 0.4;
+    pointer-events: none;
     width: 100%;
 
     .modus-wc-image-fallback-icon {
-      height: 48px;
-      width: 48px;
+      color: var(--modus-wc-color-accent);
+      display: flex;
+      font-size: 48px;
+      pointer-events: none;
     }
   }
 }

--- a/src/components/modus-wc-image/modus-wc-image.spec.ts
+++ b/src/components/modus-wc-image/modus-wc-image.spec.ts
@@ -142,7 +142,7 @@ describe('modus-wc-image', () => {
   );
 
   it.each([
-    ['cover', 'modus-wc-image--cover'],
+    ['default', 'modus-wc-image--default'],
     ['contain', 'modus-wc-image--contain'],
     ['scale-down', 'modus-wc-image--scale-down'],
     ['none', 'modus-wc-image--none'],

--- a/src/components/modus-wc-image/modus-wc-image.spec.ts
+++ b/src/components/modus-wc-image/modus-wc-image.spec.ts
@@ -16,9 +16,9 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/image.jpg"></modus-wc-image>',
     });
     const img = page.root?.querySelector('img');
-    expect(img?.getAttribute('role')).toBe('presentation');
-    expect(img?.getAttribute('aria-hidden')).toBe('true');
     expect(img?.getAttribute('alt')).toBe('');
+    expect(img?.hasAttribute('role')).toBe(false);
+    expect(img?.hasAttribute('aria-hidden')).toBe(false);
     expect(page.root).toMatchSnapshot();
   });
 
@@ -28,9 +28,33 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/image.jpg" alt=""></modus-wc-image>',
     });
     const img = page.root?.querySelector('img');
-    expect(img?.getAttribute('role')).toBe('presentation');
-    expect(img?.getAttribute('aria-hidden')).toBe('true');
+    expect(img?.getAttribute('alt')).toBe('');
+    expect(img?.hasAttribute('role')).toBe(false);
+    expect(img?.hasAttribute('aria-hidden')).toBe(false);
     expect(page.root).toMatchSnapshot();
+  });
+
+  it('should treat whitespace-only alt as decorative', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt=" "></modus-wc-image>',
+    });
+    const img = page.root?.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('');
+    expect(img?.hasAttribute('role')).toBe(false);
+    expect(img?.hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  it('should use "Image unavailable" for fallback when alt is whitespace-only', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/bad.jpg" alt=" "></modus-wc-image>',
+    });
+    const instance = page.rootInstance as ModusWcImage;
+    instance['hasError'] = true;
+    await page.waitForChanges();
+    const container = page.root?.querySelector('.modus-wc-image-container');
+    expect(container?.getAttribute('aria-label')).toBe('Image unavailable');
   });
 
   it('should pass alt text to the img element when provided', async () => {
@@ -159,12 +183,26 @@ describe('modus-wc-image', () => {
     }
   );
 
-  it('should apply the custom class to the host', async () => {
+  it('should apply the custom class to the inner container', async () => {
     const page = await newSpecPage({
       components: [ModusWcImage],
       html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test" custom-class="my-custom-class"></modus-wc-image>',
     });
-    expect(page.root?.classList.contains('my-custom-class')).toBe(true);
+    const container = page.root?.querySelector('.modus-wc-image-container');
+    expect(container?.classList.contains('my-custom-class')).toBe(true);
+  });
+
+  it('should inherit host aria attributes on the fallback container', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Missing image" aria-label="Custom label"></modus-wc-image>',
+    });
+    const instance = page.rootInstance as ModusWcImage;
+    instance['hasError'] = true;
+    await page.waitForChanges();
+    const container = page.root?.querySelector('.modus-wc-image-container');
+    expect(page.root?.hasAttribute('aria-label')).toBe(false);
+    expect(container?.getAttribute('aria-label')).toBe('Missing image');
   });
 
   it('should reset hasError and isLoaded when src changes', async () => {

--- a/src/components/modus-wc-image/modus-wc-image.spec.ts
+++ b/src/components/modus-wc-image/modus-wc-image.spec.ts
@@ -59,7 +59,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    instance.isLoaded = true;
+    (instance as any).isLoaded = true;
     await page.waitForChanges();
     const container = page.root?.querySelector('.modus-wc-image-container');
     expect(container?.classList.contains('modus-wc-image--loading')).toBe(
@@ -73,7 +73,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Missing image"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    instance.hasError = true;
+    (instance as any).hasError = true;
     await page.waitForChanges();
     const fallback = page.root?.querySelector('.modus-wc-image-fallback');
     const img = page.root?.querySelector('img');
@@ -88,7 +88,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Missing image"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    instance.hasError = true;
+    (instance as any).hasError = true;
     await page.waitForChanges();
     const container = page.root?.querySelector('.modus-wc-image-container');
     expect(container?.getAttribute('role')).toBe('img');
@@ -101,7 +101,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/bad.jpg"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    instance.hasError = true;
+    (instance as any).hasError = true;
     await page.waitForChanges();
     const container = page.root?.querySelector('.modus-wc-image-container');
     expect(container?.getAttribute('aria-label')).toBe('Image unavailable');
@@ -173,13 +173,13 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    instance.hasError = true;
-    instance.isLoaded = true;
+    (instance as any).hasError = true;
+    (instance as any).isLoaded = true;
     await page.waitForChanges();
     instance.src = 'https://example.com/new-image.jpg';
     await page.waitForChanges();
-    expect(instance.hasError).toBe(false);
-    expect(instance.isLoaded).toBe(false);
+    expect((instance as any).hasError).toBe(false);
+    expect((instance as any).isLoaded).toBe(false);
   });
 
   it('should emit imageLoad event when image loads', async () => {

--- a/src/components/modus-wc-image/modus-wc-image.spec.ts
+++ b/src/components/modus-wc-image/modus-wc-image.spec.ts
@@ -1,0 +1,208 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ModusWcImage } from './modus-wc-image';
+
+describe('modus-wc-image', () => {
+  it('should render with default props', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test image"></modus-wc-image>',
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with no alt as a decorative image', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg"></modus-wc-image>',
+    });
+    const img = page.root?.querySelector('img');
+    expect(img?.getAttribute('role')).toBe('presentation');
+    expect(img?.getAttribute('aria-hidden')).toBe('true');
+    expect(img?.getAttribute('alt')).toBe('');
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should render with empty alt as a decorative image', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt=""></modus-wc-image>',
+    });
+    const img = page.root?.querySelector('img');
+    expect(img?.getAttribute('role')).toBe('presentation');
+    expect(img?.getAttribute('aria-hidden')).toBe('true');
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should pass alt text to the img element when provided', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt="A scenic mountain"></modus-wc-image>',
+    });
+    const img = page.root?.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('A scenic mountain');
+    expect(img?.hasAttribute('aria-hidden')).toBe(false);
+    expect(img?.hasAttribute('role')).toBe(false);
+  });
+
+  it('should apply the loading class before image load', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
+    });
+    const container = page.root?.querySelector('.modus-wc-image-container');
+    expect(container?.classList.contains('modus-wc-image--loading')).toBe(true);
+  });
+
+  it('should remove loading class after image loads', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
+    });
+    const instance = page.rootInstance as ModusWcImage;
+    instance.isLoaded = true;
+    await page.waitForChanges();
+    const container = page.root?.querySelector('.modus-wc-image-container');
+    expect(container?.classList.contains('modus-wc-image--loading')).toBe(
+      false
+    );
+  });
+
+  it('should show fallback when image fails to load', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Missing image"></modus-wc-image>',
+    });
+    const instance = page.rootInstance as ModusWcImage;
+    instance.hasError = true;
+    await page.waitForChanges();
+    const fallback = page.root?.querySelector('.modus-wc-image-fallback');
+    const img = page.root?.querySelector('img');
+    expect(fallback).not.toBeNull();
+    expect(img).toBeNull();
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should set role="img" and aria-label on the fallback container', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Missing image"></modus-wc-image>',
+    });
+    const instance = page.rootInstance as ModusWcImage;
+    instance.hasError = true;
+    await page.waitForChanges();
+    const container = page.root?.querySelector('.modus-wc-image-container');
+    expect(container?.getAttribute('role')).toBe('img');
+    expect(container?.getAttribute('aria-label')).toBe('Missing image');
+  });
+
+  it('should use "Image unavailable" as aria-label for fallback when no alt is provided', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/bad.jpg"></modus-wc-image>',
+    });
+    const instance = page.rootInstance as ModusWcImage;
+    instance.hasError = true;
+    await page.waitForChanges();
+    const container = page.root?.querySelector('.modus-wc-image-container');
+    expect(container?.getAttribute('aria-label')).toBe('Image unavailable');
+  });
+
+  it.each([
+    ['sm', 'modus-wc-image--sm'],
+    ['md', 'modus-wc-image--md'],
+    ['lg', 'modus-wc-image--lg'],
+    ['xl', 'modus-wc-image--xl'],
+  ])(
+    'should apply size class modus-wc-image--%s',
+    async (size: string, expectedClass: string) => {
+      const page = await newSpecPage({
+        components: [ModusWcImage],
+        html: `<modus-wc-image src="https://example.com/image.jpg" alt="Test" size="${size}"></modus-wc-image>`,
+      });
+      const container = page.root?.querySelector('.modus-wc-image-container');
+      expect(container?.classList.contains(expectedClass)).toBe(true);
+      expect(page.root).toMatchSnapshot();
+    }
+  );
+
+  it.each([
+    ['square', 'modus-wc-image--square'],
+    ['rounded', 'modus-wc-image--rounded'],
+  ])(
+    'should apply shape class for shape="%s"',
+    async (shape: string, expectedClass: string) => {
+      const page = await newSpecPage({
+        components: [ModusWcImage],
+        html: `<modus-wc-image src="https://example.com/image.jpg" alt="Test" shape="${shape}"></modus-wc-image>`,
+      });
+      const container = page.root?.querySelector('.modus-wc-image-container');
+      expect(container?.classList.contains(expectedClass)).toBe(true);
+      expect(page.root).toMatchSnapshot();
+    }
+  );
+
+  it.each([
+    ['cover', 'modus-wc-image--cover'],
+    ['contain', 'modus-wc-image--contain'],
+    ['scale-down', 'modus-wc-image--scale-down'],
+    ['none', 'modus-wc-image--none'],
+  ])(
+    'should apply fit class for fit="%s"',
+    async (fit: string, expectedClass: string) => {
+      const page = await newSpecPage({
+        components: [ModusWcImage],
+        html: `<modus-wc-image src="https://example.com/image.jpg" alt="Test" fit="${fit}"></modus-wc-image>`,
+      });
+      const container = page.root?.querySelector('.modus-wc-image-container');
+      expect(container?.classList.contains(expectedClass)).toBe(true);
+      expect(page.root).toMatchSnapshot();
+    }
+  );
+
+  it('should apply the custom class to the host', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test" custom-class="my-custom-class"></modus-wc-image>',
+    });
+    expect(page.root?.classList.contains('my-custom-class')).toBe(true);
+  });
+
+  it('should reset hasError and isLoaded when src changes', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
+    });
+    const instance = page.rootInstance as ModusWcImage;
+    instance.hasError = true;
+    instance.isLoaded = true;
+    await page.waitForChanges();
+    instance.src = 'https://example.com/new-image.jpg';
+    await page.waitForChanges();
+    expect(instance.hasError).toBe(false);
+    expect(instance.isLoaded).toBe(false);
+  });
+
+  it('should emit imageLoad event when image loads', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
+    });
+    const imageLoadSpy = jest.fn();
+    page.root?.addEventListener('imageLoad', imageLoadSpy);
+    const img = page.root?.querySelector('img');
+    img?.dispatchEvent(new Event('load'));
+    expect(imageLoadSpy).toHaveBeenCalled();
+  });
+
+  it('should emit imageError event when image fails to load', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcImage],
+      html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Test"></modus-wc-image>',
+    });
+    const imageErrorSpy = jest.fn();
+    page.root?.addEventListener('imageError', imageErrorSpy);
+    const img = page.root?.querySelector('img');
+    img?.dispatchEvent(new Event('error'));
+    expect(imageErrorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/modus-wc-image/modus-wc-image.spec.ts
+++ b/src/components/modus-wc-image/modus-wc-image.spec.ts
@@ -59,7 +59,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    (instance as any).isLoaded = true;
+    instance['isLoaded'] = true;
     await page.waitForChanges();
     const container = page.root?.querySelector('.modus-wc-image-container');
     expect(container?.classList.contains('modus-wc-image--loading')).toBe(
@@ -73,7 +73,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Missing image"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    (instance as any).hasError = true;
+    instance['hasError'] = true;
     await page.waitForChanges();
     const fallback = page.root?.querySelector('.modus-wc-image-fallback');
     const img = page.root?.querySelector('img');
@@ -88,7 +88,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/bad.jpg" alt="Missing image"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    (instance as any).hasError = true;
+    instance['hasError'] = true;
     await page.waitForChanges();
     const container = page.root?.querySelector('.modus-wc-image-container');
     expect(container?.getAttribute('role')).toBe('img');
@@ -101,7 +101,7 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/bad.jpg"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    (instance as any).hasError = true;
+    instance['hasError'] = true;
     await page.waitForChanges();
     const container = page.root?.querySelector('.modus-wc-image-container');
     expect(container?.getAttribute('aria-label')).toBe('Image unavailable');
@@ -173,13 +173,13 @@ describe('modus-wc-image', () => {
       html: '<modus-wc-image src="https://example.com/image.jpg" alt="Test"></modus-wc-image>',
     });
     const instance = page.rootInstance as ModusWcImage;
-    (instance as any).hasError = true;
-    (instance as any).isLoaded = true;
+    instance['hasError'] = true;
+    instance['isLoaded'] = true;
     await page.waitForChanges();
     instance.src = 'https://example.com/new-image.jpg';
     await page.waitForChanges();
-    expect((instance as any).hasError).toBe(false);
-    expect((instance as any).isLoaded).toBe(false);
+    expect(instance['hasError']).toBe(false);
+    expect(instance['isLoaded']).toBe(false);
   });
 
   it('should emit imageLoad event when image loads', async () => {

--- a/src/components/modus-wc-image/modus-wc-image.stories.ts
+++ b/src/components/modus-wc-image/modus-wc-image.stories.ts
@@ -48,7 +48,7 @@ const meta: Meta<ImageArgs> = {
       description: {
         component: `
 A resilient atomic image component wrapping the native \`<img>\` tag with consistent sizing tokens,
-aspect-ratio control, an accessible error fallback, and WCAG 2.1 AA compliance.`,
+aspect-ratio control, an accessible error fallback, and WCAG 2.2 compliance.`,
       },
     },
   },

--- a/src/components/modus-wc-image/modus-wc-image.stories.ts
+++ b/src/components/modus-wc-image/modus-wc-image.stories.ts
@@ -1,0 +1,101 @@
+import { withActions } from '@storybook/addon-actions/decorator';
+import { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+interface ImageArgs {
+  src: string;
+  alt?: string;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  shape?: 'square' | 'rounded';
+  fit?: 'cover' | 'contain' | 'scale-down' | 'none';
+  'custom-class'?: string;
+}
+
+const SAMPLE_IMAGE =
+  'https://images.pexels.com/photos/5146774/pexels-photo-5146774.jpeg';
+
+const meta: Meta<ImageArgs> = {
+  title: 'Components/Image',
+  component: 'modus-wc-image',
+  args: {
+    src: SAMPLE_IMAGE,
+    alt: 'A scenic mountain landscape',
+    fit: 'cover',
+    shape: 'square',
+    size: 'md',
+  },
+  argTypes: {
+    fit: {
+      control: { type: 'select' },
+      options: ['cover', 'contain', 'scale-down', 'none'],
+    },
+    shape: {
+      control: { type: 'select' },
+      options: ['square', 'rounded'],
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg', 'xl'],
+    },
+  },
+  decorators: [withActions],
+  parameters: {
+    actions: {
+      handles: ['imageLoad', 'imageError'],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<ImageArgs>;
+
+const Template: Story = {
+  render: (args) => html`
+    <modus-wc-image
+      src=${args.src}
+      alt=${ifDefined(args.alt)}
+      size=${ifDefined(args.size)}
+      shape=${ifDefined(args.shape)}
+      fit=${ifDefined(args.fit)}
+      custom-class=${ifDefined(args['custom-class'])}
+    ></modus-wc-image>
+  `,
+};
+
+export const Default: Story = { ...Template };
+
+export const Rounded: Story = {
+  ...Template,
+  args: { shape: 'rounded' },
+};
+
+export const DecorativeImage: Story = {
+  ...Template,
+  args: { alt: '' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `alt` is empty the image is treated as decorative: `role="presentation"` and `aria-hidden="true"` are applied so screen readers skip it.',
+      },
+    },
+  },
+};
+
+export const ErrorFallback: Story = {
+  ...Template,
+  args: {
+    src: 'https://example.com/this-image-does-not-exist.png',
+    alt: 'A missing image',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When the image URL fails to load the broken image icon is hidden and an accessible SVG placeholder is rendered.',
+      },
+    },
+  },
+};

--- a/src/components/modus-wc-image/modus-wc-image.stories.ts
+++ b/src/components/modus-wc-image/modus-wc-image.stories.ts
@@ -201,7 +201,7 @@ export const DecorativeImage: Story = {
     docs: {
       description: {
         story:
-          'When `alt` is empty the image is treated as decorative: `role="presentation"` and `aria-hidden="true"` are applied so screen readers skip it.',
+          'When `alt` is empty or whitespace-only the image is treated as decorative: an empty `alt` attribute is set so screen readers skip it.',
       },
     },
   },

--- a/src/components/modus-wc-image/modus-wc-image.stories.ts
+++ b/src/components/modus-wc-image/modus-wc-image.stories.ts
@@ -8,7 +8,7 @@ interface ImageArgs {
   alt?: string;
   size?: 'sm' | 'md' | 'lg' | 'xl';
   shape?: 'square' | 'rounded';
-  fit?: 'cover' | 'contain' | 'scale-down' | 'none';
+  fit?: 'default' | 'contain' | 'scale-down' | 'none';
   'custom-class'?: string;
 }
 
@@ -20,15 +20,15 @@ const meta: Meta<ImageArgs> = {
   component: 'modus-wc-image',
   args: {
     src: SAMPLE_IMAGE,
-    alt: 'A scenic mountain landscape',
-    fit: 'cover',
+    alt: 'A zebra drinks from a pond',
+    fit: 'default',
     shape: 'square',
     size: 'md',
   },
   argTypes: {
     fit: {
       control: { type: 'select' },
-      options: ['cover', 'contain', 'scale-down', 'none'],
+      options: ['default', 'contain', 'scale-down', 'none'],
     },
     shape: {
       control: { type: 'select' },
@@ -43,6 +43,13 @@ const meta: Meta<ImageArgs> = {
   parameters: {
     actions: {
       handles: ['imageLoad', 'imageError'],
+    },
+    docs: {
+      description: {
+        component: `
+A resilient atomic image component wrapping the native \`<img>\` tag with consistent sizing tokens,
+aspect-ratio control, an accessible error fallback, and WCAG 2.1 AA compliance.`,
+      },
     },
   },
 };
@@ -64,11 +71,127 @@ const Template: Story = {
   `,
 };
 
-export const Default: Story = { ...Template };
+export const Default: Story = {
+  ...Template,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Default rendering with `fit="default"` and `size="md"` (288×192 px). The image fills the fixed box completely — non-matching aspect ratios are **cropped** equally from the center edges with no distortion.',
+      },
+    },
+  },
+};
+
+export const FitContain: Story = {
+  ...Template,
+  args: { fit: 'contain' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`fit="contain"` — the image scales down to fit **entirely** inside the hard-locked box while preserving its original aspect ratio. Areas not covered by the image show the background (letterbox/pillarbox effect).',
+      },
+    },
+  },
+};
+
+export const FitScaleDown: Story = {
+  ...Template,
+  args: { fit: 'scale-down' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`fit="scale-down"` — the container uses `max-width / max-height` from the `size` token instead of hard-locked dimensions. If the image is larger than the target it is scaled down proportionally; if smaller it renders at its intrinsic size. The box shrinks to fit the image.',
+      },
+    },
+  },
+};
+
+export const FitNone: Story = {
+  ...Template,
+  args: { fit: 'none' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`fit="none"` — the image renders at its **intrinsic pixel size** with no scaling applied. The container is still hard-locked to the `size` token dimensions, so any part of the image that exceeds the box is clipped by `overflow: hidden`.',
+      },
+    },
+  },
+};
 
 export const Rounded: Story = {
   ...Template,
   args: { shape: 'rounded' },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Applies a `16 px` border-radius to the image container via `shape="rounded"`. All size variants use the same radius value.',
+      },
+    },
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-wrap: wrap; gap: 24px; align-items: flex-end;"
+    >
+      <div>
+        <p style="margin: 0 0 8px; font-size: 12px; font-weight: 600;">
+          sm — 128×128 px
+        </p>
+        <modus-wc-image
+          src=${SAMPLE_IMAGE}
+          alt="Small"
+          size="sm"
+          fit="default"
+        ></modus-wc-image>
+      </div>
+      <div>
+        <p style="margin: 0 0 8px; font-size: 12px; font-weight: 600;">
+          md — 288×192 px (default)
+        </p>
+        <modus-wc-image
+          src=${SAMPLE_IMAGE}
+          alt="Medium"
+          size="md"
+          fit="default"
+        ></modus-wc-image>
+      </div>
+      <div>
+        <p style="margin: 0 0 8px; font-size: 12px; font-weight: 600;">
+          lg — 384×256 px
+        </p>
+        <modus-wc-image
+          src=${SAMPLE_IMAGE}
+          alt="Large"
+          size="lg"
+          fit="default"
+        ></modus-wc-image>
+      </div>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+All available size tokens side by side (xl omitted for layout reasons — it is 1486×384 px).
+For \`fit="scale-down"\` these values act as \`max-width / max-height\` constraints rather than fixed dimensions.
+
+| \`size\` | Width | Height |
+|---------|-------|--------|
+| \`sm\` | 128 px | 128 px |
+| \`md\` *(default)* | 288 px | 192 px |
+| \`lg\` | 384 px | 256 px |
+| \`xl\` | 1486 px | 384 px |
+        `,
+      },
+    },
+  },
 };
 
 export const DecorativeImage: Story = {

--- a/src/components/modus-wc-image/modus-wc-image.stories.ts
+++ b/src/components/modus-wc-image/modus-wc-image.stories.ts
@@ -217,7 +217,7 @@ export const ErrorFallback: Story = {
     docs: {
       description: {
         story:
-          'When the image URL fails to load the broken image icon is hidden and an accessible SVG placeholder is rendered.',
+          'When the image URL fails to load the broken image icon is hidden and a `modus-wc-icon` fallback (`image_disabled`) is rendered; the container keeps the accessible name from `alt`.',
       },
     },
   },

--- a/src/components/modus-wc-image/modus-wc-image.tailwind.ts
+++ b/src/components/modus-wc-image/modus-wc-image.tailwind.ts
@@ -1,0 +1,21 @@
+export type ImageSize = 'sm' | 'md' | 'lg' | 'xl';
+export type ImageShape = 'square' | 'rounded';
+export type ImageFit = 'cover' | 'contain' | 'scale-down' | 'none';
+
+export const convertPropsToClasses = ({
+  fit,
+  shape,
+  size,
+}: {
+  fit?: ImageFit;
+  shape?: ImageShape;
+  size?: ImageSize;
+}): string => {
+  const classes: string[] = [];
+
+  if (size) classes.push(`modus-wc-image--${size}`);
+  if (shape) classes.push(`modus-wc-image--${shape}`);
+  if (fit) classes.push(`modus-wc-image--${fit}`);
+
+  return classes.join(' ');
+};

--- a/src/components/modus-wc-image/modus-wc-image.tailwind.ts
+++ b/src/components/modus-wc-image/modus-wc-image.tailwind.ts
@@ -1,6 +1,6 @@
 export type ImageSize = 'sm' | 'md' | 'lg' | 'xl';
 export type ImageShape = 'square' | 'rounded';
-export type ImageFit = 'cover' | 'contain' | 'scale-down' | 'none';
+export type ImageFit = 'default' | 'contain' | 'scale-down' | 'none';
 
 export const convertPropsToClasses = ({
   fit,

--- a/src/components/modus-wc-image/modus-wc-image.tsx
+++ b/src/components/modus-wc-image/modus-wc-image.tsx
@@ -48,7 +48,7 @@ export class ModusWcImage {
   /** Controls containment, cropping, and aspect ratio preservation. */
   @Prop() fit?: ImageFit = 'default';
 
-  /** Custom CSS class to apply to the component. */
+  /** Custom CSS class to apply to the inner container. */
   @Prop() customClass?: string = '';
 
   @State() private hasError: boolean = false;
@@ -71,6 +71,10 @@ export class ModusWcImage {
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
+  private getTrimmedAlt(): string {
+    return this.alt?.trim() ?? '';
+  }
+
   private getContainerClasses(isErrorContainer = false): string {
     const classList = ['modus-wc-image-container'];
 
@@ -81,6 +85,7 @@ export class ModusWcImage {
     });
 
     if (propClasses) classList.push(propClasses);
+    if (this.customClass) classList.push(this.customClass);
     if (isErrorContainer) classList.push('modus-wc-image--error');
     else if (!this.isLoaded) classList.push('modus-wc-image--loading');
 
@@ -97,11 +102,16 @@ export class ModusWcImage {
     this.imageLoad.emit(event);
   };
 
-  private renderFallback() {
-    const label = this.alt || 'Image unavailable';
+  private renderFallback(altText: string) {
+    const label = altText || 'Image unavailable';
 
     return (
-      <div class={this.getContainerClasses(true)} role="img" aria-label={label}>
+      <div
+        class={this.getContainerClasses(true)}
+        {...this.inheritedAttributes}
+        role="img"
+        aria-label={label}
+      >
         <div class="modus-wc-image-fallback">
           <modus-wc-icon
             name="image_disabled"
@@ -114,26 +124,23 @@ export class ModusWcImage {
   }
 
   render() {
-    const hostClass = this.customClass || undefined;
+    const altText = this.getTrimmedAlt();
+    const isDecorative = altText === '';
 
     if (this.hasError) {
-      return <Host class={hostClass}>{this.renderFallback()}</Host>;
+      return <Host>{this.renderFallback(altText)}</Host>;
     }
 
-    const isDecorative = !this.alt || this.alt === '';
-
     return (
-      <Host class={hostClass}>
+      <Host>
         <div class={this.getContainerClasses()}>
           <img
+            {...this.inheritedAttributes}
             src={this.src}
-            alt={isDecorative ? '' : this.alt}
-            role={isDecorative ? 'presentation' : undefined}
-            aria-hidden={isDecorative ? 'true' : undefined}
+            alt={isDecorative ? '' : altText}
             class="modus-wc-image-img"
             onError={this.handleError}
             onLoad={this.handleLoad}
-            {...this.inheritedAttributes}
           />
         </div>
       </Host>

--- a/src/components/modus-wc-image/modus-wc-image.tsx
+++ b/src/components/modus-wc-image/modus-wc-image.tsx
@@ -48,8 +48,8 @@ export class ModusWcImage {
   /** Custom CSS class to apply to the component. */
   @Prop() customClass?: string = '';
 
-  @State() hasError: boolean = false;
-  @State() isLoaded: boolean = false;
+  @State() private hasError: boolean = false;
+  @State() private isLoaded: boolean = false;
 
   /** Event emitted when the image loads successfully. */
   @StencilEvent() imageLoad!: EventEmitter<Event>;
@@ -83,12 +83,12 @@ export class ModusWcImage {
     return classList.join(' ');
   }
 
-  handleError = (event: Event) => {
+  private handleError = (event: Event) => {
     this.hasError = true;
     this.imageError.emit(event);
   };
 
-  handleLoad = (event: Event) => {
+  private handleLoad = (event: Event) => {
     this.isLoaded = true;
     this.imageLoad.emit(event);
   };

--- a/src/components/modus-wc-image/modus-wc-image.tsx
+++ b/src/components/modus-wc-image/modus-wc-image.tsx
@@ -6,8 +6,8 @@ import {
   Host,
   Prop,
   State,
-  Watch,
   Event as StencilEvent,
+  Watch,
 } from '@stencil/core';
 import {
   convertPropsToClasses,
@@ -43,7 +43,7 @@ export class ModusWcImage {
   @Prop({ reflect: true }) shape?: ImageShape = 'square';
 
   /** Controls containment, cropping, and aspect ratio preservation. */
-  @Prop({ reflect: true }) fit?: ImageFit = 'cover';
+  @Prop({ reflect: true }) fit?: ImageFit = 'default';
 
   /** Custom CSS class to apply to the component. */
   @Prop() customClass?: string = '';

--- a/src/components/modus-wc-image/modus-wc-image.tsx
+++ b/src/components/modus-wc-image/modus-wc-image.tsx
@@ -1,0 +1,140 @@
+import {
+  Component,
+  Element,
+  EventEmitter,
+  h,
+  Host,
+  Prop,
+  State,
+  Watch,
+  Event as StencilEvent,
+} from '@stencil/core';
+import {
+  convertPropsToClasses,
+  ImageFit,
+  ImageShape,
+  ImageSize,
+} from './modus-wc-image.tailwind';
+import { handleShadowDOMStyles } from '../base-component';
+
+/**
+ * A resilient atomic image component that wraps native <img> tags with consistent sizing,
+ * aspect-ratio control, fallback error state, and full WCAG 2.1 AA accessibility support.
+ */
+@Component({
+  tag: 'modus-wc-image',
+  styleUrl: 'modus-wc-image.scss',
+  shadow: false,
+})
+export class ModusWcImage {
+  /** Reference to the host element */
+  @Element() el!: HTMLElement;
+
+  /** The source URL of the image asset. */
+  @Prop() src!: string;
+
+  /** Accessible text description. Omit or leave empty for decorative images. */
+  @Prop() alt?: string;
+
+  /** Determines dimensional size tokens. */
+  @Prop({ reflect: true }) size?: ImageSize = 'md';
+
+  /** Sets corner radius styling. */
+  @Prop({ reflect: true }) shape?: ImageShape = 'square';
+
+  /** Controls containment, cropping, and aspect ratio preservation. */
+  @Prop({ reflect: true }) fit?: ImageFit = 'cover';
+
+  /** Custom CSS class to apply to the component. */
+  @Prop() customClass?: string = '';
+
+  @State() hasError: boolean = false;
+  @State() isLoaded: boolean = false;
+
+  /** Event emitted when the image loads successfully. */
+  @StencilEvent() imageLoad!: EventEmitter<Event>;
+
+  /** Event emitted when the image fails to load. */
+  @StencilEvent() imageError!: EventEmitter<Event>;
+
+  @Watch('src')
+  onSrcChange() {
+    this.hasError = false;
+    this.isLoaded = false;
+  }
+
+  componentWillLoad() {
+    handleShadowDOMStyles(this.el);
+  }
+
+  private getContainerClasses(isErrorContainer = false): string {
+    const classList = ['modus-wc-image-container'];
+
+    const propClasses = convertPropsToClasses({
+      fit: this.fit,
+      shape: this.shape,
+      size: this.size,
+    });
+
+    if (propClasses) classList.push(propClasses);
+    if (isErrorContainer) classList.push('modus-wc-image--error');
+    else if (!this.isLoaded) classList.push('modus-wc-image--loading');
+
+    return classList.join(' ');
+  }
+
+  handleError = (event: Event) => {
+    this.hasError = true;
+    this.imageError.emit(event);
+  };
+
+  handleLoad = (event: Event) => {
+    this.isLoaded = true;
+    this.imageLoad.emit(event);
+  };
+
+  private renderFallback() {
+    const label = this.alt || 'Image unavailable';
+
+    return (
+      <div class={this.getContainerClasses(true)} role="img" aria-label={label}>
+        <div class="modus-wc-image-fallback">
+          {/* Material Design "broken_image" icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            class="modus-wc-image-fallback-icon"
+          >
+            <path d="M21 5v6.59l-3-3.01-4 4.01-4-4-4 4-3-3.01V5c0-1.1.9-2 2-2h14c1.1 0 2 .9 2 2zm-3 6.42 3 3.01V19c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2v-6.58l3 2.99 4-4 4 4 4-3.99z" />
+          </svg>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    if (this.hasError) {
+      return <Host class={this.customClass}>{this.renderFallback()}</Host>;
+    }
+
+    const isDecorative = !this.alt || this.alt.trim() === '';
+
+    return (
+      <Host class={this.customClass}>
+        <div class={this.getContainerClasses()}>
+          <img
+            src={this.src}
+            alt={isDecorative ? '' : this.alt}
+            role={isDecorative ? 'presentation' : undefined}
+            aria-hidden={isDecorative ? 'true' : undefined}
+            class="modus-wc-image-img"
+            onError={this.handleError}
+            onLoad={this.handleLoad}
+          />
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/components/modus-wc-image/modus-wc-image.tsx
+++ b/src/components/modus-wc-image/modus-wc-image.tsx
@@ -19,7 +19,7 @@ import { handleShadowDOMStyles } from '../base-component';
 
 /**
  * A resilient atomic image component that wraps native <img> tags with consistent sizing,
- * aspect-ratio control, fallback error state, and full WCAG 2.1 AA accessibility support.
+ * aspect-ratio control, fallback error state, and full WCAG 2.2 accessibility support.
  */
 @Component({
   tag: 'modus-wc-image',

--- a/src/components/modus-wc-image/modus-wc-image.tsx
+++ b/src/components/modus-wc-image/modus-wc-image.tsx
@@ -16,6 +16,7 @@ import {
   ImageSize,
 } from './modus-wc-image.tailwind';
 import { handleShadowDOMStyles } from '../base-component';
+import { Attributes, inheritAriaAttributes } from '../utils';
 
 /**
  * A resilient atomic image component that wraps native <img> tags with consistent sizing,
@@ -27,6 +28,8 @@ import { handleShadowDOMStyles } from '../base-component';
   shadow: false,
 })
 export class ModusWcImage {
+  private inheritedAttributes: Attributes = {};
+
   /** Reference to the host element */
   @Element() el!: HTMLElement;
 
@@ -37,13 +40,13 @@ export class ModusWcImage {
   @Prop() alt?: string;
 
   /** Determines dimensional size tokens. */
-  @Prop({ reflect: true }) size?: ImageSize = 'md';
+  @Prop() size?: ImageSize = 'md';
 
   /** Sets corner radius styling. */
-  @Prop({ reflect: true }) shape?: ImageShape = 'square';
+  @Prop() shape?: ImageShape = 'square';
 
   /** Controls containment, cropping, and aspect ratio preservation. */
-  @Prop({ reflect: true }) fit?: ImageFit = 'default';
+  @Prop() fit?: ImageFit = 'default';
 
   /** Custom CSS class to apply to the component. */
   @Prop() customClass?: string = '';
@@ -65,6 +68,7 @@ export class ModusWcImage {
 
   componentWillLoad() {
     handleShadowDOMStyles(this.el);
+    this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 
   private getContainerClasses(isErrorContainer = false): string {
@@ -99,30 +103,27 @@ export class ModusWcImage {
     return (
       <div class={this.getContainerClasses(true)} role="img" aria-label={label}>
         <div class="modus-wc-image-fallback">
-          {/* Material Design "broken_image" icon */}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            aria-hidden="true"
+          <modus-wc-icon
+            name="image_disabled"
+            decorative
             class="modus-wc-image-fallback-icon"
-          >
-            <path d="M21 5v6.59l-3-3.01-4 4.01-4-4-4 4-3-3.01V5c0-1.1.9-2 2-2h14c1.1 0 2 .9 2 2zm-3 6.42 3 3.01V19c0 1.1-.9 2-2 2H5c-1.1 0-2-.9-2-2v-6.58l3 2.99 4-4 4 4 4-3.99z" />
-          </svg>
+          />
         </div>
       </div>
     );
   }
 
   render() {
+    const hostClass = this.customClass || undefined;
+
     if (this.hasError) {
-      return <Host class={this.customClass}>{this.renderFallback()}</Host>;
+      return <Host class={hostClass}>{this.renderFallback()}</Host>;
     }
 
-    const isDecorative = !this.alt || this.alt.trim() === '';
+    const isDecorative = !this.alt || this.alt === '';
 
     return (
-      <Host class={this.customClass}>
+      <Host class={hostClass}>
         <div class={this.getContainerClasses()}>
           <img
             src={this.src}
@@ -132,6 +133,7 @@ export class ModusWcImage {
             class="modus-wc-image-img"
             onError={this.handleError}
             onLoad={this.handleLoad}
+            {...this.inheritedAttributes}
           />
         </div>
       </Host>

--- a/src/components/modus-wc-image/readme.md
+++ b/src/components/modus-wc-image/readme.md
@@ -1,0 +1,35 @@
+# modus-wc-image
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+A resilient atomic image component that wraps native <img> tags with consistent sizing,
+aspect-ratio control, fallback error state, and full WCAG 2.1 AA accessibility support.
+
+## Properties
+
+| Property           | Attribute      | Description                                                             | Type                                                          | Default     |
+| ------------------ | -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- | ----------- |
+| `alt`              | `alt`          | Accessible text description. Omit or leave empty for decorative images. | `string \| undefined`                                         | `undefined` |
+| `customClass`      | `custom-class` | Custom CSS class to apply to the component.                             | `string \| undefined`                                         | `''`        |
+| `fit`              | `fit`          | Controls containment, cropping, and aspect ratio preservation.          | `"contain" \| "cover" \| "none" \| "scale-down" \| undefined` | `'cover'`   |
+| `shape`            | `shape`        | Sets corner radius styling.                                             | `"rounded" \| "square" \| undefined`                          | `'square'`  |
+| `size`             | `size`         | Determines dimensional size tokens.                                     | `"lg" \| "md" \| "sm" \| "xl" \| undefined`                   | `'md'`      |
+| `src` _(required)_ | `src`          | The source URL of the image asset.                                      | `string`                                                      | `undefined` |
+
+
+## Events
+
+| Event        | Description                                      | Type                 |
+| ------------ | ------------------------------------------------ | -------------------- |
+| `imageError` | Event emitted when the image fails to load.      | `CustomEvent<Event>` |
+| `imageLoad`  | Event emitted when the image loads successfully. | `CustomEvent<Event>` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/modus-wc-image/readme.md
+++ b/src/components/modus-wc-image/readme.md
@@ -8,7 +8,7 @@
 ## Overview
 
 A resilient atomic image component that wraps native <img> tags with consistent sizing,
-aspect-ratio control, fallback error state, and full WCAG 2.1 AA accessibility support.
+aspect-ratio control, fallback error state, and full WCAG 2.2 accessibility support.
 
 ## Properties
 

--- a/src/components/modus-wc-image/readme.md
+++ b/src/components/modus-wc-image/readme.md
@@ -15,7 +15,7 @@ aspect-ratio control, fallback error state, and full WCAG 2.2 accessibility supp
 | Property           | Attribute      | Description                                                             | Type                                                            | Default     |
 | ------------------ | -------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------- | ----------- |
 | `alt`              | `alt`          | Accessible text description. Omit or leave empty for decorative images. | `string \| undefined`                                           | `undefined` |
-| `customClass`      | `custom-class` | Custom CSS class to apply to the component.                             | `string \| undefined`                                           | `''`        |
+| `customClass`      | `custom-class` | Custom CSS class to apply to the inner container.                       | `string \| undefined`                                           | `''`        |
 | `fit`              | `fit`          | Controls containment, cropping, and aspect ratio preservation.          | `"contain" \| "default" \| "none" \| "scale-down" \| undefined` | `'default'` |
 | `shape`            | `shape`        | Sets corner radius styling.                                             | `"rounded" \| "square" \| undefined`                            | `'square'`  |
 | `size`             | `size`         | Determines dimensional size tokens.                                     | `"lg" \| "md" \| "sm" \| "xl" \| undefined`                     | `'md'`      |

--- a/src/components/modus-wc-image/readme.md
+++ b/src/components/modus-wc-image/readme.md
@@ -30,6 +30,19 @@ aspect-ratio control, fallback error state, and full WCAG 2.2 accessibility supp
 | `imageLoad`  | Event emitted when the image loads successfully. | `CustomEvent<Event>` |
 
 
+## Dependencies
+
+### Depends on
+
+- [modus-wc-icon](../modus-wc-icon)
+
+### Graph
+```mermaid
+graph TD;
+  modus-wc-image --> modus-wc-icon
+  style modus-wc-image fill:#f9f,stroke:#333,stroke-width:4px
+```
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/modus-wc-image/readme.md
+++ b/src/components/modus-wc-image/readme.md
@@ -12,14 +12,14 @@ aspect-ratio control, fallback error state, and full WCAG 2.1 AA accessibility s
 
 ## Properties
 
-| Property           | Attribute      | Description                                                             | Type                                                          | Default     |
-| ------------------ | -------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------- | ----------- |
-| `alt`              | `alt`          | Accessible text description. Omit or leave empty for decorative images. | `string \| undefined`                                         | `undefined` |
-| `customClass`      | `custom-class` | Custom CSS class to apply to the component.                             | `string \| undefined`                                         | `''`        |
-| `fit`              | `fit`          | Controls containment, cropping, and aspect ratio preservation.          | `"contain" \| "cover" \| "none" \| "scale-down" \| undefined` | `'cover'`   |
-| `shape`            | `shape`        | Sets corner radius styling.                                             | `"rounded" \| "square" \| undefined`                          | `'square'`  |
-| `size`             | `size`         | Determines dimensional size tokens.                                     | `"lg" \| "md" \| "sm" \| "xl" \| undefined`                   | `'md'`      |
-| `src` _(required)_ | `src`          | The source URL of the image asset.                                      | `string`                                                      | `undefined` |
+| Property           | Attribute      | Description                                                             | Type                                                            | Default     |
+| ------------------ | -------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------- | ----------- |
+| `alt`              | `alt`          | Accessible text description. Omit or leave empty for decorative images. | `string \| undefined`                                           | `undefined` |
+| `customClass`      | `custom-class` | Custom CSS class to apply to the component.                             | `string \| undefined`                                           | `''`        |
+| `fit`              | `fit`          | Controls containment, cropping, and aspect ratio preservation.          | `"contain" \| "default" \| "none" \| "scale-down" \| undefined` | `'default'` |
+| `shape`            | `shape`        | Sets corner radius styling.                                             | `"rounded" \| "square" \| undefined`                            | `'square'`  |
+| `size`             | `size`         | Determines dimensional size tokens.                                     | `"lg" \| "md" \| "sm" \| "xl" \| undefined`                     | `'md'`      |
+| `src` _(required)_ | `src`          | The source URL of the image asset.                                      | `string`                                                        | `undefined` |
 
 
 ## Events


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Adding a new Image Component to the library withthe below features

4 fit modes — default, contain, scale-down, none
4 size tokens — sm (128×128), md (288×192), lg (384×256), xl (1486×384)
2 shape variants — square (0 border-radius), rounded (16 px border-radius)
Error fallback — broken-image SVG placeholder rendered when the image URL fails
Loading state — placeholder background prevents layout flash before the image resolves
Accessibility — meaningful images pass [alt](vscode-file://vscode-app/c:/Users/kavins/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to the native [<img>](vscode-file://vscode-app/c:/Users/kavins/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html); decorative images (empty/omitted [alt](vscode-file://vscode-app/c:/Users/kavins/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) automatically receive [role="presentation"](vscode-file://vscode-app/c:/Users/kavins/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and aria-hidden="true"; fallback container exposes [role="img"](vscode-file://vscode-app/c:/Users/kavins/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with [aria-label](vscode-file://vscode-app/c:/Users/kavins/AppData/Local/Programs/Microsoft%20VS%20Code/cfbea10c5f/resources/app/out/vs/code/electron-browser/workbench/workbench.html)


### :thought_balloon: Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue #1437
