### PR TITLE
QA routing, graph impact, and graded verdicts

### DIFF
--- a/.cursor/rules/automation.mdc
+++ b/.cursor/rules/automation.mdc
@@ -4,29 +4,77 @@ alwaysApply: true
 
 # Cursor automations
 
-Follow this file on every Dev / QA / Fix / `/ask` / `/refine` run. Do not skip it.
+Follow this file on every Dev / QA / `/ask` / `/refine` run. Do not skip it.
 
 ## QA labels
 
 GitHub MCP **cannot** add, remove, or create labels on `trimble-oss/modus-wc-2.0` (403). Do not run `gh label create`. These labels already exist: `qa-skip`, `qa-full`, `qa-rerun`, `qa-failed`, `needs-human`.
 
-Workflow [`.github/workflows/automation-label-router.yml`](../../.github/workflows/automation-label-router.yml) attaches them when **you** (`ElishaSamPeterPrabhu`) or `cursor[bot]` post one of these **exact lines** on the PR (conversation comment **or** review body):
+Workflow [`.github/workflows/automation-label-router.yml`](../../.github/workflows/automation-label-router.yml) attaches them when **you** (`ElishaSamPeterPrabhu`) or `cursor[bot]` post one of these **exact lines** on the PR.
 
-| Comment | Label |
+**Canonical surface: PR conversation comment** (GitHub MCP `add_issue_comment` on the PR). Review bodies are a fallback. On 2026-08-31 a Dev `QA-rerun: add` **review** on #1417 (13:14 UTC) produced no Action run; conversation comments have always fired.
+
+| Comment first line | Label |
 |---------|--------|
-| `Routing: qa-full` | `qa-full` (removes `qa-skip`, then delete+add `qa-full`) |
-| `Routing: qa-skip` | `qa-skip` (removes `qa-full`, then delete+add `qa-skip`) |
-| `QA-rerun: add` or `Routing: qa-rerun` | `qa-rerun` (delete then add even if already present) |
-| `## QA FAILED` | `qa-failed` (delete then add) |
-| `## NEED CLARIFICATION` or `## NOT FEASIBLE` | `needs-human` (delete then add) |
+| `Routing: qa-full` | `qa-full` (removes `qa-skip`, then pulse `qa-full`) |
+| `Routing: qa-skip` | `qa-skip` (removes `qa-full`, then pulse `qa-skip`) |
+| `QA-rerun: add` or `Routing: qa-rerun` | `qa-rerun` (pulse even if already present) |
+| `## QA FAILED` (including `— visual` / `— functional`) | `qa-failed` (pulse) |
+| `## QA PASSED WITH CONCERNS` | `needs-human` (pulse) |
+| `## QA BLOCKED` | `needs-human` (pulse) |
+| `## NEED CLARIFICATION` or `## NOT FEASIBLE` | `needs-human` (pulse) |
 
-The Action **always removes then re-adds** the target label. Cursor Automations only wake on a new `labeled` event; adding a label that is already on the PR is a no-op.
-
-Prefer a **PR conversation comment** for routing lines. Review bodies also work after the Action listens to `pull_request_review`.
+The Action **always removes then re-adds** the target label. Cursor Automations only wake on a new `labeled` event.
 
 Do **not** claim you attached the label. If it is missing after about one minute, ask the human once to add the existing name. Do not retry GitHub MCP.
 
 QA/Dev still wake on **label added**, not on the comment itself.
