### PR TITLE
Form components: Fix default aria-label overriding visible label on form controls

### DIFF
--- a/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
+++ b/src/components/modus-wc-autocomplete/__snapshots__/modus-wc-autocomplete.spec.ts.snap
@@ -531,7 +531,7 @@ exports[`modus-wc-autocomplete should render with default props 1`] = `
   <modus-wc-text-input inputmode="text" value="">
     <!---->
     <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-      <input aria-label="Default autocomplete" class="modus-wc-grow" id="mwc_id_0" placeholder="" type="text" value="">
+      <input class="modus-wc-grow" id="mwc_id_0" placeholder="" type="text" value="">
     </label>
   </modus-wc-text-input>
 </modus-wc-autocomplete>

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.spec.ts
@@ -24,7 +24,7 @@ describe('modus-wc-autocomplete', () => {
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcAutocomplete, ModusWcMenu, ModusWcTextInput],
-      html: '<modus-wc-autocomplete aria-label="Default autocomplete"></modus-wc-autocomplete>',
+      html: '<modus-wc-autocomplete></modus-wc-autocomplete>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -37,10 +37,15 @@ describe('modus-wc-autocomplete', () => {
         ModusWcTextInput,
         ModusWcInputLabel,
       ],
-      html: '<modus-wc-autocomplete label="Search" aria-label="Search"></modus-wc-autocomplete>',
+      html: '<modus-wc-autocomplete label="Search"></modus-wc-autocomplete>',
     });
 
     expectLabelLinkedToControl(page.root!, 'modus-wc-text-input input');
+
+    const input = page.root!.querySelector(
+      'modus-wc-text-input input'
+    ) as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should render with custom props', async () => {

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -489,7 +489,6 @@ export const WithCustomIconSlot: Story = {
   }
 </style>
 <modus-wc-autocomplete
-  aria-label="Autocomplete with custom icon"
   ?bordered=${args.bordered}
   custom-class=${ifDefined(args['custom-class'])}
   debounce-ms=${ifDefined(args['debounce-ms'])}
@@ -526,6 +525,7 @@ ${Items}
 </script>
   `,
   args: {
+    label: 'Autocomplete with custom icon',
     placeholder: 'Search fruits...',
   },
 };
@@ -538,7 +538,6 @@ export const WithFeedback: Story = {
       }
     </style>
     <modus-wc-autocomplete
-      aria-label="Fruit autocomplete with feedback"
       ?bordered=${args.bordered}
       .items=${args.items}
       .feedback=${args.feedback}
