### PR TITLE
Fix npm publish 404 after setup-node v7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,12 @@ permissions:
 jobs:
   build-and-publish-wc:
     runs-on: ubuntu-latest
+    # setup-node v7 with registry-url writes
+    # //registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN} and no longer exports a
+    # dummy NODE_AUTH_TOKEN. Without this env, npm publish sends an empty token
+    # and npmjs.org returns a misleading 404 on PUT for scoped packages.
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -92,7 +98,12 @@ jobs:
         run: npm run build:ci
 
       - name: Set npm Registry Auth Token
-        run: npm set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN secret is empty; cannot publish to npmjs.org." >&2
+            exit 1
+          fi
+          npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
 
       - name: Pack the package
         working-directory: dist
@@ -109,7 +120,7 @@ jobs:
 
       - name: Publish npm Package Publicly
         working-directory: dist
-        run: npm publish --registry=https://registry.npmjs.org
+        run: npm publish --access public --registry=https://registry.npmjs.org
 
       - name: Set GitHub Registry Auth Token
         working-directory: dist


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### :page_facing_up: Summary of Changes

`Publish & Release` failed for `@trimble-oss/moduswebcomponents@1.16.0` with a misleading npm `E404` on `PUT https://registry.npmjs.org/@trimble-oss%2fmoduswebcomponents`. The package already exists on npm (latest `1.15.1`); npm returns 404 when publish auth is empty or rejected.

Root cause: Dependabot PR #1443 bumped `actions/setup-node` v6 → v7. With `registry-url` set, setup-node writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `$RUNNER_TEMP/.npmrc`. v6 also exported a dummy `NODE_AUTH_TOKEN`; v7 stopped doing that (`Remove dummy NODE_AUTH_TOKEN export`). The 1.15.1 run still had `NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX` in the job env; the 1.16.0 run did not, so npm sent an empty token.

This PR wires `secrets.NPM_TOKEN` into `NODE_AUTH_TOKEN` for the publish job, fail-fasts if the secret is empty, and writes the token via `npm config set` from that env var.

After this lands on `main`, re-run **Publish & Release** with `1.16.0`.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

- Compared GitHub Actions logs: successful 1.15.1 publish (run `32390012632`) vs failed 1.16.0 publish (run `33530684540`).
- Confirmed npm registry has `@trimble-oss/moduswebcomponents@1.15.1`; the 404 is not a missing package name.
- Reproduced setup-node v7 `.npmrc` placeholder locally (`${NODE_AUTH_TOKEN}` with the env unset).
- YAML contains job-level `NODE_AUTH_TOKEN` and an empty-secret fail-fast.
- Cannot actually publish from this environment (no `NPM_TOKEN`). Merge to `main` and re-run the workflow to confirm.

### :white_check_mark: Self Code Review Checklist

- [x] My code is clean and readable
- [x] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Issue # (publish workflow run 33530684540, 2026-09-01)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2db4144-5180-479e-ac3f-e248e916b7a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2db4144-5180-479e-ac3f-e248e916b7a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

