### PR TITLE
chore(pr): Use Closes # in the pull request template

### DIFF
--- a/.cursor/rules/automation.mdc
+++ b/.cursor/rules/automation.mdc
@@ -157,6 +157,10 @@ If the fix breaks the UI, explain the root cause in the PR comment. Do not claim
 - `/refine` → patch the same branch; conversation-comment routing + `QA-rerun: add`.
 - QA → label-added only (`qa-full`, `qa-rerun`, `qa-skip`). No PR-opened trigger.
 
+## PR Work Item
+
+When opening a PR from `/approve`, fill `.github/pull_request_template.md` Work Item as `Closes #<issue-number>` (GitHub closing keyword). Do not write `Issue #<n>` — that does not close the issue on merge.
+
 ## Slash commands
 
 | Command | Surface | Effect |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,4 @@ PR authors and reviewers, please verify that all of these items have been comple
 
 ### :link: Work Item
 
-Issue #
+Closes #


### PR DESCRIPTION
### Summary of Changes

The PR template Work Item stub was `Issue #`, which does **not** auto-close the linked GitHub issue on merge. Future PRs (including Dev `/approve`) should use a [closing keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).

This does **not** rewrite existing PRs (e.g. #1457).

### Type of Change

- [x] Documentation change

### Test Plan

- Open a new PR after merge: Work Item placeholder is `Closes #`.
- Confirm GitHub still auto-links when the number is filled (`Closes #1234`).

### Work Item

No issue — template/docs only.