@@ -559,7 +558,6 @@ export const WithFeedback: Story = {
       source: {
         code: `
 <modus-wc-autocomplete
-  aria-label="Fruit autocomplete with feedback"
   label="With Feedback"
   required
 ></modus-wc-autocomplete>
@@ -633,7 +631,7 @@ const tooltipItems = [
 ];
 </script>
 <modus-wc-autocomplete
-  aria-label="Fruits with tooltips"
+  label="Fruits with tooltips"
   leave-menu-open="true"
   placeholder="Search fruits"
   min-chars="0"
@@ -699,7 +697,7 @@ const tooltipItems = [
       </style>
       <div style="width: 300px;">
         <modus-wc-autocomplete
-          aria-label="Fruits with tooltips"
+          label="Fruits with tooltips"
           leave-menu-open="true"
           placeholder="Search fruits"
           .items=${tooltipItems}
@@ -734,7 +732,6 @@ export const MultiSelect: Story = {
         }
       </style>
       <modus-wc-autocomplete
-        aria-label="Fruit autocomplete"
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
         debounce-ms=${ifDefined(args['debounce-ms'])}
@@ -829,7 +826,6 @@ export const WithSpinner: Story = {
         }
       </style>
       <modus-wc-autocomplete
-        aria-label="Fruit autocomplete with spinner"
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
         debounce-ms=${ifDefined(args['debounce-ms'])}
@@ -1134,7 +1130,6 @@ modus-wc-menu-item.hidden {
 
 </style>
 <modus-wc-autocomplete
-  aria-label="Custom menu items example"
   ?bordered=${args.bordered}
   custom-class=${ifDefined(args['custom-class'])}
   debounce-ms=${ifDefined(args['debounce-ms'])}
@@ -1580,7 +1575,6 @@ export const CustomEventHandlers: Story = {
       </style>
 
       <modus-wc-autocomplete
-        aria-label="Custom handlers autocomplete"
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
         debounce-ms=${0}
@@ -2045,7 +2039,6 @@ export const WithProgrammaticControl: Story = {
       </modus-wc-card>
       <modus-wc-autocomplete
         id="programmatic-autocomplete"
-        aria-label="Programmatic control demo"
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
         debounce-ms=${ifDefined(args['debounce-ms'])}
@@ -2293,7 +2286,6 @@ export const DynamicOptions: Story = {
         }
       </style>
       <modus-wc-autocomplete
-        aria-label="Dynamic fruits autocomplete"
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
         debounce-ms=${ifDefined(args['debounce-ms'])}

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.stories.ts
@@ -439,7 +439,6 @@ const Template: Story = {
   }
 </style>
 <modus-wc-autocomplete
-  aria-label="Fruit autocomplete"
   auto-complete=${ifDefined(args['auto-complete'])}
   ?bordered=${args.bordered}
   custom-class=${ifDefined(args['custom-class'])}

--- a/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
+++ b/src/components/modus-wc-autocomplete/modus-wc-autocomplete.tsx
@@ -259,10 +259,6 @@ export class ModusWcAutocomplete {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Autocomplete input';
-    }
-
     this.inheritedAttributes = inheritAriaAttributes(this.el);
     document.addEventListener('click', this.handleOutsideClick);
 

--- a/src/components/modus-wc-checkbox/__snapshots__/modus-wc-checkbox.spec.ts.snap
+++ b/src/components/modus-wc-checkbox/__snapshots__/modus-wc-checkbox.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`modus-wc-checkbox renders with default props 1`] = `
 <modus-wc-checkbox class="modus-wc-checkbox-host">
-  <input aria-label="Default checkbox" class="modus-wc-checkbox modus-wc-checkbox-md" id="mwc_id_0" type="checkbox">
+  <input class="modus-wc-checkbox modus-wc-checkbox-md" id="mwc_id_0" type="checkbox">
 </modus-wc-checkbox>
 `;
 

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.spec.ts
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.spec.ts
@@ -7,7 +7,7 @@ describe('modus-wc-checkbox', () => {
   it('renders with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcCheckbox],
-      html: '<modus-wc-checkbox aria-label="Default checkbox"></modus-wc-checkbox>',
+      html: '<modus-wc-checkbox></modus-wc-checkbox>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -36,10 +36,15 @@ describe('modus-wc-checkbox', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcCheckbox, ModusWcInputLabel],
-      html: '<modus-wc-checkbox label="Email alerts" aria-label="Email alerts"></modus-wc-checkbox>',
+      html: '<modus-wc-checkbox label="Email alerts"></modus-wc-checkbox>',
     });
 
     expectLabelLinkedToControl(page.root!, 'input[type="checkbox"]');
+
+    const input = page.root!.querySelector(
+      'input[type="checkbox"]'
+    ) as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should retain the same generated id across re-renders', async () => {

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.stories.ts
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.stories.ts
@@ -53,7 +53,6 @@ export const Default: Story = {
   render: (args) => {
     return html`
       <modus-wc-checkbox
-        aria-label="Checkbox"
         custom-class=${ifDefined(args['custom-class'])}
         ?disabled=${args.disabled}
         .indeterminate=${args.indeterminate}

--- a/src/components/modus-wc-checkbox/modus-wc-checkbox.tsx
+++ b/src/components/modus-wc-checkbox/modus-wc-checkbox.tsx
@@ -83,10 +83,6 @@ export class ModusWcCheckbox {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Checkbox';
-    }
-
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
+++ b/src/components/modus-wc-date/__snapshots__/modus-wc-date.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modus-wc-date renders with default props 1`] = `
 <modus-wc-date end-value="" format="dd/mm/yyyy" value="">
   <div class="date-input-container">
-    <input aria-label="Default date" class="modus-wc-date-input modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" id="mwc_id_0" placeholder="dd/mm/yyyy" type="text" value="">
+    <input class="modus-wc-date-input modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-w-full" id="mwc_id_0" placeholder="dd/mm/yyyy" type="text" value="">
     <modus-wc-button aria-label="Open calendar" class="calendar-icon-button" color="tertiary" shape="circle" size="xs" variant="borderless">
       <modus-wc-icon name="calendar_blank" size="sm"></modus-wc-icon>
     </modus-wc-button>

--- a/src/components/modus-wc-date/modus-wc-date.spec.ts
+++ b/src/components/modus-wc-date/modus-wc-date.spec.ts
@@ -18,6 +18,7 @@ import {
   shouldApplyRangeCapLeft,
   shouldApplyRangeCapRight,
 } from './utils/range-utils';
+import { resolveReferencedAriaText } from './utils/resolve-referenced-aria-text';
 
 async function createDatePage(html: string) {
   const page = await newSpecPage({
@@ -4793,6 +4794,29 @@ describe('modus-wc-date', () => {
         expect(inputs[1].getAttribute('aria-label')).toBe('Trip dates end');
       });
 
+      it('should derive the end input accessible name from aria-labelledby', async () => {
+        const page = await newSpecPage({
+          components: [ModusWcDate],
+          html: `
+            <span id="trip-range-label">Trip dates</span>
+            <modus-wc-date type="range" aria-labelledby="trip-range-label"></modus-wc-date>
+          `,
+        });
+        const inputs = page.root!.querySelectorAll('input');
+
+        expect(inputs[1].getAttribute('aria-label')).toBe('Trip dates end');
+      });
+
+      it('should leave the end input without an accessible name when aria-labelledby references are missing', async () => {
+        const page = await newSpecPage({
+          components: [ModusWcDate],
+          html: '<modus-wc-date type="range" aria-labelledby="missing-label-id"></modus-wc-date>',
+        });
+        const endInput = page.root!.querySelectorAll('input')[1];
+
+        expect(endInput.hasAttribute('aria-label')).toBe(false);
+      });
+
       it('should leave the end input without an accessible name when neither aria-label nor label is provided', async () => {
         const page = await newSpecPage({
           components: [ModusWcDate],
@@ -5913,5 +5937,75 @@ describe('modus-wc-date', () => {
     expect(
       page.root!.querySelector('.calendar-container.dynamic-height')
     ).not.toBeNull();
+  });
+});
+
+describe('resolveReferencedAriaText', () => {
+  it('should resolve label text from a document context', () => {
+    const label = document.createElement('span');
+    label.id = 'doc-context-label';
+    label.textContent = 'Trip dates';
+    document.body.appendChild(label);
+
+    expect(resolveReferencedAriaText(document, 'doc-context-label')).toBe(
+      'Trip dates'
+    );
+
+    document.body.removeChild(label);
+  });
+
+  it('should resolve label text from an element owner document', () => {
+    const label = document.createElement('span');
+    label.id = 'host-context-label';
+    label.textContent = 'Departure';
+    document.body.appendChild(label);
+
+    const host = document.createElement('div');
+    expect(resolveReferencedAriaText(host, 'host-context-label')).toBe(
+      'Departure'
+    );
+
+    document.body.removeChild(label);
+  });
+
+  it('should join multiple referenced labels and skip missing or blank ids', () => {
+    const first = document.createElement('span');
+    first.id = 'range-label-a';
+    first.textContent = 'Start';
+    const blank = document.createElement('span');
+    blank.id = 'range-label-blank';
+    blank.textContent = '   ';
+    document.body.append(first, blank);
+
+    const host = document.createElement('div');
+    expect(
+      resolveReferencedAriaText(
+        host,
+        'missing-id range-label-a range-label-blank'
+      )
+    ).toBe('Start');
+
+    document.body.removeChild(first);
+    document.body.removeChild(blank);
+  });
+
+  it('should return an empty string when getElementById is unavailable', () => {
+    const host = document.createElement('div');
+    Object.defineProperty(host, 'ownerDocument', {
+      configurable: true,
+      value: { getElementById: undefined },
+    });
+
+    expect(resolveReferencedAriaText(host, 'any-id')).toBe('');
+  });
+
+  it('should return an empty string when ownerDocument is null', () => {
+    const host = document.createElement('div');
+    Object.defineProperty(host, 'ownerDocument', {
+      configurable: true,
+      value: null,
+    });
+
+    expect(resolveReferencedAriaText(host, 'any-id')).toBe('');
   });
 });

--- a/src/components/modus-wc-date/modus-wc-date.spec.ts
+++ b/src/components/modus-wc-date/modus-wc-date.spec.ts
@@ -4775,11 +4775,32 @@ describe('modus-wc-date', () => {
         expect(inputs[1].getAttribute('aria-label')).toBe('Trip dates end');
       });
 
-      it('should default the end input accessible name when aria-label is absent', async () => {
+      it('should not inject a default end input accessible name when aria-label is absent', async () => {
         const { component } = await createRangePage();
         component['inheritedAttributes'] = { 'aria-describedby': 'desc' };
 
-        expect(component['endInputAttributes']['aria-label']).toBe('End date');
+        expect(component['endInputAttributes']['aria-label']).toBeUndefined();
+      });
+
+      it('should derive the end input accessible name from the label prop', async () => {
+        const page = await newSpecPage({
+          components: [ModusWcDate, ModusWcInputLabel],
+          html: '<modus-wc-date type="range" label="Trip dates"></modus-wc-date>',
+        });
+        const inputs = page.root!.querySelectorAll('input');
+
+        expect(inputs[0].hasAttribute('aria-label')).toBe(false);
+        expect(inputs[1].getAttribute('aria-label')).toBe('Trip dates end');
+      });
+
+      it('should leave the end input without an accessible name when neither aria-label nor label is provided', async () => {
+        const page = await newSpecPage({
+          components: [ModusWcDate],
+          html: '<modus-wc-date type="range"></modus-wc-date>',
+        });
+        const endInput = page.root!.querySelectorAll('input')[1];
+
+        expect(endInput.hasAttribute('aria-label')).toBe(false);
       });
 
       it('should emit inputChange with field end on end input', async () => {

--- a/src/components/modus-wc-date/modus-wc-date.spec.ts
+++ b/src/components/modus-wc-date/modus-wc-date.spec.ts
@@ -44,7 +44,7 @@ describe('modus-wc-date', () => {
   it('renders with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcDate],
-      html: '<modus-wc-date aria-label="Default date" format="dd/mm/yyyy"></modus-wc-date>',
+      html: '<modus-wc-date format="dd/mm/yyyy"></modus-wc-date>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -79,10 +79,15 @@ describe('modus-wc-date', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcDate, ModusWcInputLabel],
-      html: '<modus-wc-date label="Birth date" aria-label="Birth date" format="dd/mm/yyyy"></modus-wc-date>',
+      html: '<modus-wc-date label="Birth date" format="dd/mm/yyyy"></modus-wc-date>',
     });
 
     expectLabelLinkedToControl(page.root!, 'input[type="text"]');
+
+    const input = page.root!.querySelector(
+      'input[type="text"]'
+    ) as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should render with error feedback', async () => {

--- a/src/components/modus-wc-date/modus-wc-date.stories.ts
+++ b/src/components/modus-wc-date/modus-wc-date.stories.ts
@@ -129,7 +129,6 @@ const Template: Story = {
         }
       </style>
       <modus-wc-date
-        aria-label="Date input"
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
         ?disabled=${args.disabled}

--- a/src/components/modus-wc-date/modus-wc-date.tsx
+++ b/src/components/modus-wc-date/modus-wc-date.tsx
@@ -342,9 +342,6 @@ export class ModusWcDate {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Date input';
-    }
     this.inheritedAttributes = inheritAriaAttributes(this.el);
 
     try {

--- a/src/components/modus-wc-date/modus-wc-date.tsx
+++ b/src/components/modus-wc-date/modus-wc-date.tsx
@@ -2168,11 +2168,22 @@ export class ModusWcDate {
     const attrs = { ...this.inheritedAttributes };
     const ariaLabel = attrs['aria-label'];
     delete attrs['aria-labelledby'];
+    delete attrs['aria-label'];
 
-    return {
-      ...attrs,
-      'aria-label': ariaLabel ? `${ariaLabel} end` : 'End date',
-    };
+    const endAccessibleName = ariaLabel
+      ? `${ariaLabel} end`
+      : this.label
+        ? `${this.label} end`
+        : undefined;
+
+    if (endAccessibleName) {
+      return {
+        ...attrs,
+        'aria-label': endAccessibleName,
+      };
+    }
+
+    return attrs;
   }
 
   render() {

--- a/src/components/modus-wc-date/modus-wc-date.tsx
+++ b/src/components/modus-wc-date/modus-wc-date.tsx
@@ -41,6 +41,7 @@ import {
   getRangeDayCellClasses,
   isInHighlightRun,
 } from './utils/range-utils';
+import { resolveReferencedAriaText } from './utils/resolve-referenced-aria-text';
 
 /**
  * A customizable date picker component used to create date inputs.
@@ -2167,14 +2168,19 @@ export class ModusWcDate {
   private get endInputAttributes(): Attributes {
     const attrs = { ...this.inheritedAttributes };
     const ariaLabel = attrs['aria-label'];
+    const labelledBy = attrs['aria-labelledby'];
     delete attrs['aria-labelledby'];
     delete attrs['aria-label'];
 
-    const endAccessibleName = ariaLabel
-      ? `${ariaLabel} end`
-      : this.label
-        ? `${this.label} end`
-        : undefined;
+    let endAccessibleName: string | undefined;
+    if (ariaLabel) {
+      endAccessibleName = `${ariaLabel} end`;
+    } else if (labelledBy) {
+      const referencedName = resolveReferencedAriaText(this.el, labelledBy);
+      endAccessibleName = referencedName ? `${referencedName} end` : undefined;
+    } else if (this.label) {
+      endAccessibleName = `${this.label} end`;
+    }
 
     if (endAccessibleName) {
       return {

--- a/src/components/modus-wc-date/utils/resolve-referenced-aria-text.ts
+++ b/src/components/modus-wc-date/utils/resolve-referenced-aria-text.ts
@@ -1,0 +1,19 @@
+export function resolveReferencedAriaText(
+  context: Document | HTMLElement,
+  labelledBy: string
+): string {
+  const doc =
+    (context as HTMLElement).nodeType === 9
+      ? (context as Document)
+      : (context as HTMLElement).ownerDocument;
+
+  if (!doc?.getElementById) {
+    return '';
+  }
+
+  return labelledBy
+    .split(/\s+/)
+    .map((id) => doc.getElementById(id)?.textContent?.trim() ?? '')
+    .filter(Boolean)
+    .join(' ');
+}

--- a/src/components/modus-wc-input-label/modus-wc-input-label.spec.ts
+++ b/src/components/modus-wc-input-label/modus-wc-input-label.spec.ts
@@ -25,6 +25,16 @@ describe('modus-wc-input-label', () => {
     expect(page.root).toMatchSnapshot();
   });
 
+  it('should set id on the label element when label-id is provided', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcInputLabel],
+      html: '<modus-wc-input-label label-id="progress-label" label-text="Loading"></modus-wc-input-label>',
+    });
+    const label = page.root!.querySelector('label');
+
+    expect(label!.id).toBe('progress-label');
+  });
+
   it('should render with content in the primary slot', async () => {
     const page = await newSpecPage({
       components: [ModusWcInputLabel],

--- a/src/components/modus-wc-input-label/modus-wc-input-label.tsx
+++ b/src/components/modus-wc-input-label/modus-wc-input-label.tsx
@@ -22,6 +22,9 @@ export class ModusWcInputLabel {
   /** The `for` attribute of the label, matching the `id` of the associated input. */
   @Prop() forId?: string;
 
+  /** The `id` of the label element (for `aria-labelledby` on non-labelable controls). */
+  @Prop() labelId?: string;
+
   /** Additional classes for custom styling. */
   @Prop() customClass?: string = '';
 
@@ -60,6 +63,7 @@ export class ModusWcInputLabel {
         <label
           class={this.getClasses()}
           htmlFor={this.forId}
+          id={this.labelId}
           {...this.inheritedAttributes}
         >
           {this.labelText}

--- a/src/components/modus-wc-input-label/readme.md
+++ b/src/components/modus-wc-input-label/readme.md
@@ -13,14 +13,15 @@ The component supports a `<slot>` for injecting additional custom content inside
 
 ## Properties
 
-| Property       | Attribute        | Description                                                                  | Type                                | Default     |
-| -------------- | ---------------- | ---------------------------------------------------------------------------- | ----------------------------------- | ----------- |
-| `customClass`  | `custom-class`   | Additional classes for custom styling.                                       | `string \| undefined`               | `''`        |
-| `forId`        | `for-id`         | The `for` attribute of the label, matching the `id` of the associated input. | `string \| undefined`               | `undefined` |
-| `labelText`    | `label-text`     | The text to display within the label.                                        | `string \| undefined`               | `undefined` |
-| `required`     | `required`       | Whether the label indicates a required field.                                | `boolean \| undefined`              | `false`     |
-| `size`         | `size`           | The size of the label.                                                       | `"lg" \| "md" \| "sm" \| undefined` | `'md'`      |
-| `subLabelText` | `sub-label-text` | The text rendered beneath the label.                                         | `string \| undefined`               | `undefined` |
+| Property       | Attribute        | Description                                                                      | Type                                | Default     |
+| -------------- | ---------------- | -------------------------------------------------------------------------------- | ----------------------------------- | ----------- |
+| `customClass`  | `custom-class`   | Additional classes for custom styling.                                           | `string \| undefined`               | `''`        |
+| `forId`        | `for-id`         | The `for` attribute of the label, matching the `id` of the associated input.     | `string \| undefined`               | `undefined` |
+| `labelId`      | `label-id`       | The `id` of the label element (for `aria-labelledby` on non-labelable controls). | `string \| undefined`               | `undefined` |
+| `labelText`    | `label-text`     | The text to display within the label.                                            | `string \| undefined`               | `undefined` |
+| `required`     | `required`       | Whether the label indicates a required field.                                    | `boolean \| undefined`              | `false`     |
+| `size`         | `size`           | The size of the label.                                                           | `"lg" \| "md" \| "sm" \| undefined` | `'md'`      |
+| `subLabelText` | `sub-label-text` | The text rendered beneath the label.                                             | `string \| undefined`               | `undefined` |
 
 
 ## Dependencies

--- a/src/components/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
+++ b/src/components/modus-wc-number-input/__snapshots__/modus-wc-number-input.spec.ts.snap
@@ -15,7 +15,7 @@ exports[`modus-wc-number-input should render with custom props 1`] = `
 exports[`modus-wc-number-input should render with default props 1`] = `
 <modus-wc-number-input inputmode="numeric" value="">
   <div class="modus-wc-number-input-container">
-    <input aria-label="Default input" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-number-input modus-wc-w-full" id="mwc_id_0" placeholder="" type="number" value="">
+    <input class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-number-input modus-wc-w-full" id="mwc_id_0" placeholder="" type="number" value="">
   </div>
 </modus-wc-number-input>
 `;

--- a/src/components/modus-wc-number-input/modus-wc-number-input.spec.ts
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.spec.ts
@@ -9,7 +9,7 @@ describe('modus-wc-number-input', () => {
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcNumberInput],
-      html: '<modus-wc-number-input aria-label="Default input"></modus-wc-number-input>',
+      html: '<modus-wc-number-input></modus-wc-number-input>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -48,10 +48,13 @@ describe('modus-wc-number-input', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcNumberInput, ModusWcInputLabel],
-      html: '<modus-wc-number-input label="Quantity" aria-label="Quantity"></modus-wc-number-input>',
+      html: '<modus-wc-number-input label="Quantity"></modus-wc-number-input>',
     });
 
     expectLabelLinkedToControl(page.root!, 'input');
+
+    const input = page.root!.querySelector('input') as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should render with error feedback', async () => {

--- a/src/components/modus-wc-number-input/modus-wc-number-input.stories.ts
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.stories.ts
@@ -91,7 +91,6 @@ type Story = StoryObj<NumberInputArgs>;
 const Template: Story = {
   render: (args) => html`
     <modus-wc-number-input
-      aria-label="Number input"
       auto-complete=${ifDefined(args['auto-complete'])}
       ?bordered=${args.bordered}
       currency-symbol=${ifDefined(args['currency-symbol'])}

--- a/src/components/modus-wc-number-input/modus-wc-number-input.tsx
+++ b/src/components/modus-wc-number-input/modus-wc-number-input.tsx
@@ -102,10 +102,6 @@ export class ModusWcNumberInput {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = this.placeholder || 'Number input';
-    }
-
     this.inheritedAttributes = {
       ...inheritAriaAttributes(this.el),
       ...inheritAttributes(this.el, ['inputmode']),

--- a/src/components/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
+++ b/src/components/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
@@ -3,27 +3,27 @@
 exports[`modus-wc-progress should render indeterminate state 1`] = `
 <modus-wc-progress class="modus-wc-progress-container" indeterminate="" value="0">
   <!---->
-  <progress aria-hidden="true" aria-label="Custom Progress Bar" class="modus-wc-progress modus-wc-w-full"></progress>
+  <progress aria-busy="true" aria-label="Custom Progress Bar" class="modus-wc-progress modus-wc-w-full"></progress>
 </modus-wc-progress>
 `;
 
-exports[`modus-wc-progress should render label 1`] = `
+exports[`modus-wc-progress should render label below progress and associate it with aria-labelledby 1`] = `
 <modus-wc-progress class="modus-wc-progress-container" label="Loading..." value="0">
   <!---->
+  <progress aria-labelledby="mwc_id_0" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
   <modus-wc-input-label class="modus-wc-input-label-host">
     <!---->
-    <label class="modus-wc-input-label modus-wc-input-label-size-md" htmlfor="mwc_id_0">
+    <label class="modus-wc-input-label modus-wc-input-label-size-md" id="mwc_id_0">
       Loading...
     </label>
   </modus-wc-input-label>
-  <progress aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" id="mwc_id_0" max="100" value="0"></progress>
 </modus-wc-progress>
 `;
 
 exports[`modus-wc-progress should render with custom props 1`] = `
 <modus-wc-progress class="modus-wc-progress-container" custom-class="test-class" indeterminate="" max="50" value="25" variant="radial">
   <!---->
-  <div aria-hidden="true" aria-label="Custom Progress Bar" class="modus-wc-radial-progress modus-wc-radial-progress--indeterminate test-class" role="progressbar" style="--value: 50;">
+  <div aria-busy="true" aria-label="Custom Progress Bar" class="modus-wc-radial-progress modus-wc-radial-progress--indeterminate test-class" role="progressbar" style="--value: 50;">
     <span class="modus-wc-radial-progress-label"></span>
   </div>
 </modus-wc-progress>

--- a/src/components/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
+++ b/src/components/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
@@ -10,8 +10,13 @@ exports[`modus-wc-progress should render indeterminate state 1`] = `
 exports[`modus-wc-progress should render label 1`] = `
 <modus-wc-progress class="modus-wc-progress-container" label="Loading..." value="0">
   <!---->
-  <progress aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
-  <modus-wc-input-label labeltext="Loading..."></modus-wc-input-label>
+  <modus-wc-input-label class="modus-wc-input-label-host">
+    <!---->
+    <label class="modus-wc-input-label modus-wc-input-label-size-md" htmlfor="mwc_id_0">
+      Loading...
+    </label>
+  </modus-wc-input-label>
+  <progress aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" id="mwc_id_0" max="100" value="0"></progress>
 </modus-wc-progress>
 `;
 

--- a/src/components/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
+++ b/src/components/modus-wc-progress/__snapshots__/modus-wc-progress.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`modus-wc-progress should render indeterminate state 1`] = `
 exports[`modus-wc-progress should render label 1`] = `
 <modus-wc-progress class="modus-wc-progress-container" label="Loading..." value="0">
   <!---->
-  <progress aria-label="Custom Progress Bar" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
+  <progress aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
   <modus-wc-input-label labeltext="Loading..."></modus-wc-input-label>
 </modus-wc-progress>
 `;
@@ -27,6 +27,6 @@ exports[`modus-wc-progress should render with custom props 1`] = `
 exports[`modus-wc-progress should render with default props 1`] = `
 <modus-wc-progress class="modus-wc-progress-container" value="0">
   <!---->
-  <progress aria-label="Default Progress Bar" aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
+  <progress aria-valuemax="100" aria-valuemin="0" aria-valuenow="0" class="modus-wc-progress modus-wc-w-full" max="100" value="0"></progress>
 </modus-wc-progress>
 `;

--- a/src/components/modus-wc-progress/modus-wc-progress.spec.ts
+++ b/src/components/modus-wc-progress/modus-wc-progress.spec.ts
@@ -1,4 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
+import { ModusWcInputLabel } from '../modus-wc-input-label/modus-wc-input-label';
+import { expectLabelLinkedToControl } from '../utils';
 import { ModusWcProgress } from './modus-wc-progress';
 
 describe('modus-wc-progress', () => {
@@ -28,9 +30,10 @@ describe('modus-wc-progress', () => {
 
   it('should render label', async () => {
     const page = await newSpecPage({
-      components: [ModusWcProgress],
+      components: [ModusWcProgress, ModusWcInputLabel],
       html: '<modus-wc-progress label="Loading..."></modus-wc-progress>',
     });
+    expectLabelLinkedToControl(page.root!, 'progress');
     expect(page.root).toMatchSnapshot();
   });
 });

--- a/src/components/modus-wc-progress/modus-wc-progress.spec.ts
+++ b/src/components/modus-wc-progress/modus-wc-progress.spec.ts
@@ -5,7 +5,7 @@ describe('modus-wc-progress', () => {
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcProgress],
-      html: '<modus-wc-progress aria-label="Default Progress Bar"></modus-wc-progress>',
+      html: '<modus-wc-progress></modus-wc-progress>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -29,7 +29,7 @@ describe('modus-wc-progress', () => {
   it('should render label', async () => {
     const page = await newSpecPage({
       components: [ModusWcProgress],
-      html: '<modus-wc-progress aria-label="Custom Progress Bar" label="Loading..."></modus-wc-progress>',
+      html: '<modus-wc-progress label="Loading..."></modus-wc-progress>',
     });
     expect(page.root).toMatchSnapshot();
   });

--- a/src/components/modus-wc-progress/modus-wc-progress.spec.ts
+++ b/src/components/modus-wc-progress/modus-wc-progress.spec.ts
@@ -1,7 +1,6 @@
 import { newSpecPage } from '@stencil/core/testing';
-import { ModusWcInputLabel } from '../modus-wc-input-label/modus-wc-input-label';
-import { expectLabelLinkedToControl } from '../utils';
 import { ModusWcProgress } from './modus-wc-progress';
+import { ModusWcInputLabel } from '../modus-wc-input-label/modus-wc-input-label';
 
 describe('modus-wc-progress', () => {
   it('should render with default props', async () => {
@@ -28,12 +27,49 @@ describe('modus-wc-progress', () => {
     expect(page.root).toMatchSnapshot();
   });
 
-  it('should render label', async () => {
+  it('should render label below progress and associate it with aria-labelledby', async () => {
     const page = await newSpecPage({
       components: [ModusWcProgress, ModusWcInputLabel],
       html: '<modus-wc-progress label="Loading..."></modus-wc-progress>',
     });
-    expectLabelLinkedToControl(page.root!, 'progress');
+
+    const progress = page.root!.querySelector('progress');
+    const label = page.root!.querySelector('modus-wc-input-label label');
+
+    expect(progress).not.toBeNull();
+    expect(label).not.toBeNull();
+    expect(label!.id).toBeTruthy();
+    expect(progress!.getAttribute('aria-labelledby')).toBe(label!.id);
+    expect(progress!.hasAttribute('aria-label')).toBe(false);
+
+    const progressIndex = Array.from(page.root!.children).indexOf(progress!);
+    const labelHost = page.root!.querySelector('modus-wc-input-label');
+    const labelIndex = Array.from(page.root!.children).indexOf(labelHost!);
+    expect(progressIndex).toBeLessThan(labelIndex);
+
     expect(page.root).toMatchSnapshot();
+  });
+
+  it('should expose indeterminate progress when aria-label is provided', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcProgress],
+      html: '<modus-wc-progress aria-label="Custom Progress Bar" indeterminate="true"></modus-wc-progress>',
+    });
+    const progress = page.root!.querySelector('progress');
+
+    expect(progress!.getAttribute('aria-hidden')).toBeNull();
+    expect(progress!.getAttribute('aria-busy')).toBe('true');
+    expect(progress!.getAttribute('aria-label')).toBe('Custom Progress Bar');
+  });
+
+  it('should hide indeterminate progress from accessibility tree when no name is provided', async () => {
+    const page = await newSpecPage({
+      components: [ModusWcProgress],
+      html: '<modus-wc-progress indeterminate="true"></modus-wc-progress>',
+    });
+    const progress = page.root!.querySelector('progress');
+
+    expect(progress!.getAttribute('aria-hidden')).toBe('true');
+    expect(progress!.hasAttribute('aria-busy')).toBe(false);
   });
 });

--- a/src/components/modus-wc-progress/modus-wc-progress.stories.ts
+++ b/src/components/modus-wc-progress/modus-wc-progress.stories.ts
@@ -17,6 +17,7 @@ const meta: Meta<ProgressArgs> = {
   component: 'modus-wc-progress',
   args: {
     indeterminate: false,
+    label: 'Progress',
     max: 100,
     value: 70,
     variant: 'default',
@@ -53,7 +54,12 @@ export const Default: Story = {
 
 export const Indeterminate: Story = {
   render: () => {
-    return html` <modus-wc-progress indeterminate="true"></modus-wc-progress> `;
+    return html`
+      <modus-wc-progress
+        aria-label="Loading progress"
+        indeterminate="true"
+      ></modus-wc-progress>
+    `;
   },
 };
 

--- a/src/components/modus-wc-progress/modus-wc-progress.stories.ts
+++ b/src/components/modus-wc-progress/modus-wc-progress.stories.ts
@@ -40,7 +40,6 @@ export const Default: Story = {
   render: (args) => {
     return html`
       <modus-wc-progress
-        aria-label="Progress bar"
         custom-class="${ifDefined(args['custom-class'])}"
         ?indeterminate=${args.indeterminate}
         label=${ifDefined(args.label)}

--- a/src/components/modus-wc-progress/modus-wc-progress.stories.ts
+++ b/src/components/modus-wc-progress/modus-wc-progress.stories.ts
@@ -78,11 +78,15 @@ export const SizeVariations: Story = {
 <div>
   <div>
     Default size
-    <modus-wc-progress value=${args.value}></modus-wc-progress>
+    <modus-wc-progress
+      aria-label="Progress"
+      value=${args.value}
+    ></modus-wc-progress>
   </div>
   <div>
     Small size
     <modus-wc-progress
+      aria-label="Progress"
       value=${args.value}
       custom-class="size-small"
     ></modus-wc-progress>
@@ -90,6 +94,7 @@ export const SizeVariations: Story = {
   <div>
     Compact size
     <modus-wc-progress
+      aria-label="Progress"
       value=${args.value}
       custom-class="size-compact"
     ></modus-wc-progress>
@@ -134,6 +139,7 @@ export const CustomBarColor: Story = {
   }
 </style>
 <modus-wc-progress
+  aria-label="Progress"
   value=${args.value}
   custom-class="custom-bar-color"
 ></modus-wc-progress>
@@ -151,6 +157,7 @@ export const CustomBackgroundColor: Story = {
   }
 </style>
 <modus-wc-progress
+  aria-label="Progress"
   value=${args.value}
   custom-class="custom-bg-color"
 ></modus-wc-progress>

--- a/src/components/modus-wc-progress/modus-wc-progress.tsx
+++ b/src/components/modus-wc-progress/modus-wc-progress.tsx
@@ -39,9 +39,6 @@ export class ModusWcProgress {
 
   componentWillLoad() {
     handleShadowDOMStyles(this.el);
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Progress';
-    }
 
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }

--- a/src/components/modus-wc-progress/modus-wc-progress.tsx
+++ b/src/components/modus-wc-progress/modus-wc-progress.tsx
@@ -68,16 +68,22 @@ export class ModusWcProgress {
     return (safeValue / this.max!) * 100;
   }
 
-  render() {
-    const progressId = this.label
-      ? this.resolveEffectiveId(undefined)
-      : undefined;
-    const hasAuthorAccessibleName =
+  private hasAuthorAccessibleName(): boolean {
+    return (
       Boolean(this.inheritedAttributes['aria-label']) ||
-      Boolean(this.inheritedAttributes['aria-labelledby']);
+      Boolean(this.inheritedAttributes['aria-labelledby'])
+    );
+  }
+
+  render() {
+    const labelId = this.label ? this.resolveEffectiveId(undefined) : undefined;
+    const hasAccessibleName =
+      this.hasAuthorAccessibleName() || Boolean(this.label);
 
     const progressAriaAttributes = this.indeterminate
-      ? { 'aria-hidden': 'true' }
+      ? hasAccessibleName
+        ? { 'aria-busy': 'true' }
+        : { 'aria-hidden': 'true' }
       : {
           'aria-valuenow': this.value,
           'aria-valuemin': 0,
@@ -88,25 +94,25 @@ export class ModusWcProgress {
       ? {}
       : { max: this.max, value: this.value };
 
-    const radialLabelledBy =
-      this.label && !hasAuthorAccessibleName && progressId
-        ? { 'aria-labelledby': progressId }
+    const labelAssociation =
+      this.label && !this.hasAuthorAccessibleName() && labelId
+        ? { 'aria-labelledby': labelId }
         : {};
 
     return (
       <Host class="modus-wc-progress-container">
         {this.variant === 'default' ? (
           <Fragment>
-            {this.label && (
-              <modus-wc-input-label forId={progressId} labelText={this.label} />
-            )}
             <progress
               class={this.getClasses()}
-              id={progressId}
               {...valueAttributes}
               {...progressAriaAttributes}
+              {...labelAssociation}
               {...this.inheritedAttributes}
             />
+            {this.label && (
+              <modus-wc-input-label labelId={labelId} labelText={this.label} />
+            )}
           </Fragment>
         ) : (
           <div
@@ -114,10 +120,10 @@ export class ModusWcProgress {
             style={{ '--value': `${this.getPercentageValue()}` }}
             role="progressbar"
             {...progressAriaAttributes}
-            {...radialLabelledBy}
+            {...labelAssociation}
             {...this.inheritedAttributes}
           >
-            <span class="modus-wc-radial-progress-label" id={progressId}>
+            <span class="modus-wc-radial-progress-label" id={labelId}>
               {this.label}
             </span>
             <slot />

--- a/src/components/modus-wc-progress/modus-wc-progress.tsx
+++ b/src/components/modus-wc-progress/modus-wc-progress.tsx
@@ -1,7 +1,11 @@
 import { Component, Element, Fragment, h, Host, Prop } from '@stencil/core';
 import { convertPropsToClasses } from './modus-wc-progress.tailwind';
 import { handleShadowDOMStyles } from '../base-component';
-import { Attributes, inheritAriaAttributes } from '../utils';
+import {
+  Attributes,
+  createEffectiveIdResolver,
+  inheritAriaAttributes,
+} from '../utils';
 
 /**
  * A customizable progress component used to show the progress of a task or show the passing of time.
@@ -15,6 +19,7 @@ import { Attributes, inheritAriaAttributes } from '../utils';
 })
 export class ModusWcProgress {
   private inheritedAttributes: Attributes = {};
+  private readonly resolveEffectiveId = createEffectiveIdResolver();
 
   /** Reference to the host element */
   @Element() el!: HTMLElement;
@@ -64,6 +69,13 @@ export class ModusWcProgress {
   }
 
   render() {
+    const progressId = this.label
+      ? this.resolveEffectiveId(undefined)
+      : undefined;
+    const hasAuthorAccessibleName =
+      Boolean(this.inheritedAttributes['aria-label']) ||
+      Boolean(this.inheritedAttributes['aria-labelledby']);
+
     const progressAriaAttributes = this.indeterminate
       ? { 'aria-hidden': 'true' }
       : {
@@ -76,17 +88,25 @@ export class ModusWcProgress {
       ? {}
       : { max: this.max, value: this.value };
 
+    const radialLabelledBy =
+      this.label && !hasAuthorAccessibleName && progressId
+        ? { 'aria-labelledby': progressId }
+        : {};
+
     return (
       <Host class="modus-wc-progress-container">
         {this.variant === 'default' ? (
           <Fragment>
+            {this.label && (
+              <modus-wc-input-label forId={progressId} labelText={this.label} />
+            )}
             <progress
               class={this.getClasses()}
+              id={progressId}
               {...valueAttributes}
               {...progressAriaAttributes}
               {...this.inheritedAttributes}
             />
-            {this.label && <modus-wc-input-label labelText={this.label} />}
           </Fragment>
         ) : (
           <div
@@ -94,9 +114,12 @@ export class ModusWcProgress {
             style={{ '--value': `${this.getPercentageValue()}` }}
             role="progressbar"
             {...progressAriaAttributes}
+            {...radialLabelledBy}
             {...this.inheritedAttributes}
           >
-            <span class="modus-wc-radial-progress-label">{this.label}</span>
+            <span class="modus-wc-radial-progress-label" id={progressId}>
+              {this.label}
+            </span>
             <slot />
           </div>
         )}

--- a/src/components/modus-wc-radio/__snapshots__/modus-wc-radio.spec.ts.snap
+++ b/src/components/modus-wc-radio/__snapshots__/modus-wc-radio.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`modus-wc-radio renders with default props 1`] = `
 <modus-wc-radio class="modus-wc-radio-host">
-  <input aria-label="Default radio" class="modus-wc-radio modus-wc-radio-md" id="mwc_id_0" type="radio">
+  <input class="modus-wc-radio modus-wc-radio-md" id="mwc_id_0" type="radio">
 </modus-wc-radio>
 `;
 

--- a/src/components/modus-wc-radio/modus-wc-radio.spec.ts
+++ b/src/components/modus-wc-radio/modus-wc-radio.spec.ts
@@ -7,7 +7,7 @@ describe('modus-wc-radio', () => {
   it('renders with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcRadio],
-      html: '<modus-wc-radio aria-label="Default radio"></modus-wc-radio>',
+      html: '<modus-wc-radio></modus-wc-radio>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -36,10 +36,15 @@ describe('modus-wc-radio', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcRadio, ModusWcInputLabel],
-      html: '<modus-wc-radio label="Option A" aria-label="Option A"></modus-wc-radio>',
+      html: '<modus-wc-radio label="Option A"></modus-wc-radio>',
     });
 
     expectLabelLinkedToControl(page.root!, 'input[type="radio"]');
+
+    const input = page.root!.querySelector(
+      'input[type="radio"]'
+    ) as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should retain the same generated id across re-renders', async () => {

--- a/src/components/modus-wc-radio/modus-wc-radio.stories.ts
+++ b/src/components/modus-wc-radio/modus-wc-radio.stories.ts
@@ -51,7 +51,6 @@ export const Default: Story = {
   render: (args) => {
     return html`
       <modus-wc-radio
-        aria-label="Radio"
         custom-class=${ifDefined(args['custom-class'])}
         ?disabled=${args.disabled}
         input-id=${ifDefined(args['input-id'])}

--- a/src/components/modus-wc-radio/modus-wc-radio.tsx
+++ b/src/components/modus-wc-radio/modus-wc-radio.tsx
@@ -71,9 +71,6 @@ export class ModusWcRadio {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Radio button';
-    }
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/modus-wc-select/__snapshots__/modus-wc-select.spec.ts.snap
+++ b/src/components/modus-wc-select/__snapshots__/modus-wc-select.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`modus-wc-select renders with default props 1`] = `
       Label
     </label>
   </modus-wc-input-label>
-  <select aria-label="Default select" class="modus-wc-select modus-wc-select-bordered modus-wc-select-md modus-wc-w-full" id="mwc_id_0">
+  <select class="modus-wc-select modus-wc-select-bordered modus-wc-select-md modus-wc-w-full" id="mwc_id_0">
     <option disabled="" hidden="" selected="" value="">
       Select an option
     </option>

--- a/src/components/modus-wc-select/modus-wc-select.spec.ts
+++ b/src/components/modus-wc-select/modus-wc-select.spec.ts
@@ -16,7 +16,7 @@ describe('modus-wc-select', () => {
   it('renders with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcSelect, ModusWcInputLabel],
-      html: '<modus-wc-select label="Label" aria-label="Default select"></modus-wc-select>',
+      html: '<modus-wc-select label="Label"></modus-wc-select>',
     });
 
     const component = page.rootInstance as ModusWcSelect;
@@ -60,10 +60,13 @@ describe('modus-wc-select', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcSelect, ModusWcInputLabel],
-      html: '<modus-wc-select label="Country" aria-label="Country"></modus-wc-select>',
+      html: '<modus-wc-select label="Country"></modus-wc-select>',
     });
 
     expectLabelLinkedToControl(page.root!, 'select');
+
+    const select = page.root!.querySelector('select') as HTMLSelectElement;
+    expect(select.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should render with error feedback', async () => {

--- a/src/components/modus-wc-select/modus-wc-select.stories.ts
+++ b/src/components/modus-wc-select/modus-wc-select.stories.ts
@@ -93,7 +93,6 @@ type Story = StoryObj<SelectArgs>;
 export const Default: Story = {
   render: (args) => html`
     <modus-wc-select
-      aria-label="Select input"
       ?bordered=${args.bordered}
       custom-class=${ifDefined(args['custom-class'])}
       ?disabled=${args.disabled}
@@ -130,7 +129,6 @@ const errorFeedback: IInputFeedbackProp = {
 export const WithErrorFeedback: Story = {
   render: (args) => html`
     <modus-wc-select
-      aria-label="Select input"
       .feedback=${errorFeedback}
       id="error-select"
       label=${ifDefined(args.label)}

--- a/src/components/modus-wc-select/modus-wc-select.tsx
+++ b/src/components/modus-wc-select/modus-wc-select.tsx
@@ -92,10 +92,6 @@ export class ModusWcSelect {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Select';
-    }
-
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/modus-wc-slider/__snapshots__/modus-wc-slider.spec.ts.snap
+++ b/src/components/modus-wc-slider/__snapshots__/modus-wc-slider.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`modus-wc-slider renders with default props 1`] = `
 <modus-wc-slider value="0">
-  <input aria-label="Default slider" class="modus-wc-range modus-wc-range-md" id="mwc_id_0" type="range" value="0">
+  <input class="modus-wc-range modus-wc-range-md" id="mwc_id_0" type="range" value="0">
 </modus-wc-slider>
 `;
 

--- a/src/components/modus-wc-slider/modus-wc-slider.spec.ts
+++ b/src/components/modus-wc-slider/modus-wc-slider.spec.ts
@@ -7,7 +7,7 @@ describe('modus-wc-slider', () => {
   it('renders with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcSlider],
-      html: '<modus-wc-slider aria-label="Default slider"></modus-wc-slider>',
+      html: '<modus-wc-slider></modus-wc-slider>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -39,10 +39,15 @@ describe('modus-wc-slider', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcSlider, ModusWcInputLabel],
-      html: '<modus-wc-slider label="Volume" aria-label="Volume"></modus-wc-slider>',
+      html: '<modus-wc-slider label="Volume"></modus-wc-slider>',
     });
 
     expectLabelLinkedToControl(page.root!, 'input[type="range"]');
+
+    const input = page.root!.querySelector(
+      'input[type="range"]'
+    ) as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should retain the same generated id across re-renders', async () => {

--- a/src/components/modus-wc-slider/modus-wc-slider.stories.ts
+++ b/src/components/modus-wc-slider/modus-wc-slider.stories.ts
@@ -54,7 +54,6 @@ export const Default: Story = {
   render: (args) => {
     return html`
       <modus-wc-slider
-        aria-label="Slider"
         custom-class=${ifDefined(args['custom-class'])}
         ?disabled=${args.disabled}
         input-id=${ifDefined(args['input-id'])}

--- a/src/components/modus-wc-slider/modus-wc-slider.tsx
+++ b/src/components/modus-wc-slider/modus-wc-slider.tsx
@@ -80,10 +80,6 @@ export class ModusWcSlider {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Slider';
-    }
-
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/modus-wc-switch/__snapshots__/modus-wc-switch.spec.ts.snap
+++ b/src/components/modus-wc-switch/__snapshots__/modus-wc-switch.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`modus-wc-switch renders with default props 1`] = `
 <modus-wc-switch class="modus-wc-switch-host">
-  <input aria-label="Default toggle" class="modus-wc-toggle modus-wc-toggle-md" id="mwc_id_0" role="switch" type="checkbox">
+  <input class="modus-wc-toggle modus-wc-toggle-md" id="mwc_id_0" role="switch" type="checkbox">
 </modus-wc-switch>
 `;
 
@@ -21,7 +21,7 @@ exports[`modus-wc-switch should render with custom props 1`] = `
 
 exports[`modus-wc-switch should render with size xs 1`] = `
 <modus-wc-switch class="modus-wc-switch-host" label="XS label" size="xs">
-  <input aria-label="XS toggle" class="modus-wc-toggle modus-wc-toggle-xs" id="mwc_id_1" role="switch" type="checkbox">
+  <input class="modus-wc-toggle modus-wc-toggle-xs" id="mwc_id_1" role="switch" type="checkbox">
   <modus-wc-input-label class="modus-wc-input-label-host">
     <!---->
     <label class="modus-wc-input-label modus-wc-input-label-size-sm" htmlfor="mwc_id_1">

--- a/src/components/modus-wc-switch/modus-wc-switch.spec.ts
+++ b/src/components/modus-wc-switch/modus-wc-switch.spec.ts
@@ -7,7 +7,7 @@ describe('modus-wc-switch', () => {
   it('renders with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcSwitch],
-      html: '<modus-wc-switch aria-label="Default toggle"></modus-wc-switch>',
+      html: '<modus-wc-switch></modus-wc-switch>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -36,14 +36,15 @@ describe('modus-wc-switch', () => {
   it('should render with size xs', async () => {
     const page = await newSpecPage({
       components: [ModusWcSwitch, ModusWcInputLabel],
-      html: `<modus-wc-switch
-        aria-label="XS toggle"
-        label="XS label"
-        size="xs"
-      ></modus-wc-switch>`,
+      html: `<modus-wc-switch label="XS label" size="xs"></modus-wc-switch>`,
     });
     expect(page.root).toMatchSnapshot();
     expectLabelLinkedToControl(page.root!, 'input[type="checkbox"]');
+
+    const input = page.root!.querySelector(
+      'input[type="checkbox"]'
+    ) as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should retain the same generated id across re-renders', async () => {

--- a/src/components/modus-wc-switch/modus-wc-switch.stories.ts
+++ b/src/components/modus-wc-switch/modus-wc-switch.stories.ts
@@ -53,7 +53,6 @@ export const Default: Story = {
   render: (args) => {
     return html`
       <modus-wc-switch
-        aria-label="Toggle"
         custom-class=${ifDefined(args['custom-class'])}
         ?disabled=${args.disabled}
         .indeterminate=${args.indeterminate}

--- a/src/components/modus-wc-switch/modus-wc-switch.tsx
+++ b/src/components/modus-wc-switch/modus-wc-switch.tsx
@@ -85,9 +85,6 @@ export class ModusWcSwitch {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Switch button';
-    }
     this.inheritedAttributes = inheritAriaAttributes(this.el);
   }
 

--- a/src/components/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
+++ b/src/components/modus-wc-text-input/__snapshots__/modus-wc-text-input.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`modus-wc-text-input should render with default props 1`] = `
 <modus-wc-text-input inputmode="text" value="">
   <!---->
   <label class="modus-wc-flex modus-wc-gap-1 modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-items-center modus-wc-text-input modus-wc-w-full">
-    <input aria-label="Default input" class="modus-wc-grow" id="mwc_id_0" placeholder="" type="text" value="">
+    <input class="modus-wc-grow" id="mwc_id_0" placeholder="" type="text" value="">
   </label>
 </modus-wc-text-input>
 `;

--- a/src/components/modus-wc-text-input/modus-wc-text-input.spec.ts
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.spec.ts
@@ -11,7 +11,7 @@ describe('modus-wc-text-input', () => {
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcTextInput],
-      html: '<modus-wc-text-input aria-label="Default input"></modus-wc-text-input>',
+      html: '<modus-wc-text-input></modus-wc-text-input>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -54,10 +54,13 @@ describe('modus-wc-text-input', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcTextInput, ModusWcInputLabel],
-      html: '<modus-wc-text-input label="Email" aria-label="Email"></modus-wc-text-input>',
+      html: '<modus-wc-text-input label="Email"></modus-wc-text-input>',
     });
 
     expectLabelLinkedToControl(page.root!, 'input');
+
+    const input = page.root!.querySelector('input') as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should render with error feedback', async () => {

--- a/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.stories.ts
@@ -139,7 +139,6 @@ type Story = StoryObj<TextInputArgs>;
 const Template: Story = {
   render: (args) => html`
     <modus-wc-text-input
-      aria-label="Text input"
       auto-capitalize=${ifDefined(args['auto-capitalize'])}
       auto-complete=${ifDefined(args['auto-complete'])}
       auto-correct=${ifDefined(args['auto-correct'])}
@@ -182,7 +181,6 @@ export const WithErrorFeedback: Story = {
   // prettier-ignore
   render: (args) => html`
     <modus-wc-text-input
-      aria-label="Text input with error feedback"
       .feedback=${errorFeedback}
       id="error-input"
       label=${ifDefined(args.label)}

--- a/src/components/modus-wc-text-input/modus-wc-text-input.tsx
+++ b/src/components/modus-wc-text-input/modus-wc-text-input.tsx
@@ -158,10 +158,6 @@ export class ModusWcTextInput {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = this.placeholder || 'Text input';
-    }
-
     this.inheritedAttributes = {
       ...inheritAriaAttributes(this.el),
       ...inheritAttributes(this.el, ['spellcheck', 'inputmode']),

--- a/src/components/modus-wc-textarea/__snapshots__/modus-wc-textarea.spec.ts.snap
+++ b/src/components/modus-wc-textarea/__snapshots__/modus-wc-textarea.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`modus-wc-textarea renders with default props 1`] = `
-<modus-wc-textarea value=""><textarea aria-label="Default textarea" aria-placeholder="" class="modus-wc-textarea modus-wc-textarea-bordered modus-wc-textarea-md modus-wc-w-full" id="mwc_id_0" placeholder="" value=""></textarea>
+<modus-wc-textarea value=""><textarea aria-placeholder="" class="modus-wc-textarea modus-wc-textarea-bordered modus-wc-textarea-md modus-wc-w-full" id="mwc_id_0" placeholder="" value=""></textarea>
 </modus-wc-textarea>
 `;
 

--- a/src/components/modus-wc-textarea/modus-wc-textarea.spec.ts
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.spec.ts
@@ -9,7 +9,7 @@ describe('modus-wc-textarea', () => {
   it('renders with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcTextarea],
-      html: '<modus-wc-textarea aria-label="Default textarea"></modus-wc-textarea>',
+      html: '<modus-wc-textarea></modus-wc-textarea>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -45,10 +45,13 @@ describe('modus-wc-textarea', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcTextarea, ModusWcInputLabel],
-      html: '<modus-wc-textarea label="Notes" aria-label="Notes"></modus-wc-textarea>',
+      html: '<modus-wc-textarea label="Notes"></modus-wc-textarea>',
     });
 
     expectLabelLinkedToControl(page.root!, 'textarea');
+
+    const textarea = page.root!.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should render with error feedback', async () => {

--- a/src/components/modus-wc-textarea/modus-wc-textarea.spec.ts
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.spec.ts
@@ -50,7 +50,9 @@ describe('modus-wc-textarea', () => {
 
     expectLabelLinkedToControl(page.root!, 'textarea');
 
-    const textarea = page.root!.querySelector('textarea') as HTMLTextAreaElement;
+    const textarea = page.root!.querySelector(
+      'textarea'
+    ) as HTMLTextAreaElement;
     expect(textarea.hasAttribute('aria-label')).toBe(false);
   });
 

--- a/src/components/modus-wc-textarea/modus-wc-textarea.stories.ts
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.stories.ts
@@ -104,7 +104,6 @@ export const Default: Story = {
   render: (args) => {
     return html`
       <modus-wc-textarea
-        aria-label="Textarea input"
         auto-correct=${ifDefined(args['auto-correct'])}
         ?bordered=${args.bordered}
         custom-class=${ifDefined(args['custom-class'])}
@@ -138,7 +137,6 @@ const errorFeedback: IInputFeedbackProp = {
 export const WithErrorFeedback: Story = {
   render: (args) => html`
     <modus-wc-textarea
-      aria-label="Textarea input"
       .feedback=${errorFeedback}
       id="error-input"
       label=${ifDefined(args.label)}

--- a/src/components/modus-wc-textarea/modus-wc-textarea.tsx
+++ b/src/components/modus-wc-textarea/modus-wc-textarea.tsx
@@ -106,10 +106,6 @@ export class ModusWcTextarea {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = this.placeholder || 'Text area';
-    }
-
     this.inheritedAttributes = {
       ...inheritAriaAttributes(this.el),
       ...inheritAttributes(this.el, ['spellcheck']),

--- a/src/components/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
+++ b/src/components/modus-wc-time-input/__snapshots__/modus-wc-time-input.spec.ts.snap
@@ -9,7 +9,7 @@ exports[`modus-wc-time-input should render with custom props 1`] = `
 
 exports[`modus-wc-time-input should render with default props 1`] = `
 <modus-wc-time-input datalist-id="test-list" value="">
-  <input aria-label="Default input" class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-time-input modus-wc-w-full" id="mwc_id_0" list="test-list" step="60" type="time" value="">
+  <input class="modus-wc-input modus-wc-input-bordered modus-wc-input-md modus-wc-time-input modus-wc-w-full" id="mwc_id_0" list="test-list" step="60" type="time" value="">
 </modus-wc-time-input>
 `;
 

--- a/src/components/modus-wc-time-input/modus-wc-time-input.spec.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.spec.ts
@@ -9,7 +9,7 @@ describe('modus-wc-time-input', () => {
   it('should render with default props', async () => {
     const page = await newSpecPage({
       components: [ModusWcTimeInput],
-      html: '<modus-wc-time-input aria-label="Default input" datalist-id="test-list"></modus-wc-time-input>',
+      html: '<modus-wc-time-input datalist-id="test-list"></modus-wc-time-input>',
     });
     expect(page.root).toMatchSnapshot();
   });
@@ -45,10 +45,15 @@ describe('modus-wc-time-input', () => {
   it('should link label to input when input-id is omitted', async () => {
     const page = await newSpecPage({
       components: [ModusWcTimeInput, ModusWcInputLabel],
-      html: '<modus-wc-time-input label="Start time" aria-label="Start time"></modus-wc-time-input>',
+      html: '<modus-wc-time-input label="Start time"></modus-wc-time-input>',
     });
 
     expectLabelLinkedToControl(page.root!, 'input[type="time"]');
+
+    const input = page.root!.querySelector(
+      'input[type="time"]'
+    ) as HTMLInputElement;
+    expect(input.hasAttribute('aria-label')).toBe(false);
   });
 
   it('should render with error feedback', async () => {

--- a/src/components/modus-wc-time-input/modus-wc-time-input.stories.ts
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.stories.ts
@@ -75,7 +75,6 @@ type Story = StoryObj<TimeInputArgs>;
 const Template: Story = {
   render: (args) => html`
     <modus-wc-time-input
-      aria-label="Time input"
       auto-complete=${ifDefined(args['auto-complete'])}
       bordered=${ifDefined(args.bordered)}
       custom-class=${ifDefined(args['custom-class'])}

--- a/src/components/modus-wc-time-input/modus-wc-time-input.tsx
+++ b/src/components/modus-wc-time-input/modus-wc-time-input.tsx
@@ -119,10 +119,6 @@ export class ModusWcTimeInput {
     // Auto-inject CSS if component is used inside user's shadow DOM
     handleShadowDOMStyles(this.el);
 
-    if (!this.el.ariaLabel) {
-      this.el.ariaLabel = 'Time input';
-    }
-
     // if no datalistId value provided, use internal datalist id to enable time options
     if (!this.datalistId) {
       this.datalistId = this.internalDatalistId;


### PR DESCRIPTION
### :page_facing_up: Summary of Changes
Remove component-injected default aria-label values (including placeholder fallbacks) on checkbox, switch, radio, text input, textarea, number input, select, autocomplete, date, time input, slider, and progress so the accessible name comes from the label prop or an author-supplied host aria-label.

### :thought_balloon: Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Configuration change (modifies scaling or properties of existing infrastructure & services)
- [ ] Documentation change
- [ ] Other

### :clipboard: Test Plan

[comment]: # 'How do you know the changes are safe to ship to production?'
[comment]: # 'How do you know the changes will function as expected in future releases?'

### :white_check_mark: Self Code Review Checklist

PR authors and reviewers, please verify that all of these items have been completed.

- [ ] My code is clean and readable
- [ ] I followed standard conventions
- [ ] Component code is WCAG 2.2 compliant (if applicable)
- [ ] I have made theme files changes (if applicable)
- [ ] I have made documentation changes (if applicable)
- [ ] I have made Storybook changes including usage documentation (if applicable)
- [ ] I have tested the component thoroughly in Storybook including RTL rendering (if applicable)

### :link: Work Item

Closes #1423 
