### PR TITLE
fix: prevent tooltip opening from mouse clicks

### DIFF
--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
@@ -1526,6 +1526,22 @@ describe('modus-wc-tooltip', () => {
       expect(page.rootInstance.isVisible).toBe(true);
     });
 
+    it('should use pointerenter touch type to skip hover show delay', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test" show-delay="200"><button>Trigger</button></modus-wc-tooltip>',
+      });
+
+      coldPage();
+
+      const pointerEnter = new MouseEvent('pointerenter', { bubbles: true });
+      Object.defineProperty(pointerEnter, 'pointerType', { value: 'touch' });
+      page.root?.dispatchEvent(pointerEnter);
+      page.root?.dispatchEvent(new MouseEvent('mouseenter'));
+
+      expect(page.rootInstance.isVisible).toBe(true);
+    });
+
     it('should not show when a mouse click focuses the trigger', async () => {
       const page = await newSpecPage({
         components: [ModusWcTooltip],
@@ -1539,6 +1555,38 @@ describe('modus-wc-tooltip', () => {
       trigger?.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 
       expect(page.rootInstance.isVisible).toBe(false);
+    });
+
+    it('should show on focus after mouse pointerup clears suppression', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test"><button>Trigger</button></modus-wc-tooltip>',
+      });
+      const trigger = page.root?.querySelector('button');
+
+      const pointerDown = new MouseEvent('pointerdown', { bubbles: true });
+      Object.defineProperty(pointerDown, 'pointerType', { value: 'mouse' });
+      trigger?.dispatchEvent(pointerDown);
+      trigger?.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }));
+      trigger?.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+      expect(page.rootInstance.isVisible).toBe(true);
+    });
+
+    it('should show on focus after pointercancel clears suppression', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test"><button>Trigger</button></modus-wc-tooltip>',
+      });
+      const trigger = page.root?.querySelector('button');
+
+      const pointerDown = new MouseEvent('pointerdown', { bubbles: true });
+      Object.defineProperty(pointerDown, 'pointerType', { value: 'mouse' });
+      trigger?.dispatchEvent(pointerDown);
+      trigger?.dispatchEvent(new MouseEvent('pointercancel', { bubbles: true }));
+      trigger?.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+      expect(page.rootInstance.isVisible).toBe(true);
     });
 
     it('should reopen on touch after Escape dismisses the tooltip', async () => {

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
@@ -1519,12 +1519,41 @@ describe('modus-wc-tooltip', () => {
 
       coldPage();
 
-      // A tap fires pointerenter (pointerType: touch) before the emulated mouseenter
-      const pointerEnter = new MouseEvent('pointerenter');
-      Object.defineProperty(pointerEnter, 'pointerType', { value: 'touch' });
-      page.root?.dispatchEvent(pointerEnter);
-      page.root?.dispatchEvent(new MouseEvent('mouseenter'));
+      const pointerDown = new MouseEvent('pointerdown', { bubbles: true });
+      Object.defineProperty(pointerDown, 'pointerType', { value: 'touch' });
+      page.root?.dispatchEvent(pointerDown);
 
+      expect(page.rootInstance.isVisible).toBe(true);
+    });
+
+    it('should not show when a mouse click focuses the trigger', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test"><button>Trigger</button></modus-wc-tooltip>',
+      });
+      const trigger = page.root?.querySelector('button');
+
+      const pointerDown = new MouseEvent('pointerdown', { bubbles: true });
+      Object.defineProperty(pointerDown, 'pointerType', { value: 'mouse' });
+      trigger?.dispatchEvent(pointerDown);
+      trigger?.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+
+      expect(page.rootInstance.isVisible).toBe(false);
+    });
+
+    it('should reopen on touch after Escape dismisses the tooltip', async () => {
+      const page = await newSpecPage({
+        components: [ModusWcTooltip],
+        html: '<modus-wc-tooltip content="Test"><button>Trigger</button></modus-wc-tooltip>',
+      });
+
+      const pointerDown = new MouseEvent('pointerdown');
+      Object.defineProperty(pointerDown, 'pointerType', { value: 'touch' });
+      page.root?.dispatchEvent(pointerDown);
+      document.dispatchEvent(new KeyboardEvent('keyup', { code: 'Escape' }));
+      expect(page.rootInstance.isVisible).toBe(false);
+
+      page.root?.dispatchEvent(pointerDown);
       expect(page.rootInstance.isVisible).toBe(true);
     });
 

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts
@@ -1583,7 +1583,9 @@ describe('modus-wc-tooltip', () => {
       const pointerDown = new MouseEvent('pointerdown', { bubbles: true });
       Object.defineProperty(pointerDown, 'pointerType', { value: 'mouse' });
       trigger?.dispatchEvent(pointerDown);
-      trigger?.dispatchEvent(new MouseEvent('pointercancel', { bubbles: true }));
+      trigger?.dispatchEvent(
+        new MouseEvent('pointercancel', { bubbles: true })
+      );
       trigger?.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
 
       expect(page.rootInstance.isVisible).toBe(true);

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
@@ -48,6 +48,7 @@ export class ModusWcTooltip {
   private isFocused = false;
   private showDelayTimer?: ReturnType<typeof setTimeout>;
   private lastPointerType = '';
+  private suppressNextFocus = false;
 
   /** Reference to the host element */
   @Element() el!: HTMLElement;
@@ -390,11 +391,23 @@ export class ModusWcTooltip {
   @Listen('pointerdown')
   handlePointerDown(event: PointerEvent) {
     this.lastPointerType = event.pointerType;
+    this.suppressNextFocus = event.pointerType === 'mouse';
 
     if (event.pointerType === 'touch') {
+      this.escapeDismissed = false;
       this.isHovered = true;
       this.showTooltip();
     }
+  }
+
+  @Listen('pointerup')
+  handlePointerUp() {
+    this.suppressNextFocus = false;
+  }
+
+  @Listen('pointercancel')
+  handlePointerCancel() {
+    this.suppressNextFocus = false;
   }
 
   @Listen('pointerenter')
@@ -417,14 +430,9 @@ export class ModusWcTooltip {
   }
 
   @Listen('focusin')
-  handleFocusIn(event: FocusEvent) {
-    const target = event.target as HTMLElement | null;
-    const isFocusVisible =
-      target === this.el || target?.matches?.(':focus-visible');
-
-    // A mouse click may focus the trigger, but should not open the tooltip.
-    // Keyboard focus still opens it through :focus-visible.
-    if (this.lastPointerType === 'mouse' && !isFocusVisible) {
+  handleFocusIn() {
+    if (this.suppressNextFocus) {
+      this.suppressNextFocus = false;
       return;
     }
 

--- a/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
+++ b/src/components/modus-wc-tooltip/modus-wc-tooltip.tsx
@@ -387,6 +387,16 @@ export class ModusWcTooltip {
   }
 
   /** Fires before the emulated mouseenter on touch, so mouseenter knows its source. */
+  @Listen('pointerdown')
+  handlePointerDown(event: PointerEvent) {
+    this.lastPointerType = event.pointerType;
+
+    if (event.pointerType === 'touch') {
+      this.isHovered = true;
+      this.showTooltip();
+    }
+  }
+
   @Listen('pointerenter')
   handlePointerEnter(event: PointerEvent) {
     this.lastPointerType = event.pointerType;
@@ -407,7 +417,17 @@ export class ModusWcTooltip {
   }
 
   @Listen('focusin')
-  handleFocusIn() {
+  handleFocusIn(event: FocusEvent) {
+    const target = event.target as HTMLElement | null;
+    const isFocusVisible =
+      target === this.el || target?.matches?.(':focus-visible');
+
+    // A mouse click may focus the trigger, but should not open the tooltip.
+    // Keyboard focus still opens it through :focus-visible.
+    if (this.lastPointerType === 'mouse' && !isFocusVisible) {
+      return;
+    }
+
     // Focus shows immediately; drop any pending hover show so it can't re-fire
     clearTimeout(this.showDelayTimer);
     this.escapeDismissed = false;


### PR DESCRIPTION
### :page_facing_up: Summary of Changes

Prevents `modus-wc-tooltip` from opening when a trigger is focused by a mouse click while preserving touch and keyboard-focus behavior.

- Tracks pointer input on `pointerdown`.
- Opens the tooltip immediately for touch input.
- Ignores focus caused by mouse clicks with `suppressNextFocus `.
- Preserves existing hover behavior.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

- Tooltip test suite passes: `npm test -- --runInBand src/components/modus-wc-tooltip/modus-wc-tooltip.spec.ts`
- No linter errors in the changed component.
- Existing unrelated working-tree changes were excluded from this PR.

### :white_check_mark: Self Code Review Checklist

- [x] My code is clean and readable
- [x] I followed standard conventions
- [x] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Closes #1487