+
+## Routing block (Dev posts as a conversation comment)
+
+```
+Routing: qa-skip | qa-full
+QA-depth: none | visual-slice | functional | composition
+QA-scope: <component tags>
+QA-themes: modern-only | classic-only | both | n/a
+QA-assert: <what must hold>
+QA-source: <Figma or issue-screenshot URL> | none
+QA-verify: 1) <state × size × theme> 2) …
+QA-graph: none | tag → dependents
+```
+
+- `QA-source`: new feature or new variant **must** be a URL, not `none`. Existing component with `none` → QA compares Storybook to **main**.
+- `QA-verify`: numbered scenarios QA must execute. Include hover/disabled/pressed when those states exist.
+- `QA-graph`: fill from [`docs/component-graph/component-graph.json`](../../docs/component-graph/component-graph.json) `reverseImpact[<changed tag>]` (runtime edges only, depth 1). Empty array → `none`. Do not invent neighbors from memory.
+
+After `/refine` or a `qa-failed` repair, conversation-comment `QA-rerun: add` plus an updated routing block.
+
+## QA evidence and verdicts
+
+QA is a senior design-system reviewer. npm/lint/test is a **gate**, never a **verdict**. `## QA PASSED` requires visual evidence whenever the diff touches `.scss`, `.tailwind.ts`, component source, or stories.
+
+Source of truth:
+
+- New feature / new variant → compare Storybook to `QA-source`. Missing source → `## QA BLOCKED`.
+- Existing + source given → compare to source.
+- Existing + `QA-source: none` → screenshot the same states on **main**, then on the PR branch.
+
+Impact: trust `reverseImpact` over Dev's `QA-graph` if they disagree; note the mismatch. Cap: QA-scope ∪ dependents, max 3 browser targets unless human AC names more.
+
+A `/refine` screenshot of broken UI is failing evidence until that state is shown fixed.
+
+Overall comment **first heading** (one of):
+
+| Header | Meaning | Label |
+|--------|---------|--------|
+| `## QA PASSED` | All dimensions pass; every declared scenario has a screenshot | none |
+| `## QA PASSED WITH CONCERNS` | Ships-safe; named issues | `needs-human` |
+| `## QA FAILED — visual` | Gate green; Storybook scenario failed (screenshot pair required) | `qa-failed` |
+| `## QA FAILED — functional` | Gate/tests failed; visual = not-evaluated | `qa-failed` |
+| `## QA BLOCKED` | Cannot verify (env, missing source, main Storybook down) | `needs-human` |
+| `## QA SKIPPED` | Copy/docs only | none |
+
+Per-scenario states: `pass` | `fail` | `not-evaluated` | `blocked`. Never mark a scenario pass without evidence.
 
 ## PR evidence images
 
@@ -38,8 +86,15 @@ When posting screenshots or other visual evidence on a PR (for `/ask`, `/refine`
 
 ## Reply surface
 
-(Fill later.)
+- `/approve` on an issue → implement, open PR, subscribe to that PR's comments/reviews from the human.
+- `/ask` / `/clarify` → reply on the same surface (PR if a PR exists). No patch.
+- `/refine` → patch the same branch; conversation-comment routing + `QA-rerun: add`.
+- QA → label-added only (`qa-full`, `qa-rerun`, `qa-skip`). No PR-opened trigger.
 
 ## Slash commands
 
-(Fill later.)
+| Command | Surface | Effect |
+|---------|---------|--------|
+| `/approve` | issue | start work |
+| `/ask` `/clarify` | issue or PR | Q&A only |
+| `/refine` | PR conversation or inline review | patch + QA-rerun comment |

--- a/.github/workflows/automation-label-router.yml
+++ b/.github/workflows/automation-label-router.yml
@@ -85,7 +85,7 @@ jobs:
             matched=1
           fi
 
-          if grep -qE '^##[[:space:]]*(NEED CLARIFICATION|NOT FEASIBLE)' <<<"${COMMENT_BODY}"; then
+          if grep -qE '^##[[:space:]]*(QA PASSED WITH CONCERNS|QA BLOCKED|NEED CLARIFICATION|NOT FEASIBLE)' <<<"${COMMENT_BODY}"; then
             pulse_label needs-human
             matched=1
           fi


### PR DESCRIPTION
## Summary
- Documents the Dev routing block (`QA-source`, `QA-verify`, `QA-graph` from `docs/component-graph/component-graph.json` `reverseImpact`).
- Canonical routing surface is a **PR conversation comment** (`QA-rerun: add`). Review bodies remain a fallback after one missed `pull_request_review` event on #1417 (13:14 UTC).
- QA must visually verify against Figma/issue source or a main-branch Storybook baseline. npm green is a gate, not a pass.
- Router: `## QA PASSED WITH CONCERNS` and `## QA BLOCKED` pulse `needs-human`. `## QA FAILED — visual|functional` already matches `^## QA FAILED`.

## Test plan
- [ ] Merge, then post a conversation comment `## QA BLOCKED` on a test PR and confirm `needs-human` is pulsed.
- [ ] Confirm `## QA FAILED — visual` still pulses `qa-failed`.
- [ ] After merge, replace live Dev/QA instruction boxes from the research-repo pastes.


Made with [Cursor](https://cursor.com)